### PR TITLE
Allow to turn on header-only mode without foreign code intervention

### DIFF
--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -19,6 +19,10 @@
 // Include user configuration file (this can define various configuration macros)
 #include "pugiconfig.hpp"
 
+#ifdef PUGIXML_HEADER_ONLY
+#include "pugixml.cpp"
+#endif
+
 #ifndef HEADER_PUGIXML_HPP
 #define HEADER_PUGIXML_HPP
 


### PR DESCRIPTION
pugiconfig.hpp:
> // Uncomment this to switch to header-only version

I suppose it's not always convenient to edit foreign source code. This change allows to turn on header-only mode simply by defining PUGIXML_HEADER_ONLY