### PR TITLE
Add xml_text::set for float, make float/double round-trip

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4608,6 +4608,13 @@ namespace pugi
 		return impl::set_value_convert(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs);
 	}
 	
+	PUGI__FN bool xml_attribute::set_value(float rhs)
+	{
+		if (!_attr) return false;
+
+		return impl::set_value_convert(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs);
+	}
+	
 	PUGI__FN bool xml_attribute::set_value(bool rhs)
 	{
 		if (!_attr) return false;

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -3954,10 +3954,18 @@ PUGI__NS_BEGIN
 		return set_value_buffer(dest, header, header_mask, buf);
 	}
 
+	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, float value)
+	{
+		char buf[128];
+		sprintf(buf, "%.9g", value);
+
+		return set_value_buffer(dest, header, header_mask, buf);
+	}
+	
 	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, double value)
 	{
 		char buf[128];
-		sprintf(buf, "%g", value);
+		sprintf(buf, "%.17g", value);
 
 		return set_value_buffer(dest, header, header_mask, buf);
 	}
@@ -5597,6 +5605,13 @@ namespace pugi
 	}
 
 	PUGI__FN bool xml_text::set(unsigned int rhs)
+	{
+		xml_node_struct* dn = _data_new();
+
+		return dn ? impl::set_value_convert(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs) : false;
+	}
+
+	PUGI__FN bool xml_text::set(float rhs)
 	{
 		xml_node_struct* dn = _data_new();
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4553,6 +4553,12 @@ namespace pugi
 		return *this;
 	}
 	
+	PUGI__FN xml_attribute& xml_attribute::operator=(float rhs)
+	{
+		set_value(rhs);
+		return *this;
+	}
+	
 	PUGI__FN xml_attribute& xml_attribute::operator=(bool rhs)
 	{
 		set_value(rhs);
@@ -5674,6 +5680,12 @@ namespace pugi
 	}
 
 	PUGI__FN xml_text& xml_text::operator=(double rhs)
+	{
+		set(rhs);
+		return *this;
+	}
+
+	PUGI__FN xml_text& xml_text::operator=(float rhs)
 	{
 		set(rhs);
 		return *this;

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -365,6 +365,7 @@ namespace pugi
 		xml_attribute& operator=(int rhs);
 		xml_attribute& operator=(unsigned int rhs);
 		xml_attribute& operator=(double rhs);
+		xml_attribute& operator=(float rhs);
 		xml_attribute& operator=(bool rhs);
 
 	#ifdef PUGIXML_HAS_LONG_LONG
@@ -708,6 +709,7 @@ namespace pugi
 		xml_text& operator=(int rhs);
 		xml_text& operator=(unsigned int rhs);
 		xml_text& operator=(double rhs);
+		xml_text& operator=(float rhs);
 		xml_text& operator=(bool rhs);
 
 	#ifdef PUGIXML_HAS_LONG_LONG

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -693,6 +693,7 @@ namespace pugi
 		// Set text with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set(int rhs);
 		bool set(unsigned int rhs);
+        bool set(float rhs);
 		bool set(double rhs);
 		bool set(bool rhs);
 

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -352,6 +352,7 @@ namespace pugi
 		bool set_value(int rhs);
 		bool set_value(unsigned int rhs);
 		bool set_value(double rhs);
+        bool set_value(float rhs);
 		bool set_value(bool rhs);
 
 	#ifdef PUGIXML_HAS_LONG_LONG

--- a/tests/test_dom_modify.cpp
+++ b/tests/test_dom_modify.cpp
@@ -753,8 +753,8 @@ TEST_XML(dom_attr_assign_large_number, "<node attr1='' attr2='' />")
 	node.attribute(STR("attr1")) = std::numeric_limits<float>::max();
 	node.attribute(STR("attr2")) = std::numeric_limits<double>::max();
 
-	CHECK(test_node(node, STR("<node attr1=\"3.40282e+038\" attr2=\"1.79769e+308\" />"), STR(""), pugi::format_raw) ||
-		  test_node(node, STR("<node attr1=\"3.40282e+38\" attr2=\"1.79769e+308\" />"), STR(""), pugi::format_raw));
+	CHECK(test_node(node, STR("<node attr1=\"3.40282347e+038\" attr2=\"1.7976931348623157ee+308\" />"), STR(""), pugi::format_raw) ||
+		  test_node(node, STR("<node attr1=\"3.40282347e+38\" attr2=\"1.7976931348623157e+308\" />"), STR(""), pugi::format_raw));
 }
 
 TEST(dom_node_declaration_name)


### PR DESCRIPTION
The issue: Double values are printed with insufficient precision #18 

Has a link to a site that offers a solution.  This patch implements that solution.

I tested the solution for floats by iterating through all values between:
std::numeric_limits<float>::min() and std::numeric_limits<float>::max(), converting to a string, then parsing the string and I obtained the value I started with.

On my machine the test for float took about 20 minutes to run on 8 cores.

I didn't attempt to run the same test with a double since I think it would take too long to run the test.
