### PR TITLE
CMake tweaks:

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -2,12 +2,12 @@ project(pugixml)
 
 cmake_minimum_required(VERSION 2.6)
 
-set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared instead of static library")
+option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
 set(BUILD_DEFINES "" CACHE STRING "Build defines")
 
-if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
-    SET(CMAKE_INSTALL_LIBDIR lib CACHE PATH "Output directory for libraries")
-endif()
+# Pre-defines standard install locations on *nix systems.
+include(GNUInstallDirs)
+mark_as_advanced(CLEAR CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR)
 
 set(HEADERS ../src/pugixml.hpp ../src/pugiconfig.hpp)
 set(SOURCES ${HEADERS} ../src/pugixml.cpp)
@@ -24,6 +24,11 @@ endif()
 
 set_target_properties(pugixml PROPERTIES VERSION 1.4 SOVERSION 1)
 
-install(TARGETS pugixml EXPORT pugixml-config LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES ${HEADERS} DESTINATION include)
+install(TARGETS pugixml EXPORT pugixml-config 
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(EXPORT pugixml-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml)


### PR DESCRIPTION
- Include GNUInstallDirs which sets up standard install locations including
  lib64 for mulilib systems.
- Make BUILD_SHARED_LIBS an option instead of a variable which is better for
  use in either the cmake-gui or ccmake gui interfaces.
- Setup a destination for WIN32 runtime DLL's which is also helpful for MinGW
  installs.
