### PR TITLE
enlarge _memory before it isn't large enough if we are working with custom malloc(different align)

### DIFF
--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -941,7 +941,7 @@ namespace pugi
 	private:
 		char_t* _buffer;
 
-		char _memory[192];
+		char _memory[192+64];
 		
 		// Non-copyable semantics
 		xml_document(const xml_document&);


### PR DESCRIPTION
I found this issue when I'm using pugixml with my global custom allocator:
assert(reinterpret_cast(_root) + sizeof(impl::xml_document_struct) <= _memory + sizeof(_memory));