### PR TITLE
Add parse_embed_pcdata flag

### DIFF
--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -746,6 +746,9 @@ These flags control the resulting tree contents:
 
 * [[parse_ws_pcdata_single]]`parse_ws_pcdata_single` determines if whitespace-only PCDATA nodes that have no sibling nodes are to be put in DOM tree. In some cases application needs to parse the whitespace-only contents of nodes, i.e. `<node>  </node>`, but is not interested in whitespace markup elsewhere. It is possible to use <<parse_ws_pcdata,parse_ws_pcdata>> flag in this case, but it results in excessive allocations and complicates document processing; this flag can be used to avoid that. As an example, after parsing XML string `<node> <a>  </a> </node>` with `parse_ws_pcdata_single` flag set, `<node>` element will have one child `<a>`, and `<a>` element will have one child with type <<node_pcdata,node_pcdata>> and value `"  "`. This flag has no effect if <<parse_ws_pcdata,parse_ws_pcdata>> is enabled. This flag is *off* by default.
 
+* [[parse_embed_pcdata]]`parse_embed_pcdata` determines if PCDATA contents is to be saved as element values. Normally element nodes have names but not values; this flag forces the parser to store the contents as a value if PCDATA is the first child of the element node (otherwise PCDATA node is created as usual). This can significantly reduce the memory required for documents with many PCDATA nodes. To retrieve the data you can use `xml_node::value()` on the element nodes or any of the higher-level functions like `child_value` or `text`. This flag is *off* by default.
+Since this flag significantly changes the DOM structure it is only recommended for parsing documents with many PCDATA nodes in memory-constrained environments. This flag is *off* by default.
+
 * [[parse_fragment]]`parse_fragment` determines if document should be treated as a fragment of a valid XML. Parsing document as a fragment leads to top-level PCDATA content (i.e. text that is not located inside a node) to be added to a tree, and additionally treats documents without element nodes as valid. This flag is *off* by default.
 
 CAUTION: Using in-place parsing (<<xml_document::load_buffer_inplace,load_buffer_inplace>>) with `parse_fragment` flag may result in the loss of the last character of the buffer if it is a part of PCDATA. Since PCDATA values are null-terminated strings, the only way to resolve this is to provide a null-terminated buffer as an input to `load_buffer_inplace` - i.e. `doc.load_buffer_inplace("test\0", 5, pugi::parse_default | pugi::parse_fragment)`.
@@ -2611,6 +2614,7 @@ const unsigned int +++<a href="#parse_pi">parse_pi</a>+++
 const unsigned int +++<a href="#parse_trim_pcdata">parse_trim_pcdata</a>+++
 const unsigned int +++<a href="#parse_ws_pcdata">parse_ws_pcdata</a>+++
 const unsigned int +++<a href="#parse_ws_pcdata_single">parse_ws_pcdata_single</a>+++
+const unsigned int +++<a href="#parse_embed_pcdata">parse_embed_pcdata</a>+++
 const unsigned int +++<a href="#parse_wconv_attribute">parse_wconv_attribute</a>+++
 const unsigned int +++<a href="#parse_wnorm_attribute">parse_wnorm_attribute</a>+++
 ----

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -3360,13 +3360,22 @@ PUGI__NS_BEGIN
 							
 					if (cursor->parent || PUGI__OPTSET(parse_fragment))
 					{
-						PUGI__PUSHNODE(node_pcdata); // Append a new node on the tree.
-						cursor->value = s; // Save the offset.
+						if (!PUGI__OPTSET(parse_embed_pcdata))
+						{
+							PUGI__PUSHNODE(node_pcdata); // Append a new node on the tree.
+
+							cursor->value = s; // Save the offset.
+
+							PUGI__POPNODE(); // Pop since this is a standalone.
+						}
+						else
+						{
+							if (cursor->parent && !cursor->value)
+								cursor->value = s; // Save the offset.
+						}
 
 						s = strconv_pcdata(s);
 								
-						PUGI__POPNODE(); // Pop since this is a standalone.
-						
 						if (!*s) break;
 					}
 					else

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4018,17 +4018,40 @@ PUGI__NS_BEGIN
 		if (node->first_attribute)
 			node_output_attributes(writer, node, indent, indent_length, flags, depth);
 
-		if (!node->first_child)
+		// element nodes can have value if parse_embed_pcdata was used
+		if (!node->value)
 		{
-			writer.write(' ', '/', '>');
+			if (!node->first_child)
+			{
+				writer.write(' ', '/', '>');
 
-			return false;
+				return false;
+			}
+			else
+			{
+				writer.write('>');
+
+				return true;
+			}
 		}
 		else
 		{
 			writer.write('>');
 
-			return true;
+			text_output(writer, node->value, ctx_special_pcdata, flags);
+
+			if (!node->first_child)
+			{
+				writer.write('<', '/');
+				writer.write_string(name);
+				writer.write('>');
+
+				return false;
+			}
+			else
+			{
+				return true;
+			}
 		}
 	}
 
@@ -4136,6 +4159,10 @@ PUGI__NS_BEGIN
 
 					if (node_output_start(writer, node, indent, indent_length, flags, depth))
 					{
+						// element nodes can have value if parse_embed_pcdata was used
+						if (node->value)
+							indent_flags = 0;
+
 						node = node->first_child;
 						depth++;
 						continue;

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5486,13 +5486,13 @@ namespace pugi
 	{
 		if (!_root) return PUGIXML_TEXT("");
 		
-		for (xml_node_struct* i = _root->first_child; i; i = i->next_sibling)
-			if (impl::is_text_node(i) && i->value)
-				return i->value;
-
 		// element nodes can have value if parse_embed_pcdata was used
 		if (PUGI__NODETYPE(_root) == node_element && _root->value)
 			return _root->value;
+
+		for (xml_node_struct* i = _root->first_child; i; i = i->next_sibling)
+			if (impl::is_text_node(i) && i->value)
+				return i->value;
 
 		return PUGIXML_TEXT("");
 	}
@@ -6237,13 +6237,13 @@ namespace pugi
 	{
 		if (!_root || impl::is_text_node(_root)) return _root;
 
-		for (xml_node_struct* node = _root->first_child; node; node = node->next_sibling)
-			if (impl::is_text_node(node))
-				return node;
-
 		// element nodes can have value if parse_embed_pcdata was used
 		if (PUGI__NODETYPE(_root) == node_element && _root->value)
 			return _root;
+
+		for (xml_node_struct* node = _root->first_child; node; node = node->next_sibling)
+			if (impl::is_text_node(node))
+				return node;
 
 		return 0;
 	}

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5464,6 +5464,10 @@ namespace pugi
 			if (impl::is_text_node(i) && i->value)
 				return i->value;
 
+		// element nodes can have value if parse_embed_pcdata was used
+		if (PUGI__NODETYPE(_root) == node_element && _root->value)
+			return _root->value;
+
 		return PUGIXML_TEXT("");
 	}
 
@@ -6210,6 +6214,10 @@ namespace pugi
 		for (xml_node_struct* node = _root->first_child; node; node = node->next_sibling)
 			if (impl::is_text_node(node))
 				return node;
+
+		// element nodes can have value if parse_embed_pcdata was used
+		if (PUGI__NODETYPE(_root) == node_element && _root->value)
+			return _root;
 
 		return 0;
 	}

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -3360,18 +3360,17 @@ PUGI__NS_BEGIN
 							
 					if (cursor->parent || PUGI__OPTSET(parse_fragment))
 					{
-						if (!PUGI__OPTSET(parse_embed_pcdata))
+						if (PUGI__OPTSET(parse_embed_pcdata) && cursor->parent && !cursor->first_child && !cursor->value)
+						{
+							cursor->value = s; // Save the offset.
+						}
+						else
 						{
 							PUGI__PUSHNODE(node_pcdata); // Append a new node on the tree.
 
 							cursor->value = s; // Save the offset.
 
 							PUGI__POPNODE(); // Pop since this is a standalone.
-						}
-						else
-						{
-							if (cursor->parent && !cursor->value)
-								cursor->value = s; // Save the offset.
 						}
 
 						s = strconv_pcdata(s);

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -7653,6 +7653,10 @@ PUGI__NS_BEGIN
 			{
 				xpath_string result;
 
+				// element nodes can have value if parse_embed_pcdata was used
+				if (n.value()[0])
+					result.append(xpath_string::from_const(n.value()), alloc);
+
 				xml_node cur = n.first_child();
 				
 				while (cur && cur != n)

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -159,8 +159,8 @@ namespace pugi
 	const unsigned int parse_fragment = 0x1000;
 
 	// This flag determines if plain character data is be stored in the parent element's value. This significantly changes the structure of
-	// the document and does not allow some documents to round-trip; this flag is only recommended for parsing documents with a lot of
-	// PCDATA nodes in a very memory-constrained environment. This flag is off by default.
+	// the document; this flag is only recommended for parsing documents with many PCDATA nodes in memory-constrained environments.
+	// This flag is off by default.
 	const unsigned int parse_embed_pcdata = 0x2000;
 
 	// The default parsing mode.

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -158,6 +158,11 @@ namespace pugi
 	// is a valid document. This flag is off by default.
 	const unsigned int parse_fragment = 0x1000;
 
+	// This flag determines if plain character data is be stored in the parent element's value. This significantly changes the structure of
+	// the document and does not allow some documents to round-trip; this flag is only recommended for parsing documents with a lot of
+	// PCDATA nodes in a very memory-constrained environment. This flag is off by default.
+	const unsigned int parse_embed_pcdata = 0x2000;
+
 	// The default parsing mode.
 	// Elements, PCDATA and CDATA sections are added to the DOM tree, character/reference entities are expanded,
 	// End-of-Line characters are normalized, attribute values are normalized using CDATA normalization rules.


### PR DESCRIPTION
This flag determines if plain character data is be stored in the parent element's value. This significantly changes the structure of the document and does not allow some documents to round-trip; this flag is only recommended for parsing documents with a lot of PCDATA nodes in a very memory-constrained environment.

Note: this PR is incomplete (missing tests and documentation)