### PR TITLE
Align attributes each on separate line

### DIFF
--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -203,9 +203,12 @@ namespace pugi
 	// Open file using text mode in xml_document::save_file. This enables special character (i.e. new-line) conversions on some systems. This flag is off by default.
 	const unsigned int format_save_file_text = 0x20;
 
+	// Set each attribute to new line
+	const unsigned int format_each_attribute_on_new_line = 0x40;
 	// The default set of formatting flags.
 	// Nodes are indented depending on their depth in DOM tree, a default declaration is output if document has none.
 	const unsigned int format_default = format_indent;
+	const unsigned int format_indent_attributes = format_indent | format_each_attribute_on_new_line;
 		
 	// Forward declarations
 	struct xml_attribute_struct;

--- a/tests/test_write.cpp
+++ b/tests/test_write.cpp
@@ -21,6 +21,21 @@ TEST_XML(write_indent, "<node attr='1'><child><sub>text</sub></child></node>")
 	CHECK_NODE_EX(doc, STR("<node attr=\"1\">\n\t<child>\n\t\t<sub>text</sub>\n\t</child>\n</node>\n"), STR("\t"), format_indent);
 }
 
+TEST_XML(write_indent_attribute, "<node attr='1' other='2'><child><sub>text</sub></child></node>")
+{
+	CHECK_NODE_EX(doc, STR("<node\n\tattr=\"1\"\n\tother=\"2\">\n\t<child>\n\t\t<sub>text</sub>\n\t</child>\n</node>\n"), STR("\t"), format_indent_attributes);
+}
+
+TEST_XML(write_indent_attribute_empty_tag, "<node attr='1' other='2' />")
+{
+	CHECK_NODE_EX(doc, STR("<node\n\tattr=\"1\"\n\tother=\"2\" />\n"), STR("\t"), format_indent_attributes);
+}
+
+TEST_XML_FLAGS(write_indent_attribute_on_declaration, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><node attr='1' other='2' />", pugi::parse_full)
+{
+	CHECK_NODE_EX(doc, STR("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<node\n\tattr=\"1\"\n\tother=\"2\" />\n"), STR("\t"), format_indent_attributes);
+}
+
 TEST_XML(write_pcdata, "<node attr='1'><child><sub/>text</child></node>")
 {
 	CHECK_NODE_EX(doc, STR("<node attr=\"1\">\n\t<child>\n\t\t<sub />text</child>\n</node>\n"), STR("\t"), format_indent);
@@ -360,7 +375,7 @@ TEST(write_encoding_huge_invalid)
 TEST(write_unicode_escape)
 {
 	char s_utf8[] = "<\xE2\x82\xAC \xC2\xA2='\"\xF0\xA4\xAD\xA2&#x0a;\"'>&amp;\x14\xF0\xA4\xAD\xA2&lt;</\xE2\x82\xAC>";
-	
+
 	xml_document doc;
 	CHECK(doc.load_buffer(s_utf8, sizeof(s_utf8), parse_default, encoding_utf8));
 


### PR DESCRIPTION
Hi!
Here is PR with support for alignment each attribute on next line.
This alignment can simplify merge two files scenarios (for example, for compare two revisions of configuration files if only one of multiple attributes was changed).

Added `format_indent_attribute` mode:
```xml
<node
    attr="1"
    other="2">
</node>
<node
    attr="1"
    other="2" />
```

Added `format_indent_full` mode:
```xml
<node
    attr="1"
    other="2"
    >
    <sub />
</node>
<node
    attr="1"
    other="2"
    />
```

Would you like to accept this PR?
Thanks for great library!
Best regards, Aleksei.