### PR TITLE
Add flag format_no_empty_element_space to omit space before end of self-closing element tags

### DIFF
--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -1698,6 +1698,8 @@ These flags control the resulting tree contents:
 
 * [[format_indent_attributes]]`format_indent_attributes` determines if all attributes should be printed on a new line, indented with the indentation string according to the attribute's depth. This flag implies <<format_indent,format_indent>>. This flag has no effect if <<format_raw,format_raw>> is enabled. This flag is *off* by default.
 
+* [[format_no_empty_element_space]]`format_no_empty_element_space` omits the space before the final `/>` of empty elements. If this flag is on, then the output of an empty element is `<element/>` instead of `<element />`. This flag is *off* by default.
+
 * [[format_raw]]`format_raw` switches between formatted and raw output. If this flag is on, the nodes are not indented in any way, and also no newlines that are not part of document text are printed. Raw mode can be used for serialization where the result is not intended to be read by humans; also it can be useful if the document was parsed with <<parse_ws_pcdata,parse_ws_pcdata>> flag, to preserve the original document formatting as much as possible. This flag is *off* by default.
 
 * [[format_no_escapes]]`format_no_escapes` disables output escaping for attribute values and PCDATA contents. If this flag is off, special symbols (`"`, `&`, `<`, `>`) and all non-printable characters (those with codepoint values less than 32) are converted to XML escape sequences (i.e. `&amp;amp;`) during output. If this flag is on, no text processing is performed; therefore, output XML can be malformed if output contents contains invalid symbols (i.e. having a stray `<` in the PCDATA will make the output malformed). This flag is *off* by default.

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4014,7 +4014,10 @@ PUGI__NS_BEGIN
 		{
 			if (!node->first_child)
 			{
-				writer.write(' ', '/', '>');
+				if ((flags & format_no_empty_element_space) == 0) {
+					writer.write(' ');
+				}
+				writer.write('/', '>');
 
 				return false;
 			}

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -211,6 +211,9 @@ namespace pugi
 	// Write every attribute on a new line with appropriate indentation. This flag is off by default.
 	const unsigned int format_indent_attributes = 0x40;
 
+	// Don't output a space before '/>' at the end of self-closing (empty) elements.
+	const unsigned int format_no_empty_element_space = 0x80;
+
 	// The default set of formatting flags.
 	// Nodes are indented depending on their depth in DOM tree, a default declaration is output if document has none.
 	const unsigned int format_default = format_indent;

--- a/tests/test_write.cpp
+++ b/tests/test_write.cpp
@@ -31,6 +31,11 @@ TEST_XML(write_indent_attributes_empty_element, "<node attr='1' other='2' />")
 	CHECK_NODE_EX(doc, STR("<node\n\tattr=\"1\"\n\tother=\"2\" />\n"), STR("\t"), format_indent_attributes);
 }
 
+TEST_XML(write_no_empty_element_space, "<node attr='1' />")
+{
+	CHECK_NODE_EX(doc, STR("<node attr=\"1\"/>\n"), STR(""), format_no_empty_element_space);
+}
+
 TEST_XML_FLAGS(write_indent_attributes_declaration, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><node attr='1' other='2' />", parse_full)
 {
 	CHECK_NODE_EX(doc, STR("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<node\n\tattr=\"1\"\n\tother=\"2\" />\n"), STR("\t"), format_indent_attributes);


### PR DESCRIPTION
Empty elements are serialised to `<element />`. The space is not necessary for most XML parsers. Unfortunately it's not configurable. So to get the minimal XML size, it could be useful to omit the space.

I've added the option `format_no_empty_element_space` to control this.

I'd much prefer the omission of the space to be the default, but obviously that could break existing code.