### PR TITLE
Expand Nuget Configuration Options

### DIFF
--- a/scripts/nuget.autopkg
+++ b/scripts/nuget.autopkg
@@ -1,3 +1,11 @@
+configurations {
+      	// This node contains custom pivot information.
+      	Toolset 
+      	{
+           	key: "PlatformToolset";
+           	choices: { v140, v120, v110, v100 };
+      	}
+}
 nuget {
 	nuspec {
 		id = pugixml;

--- a/scripts/nuget.autopkg
+++ b/scripts/nuget.autopkg
@@ -24,9 +24,13 @@ nuget {
 	files {
 		include: { "..\src\*.hpp" };
 		
-		[x86,release] { lib: vs2015\Win32_Release\pugixml.lib; }
-		[x86,debug] { lib: vs2015\Win32_Debug\pugixml.lib; }
-		[x64,release] { lib: vs2015\x64_Release\pugixml.lib; }
-		[x64,debug] { lib: vs2015\x64_Debug\pugixml.lib; }
+		[x86,v120,static,release] { lib: vs2013\x32\pugixmls.lib; }
+		[x86,v120,static,debug] { lib: vs2013\x32\pugixmlsd.lib; }
+		[x64,v120,static,release] { lib: vs2013\x64\pugixmls.lib; }
+		[x64,v120,static,debug] { lib: vs2013\x64\pugixmlsd.lib; }
+		[x86,v140,static,release] { lib: vs2015\Win32_Release\pugixml.lib; }
+		[x86,v140,static,debug] { lib: vs2015\Win32_Debug\pugixml.lib; }
+		[x64,v140,static,release] { lib: vs2015\x64_Release\pugixml.lib; }
+		[x64,v140,static,debug] { lib: vs2015\x64_Debug\pugixml.lib; }
 	}
 }

--- a/scripts/nuget_build.bat
+++ b/scripts/nuget_build.bat
@@ -1,13 +1,11 @@
 @echo off
 cd %~dp0
 
-"%VS120COMNTOOLS%\VsMSBuildCmd.bat" && ^
+"%VS140COMNTOOLS%\VsMSBuildCmd.bat" && ^
 msbuild pugixml_vs2013_static.vcxproj /t:Rebuild /p:Configuration=Debug /p:Platform=x86 /v:minimal /nologo && ^
 msbuild pugixml_vs2013_static.vcxproj /t:Rebuild /p:Configuration=Release /p:Platform=x86 /v:minimal /nologo && ^
 msbuild pugixml_vs2013_static.vcxproj /t:Rebuild /p:Configuration=Debug /p:Platform=x64 /v:minimal /nologo && ^
-msbuild pugixml_vs2013_static.vcxproj /t:Rebuild /p:Configuration=Release /p:Platform=x64 /v:minimal /nologo
-
-"%VS140COMNTOOLS%\VsMSBuildCmd.bat" && ^
+msbuild pugixml_vs2013_static.vcxproj /t:Rebuild /p:Configuration=Release /p:Platform=x64 /v:minimal /nologo && ^
 msbuild pugixml_vs2015.vcxproj /t:Rebuild /p:Configuration=Debug /p:Platform=x86 /v:minimal /nologo && ^
 msbuild pugixml_vs2015.vcxproj /t:Rebuild /p:Configuration=Release /p:Platform=x86 /v:minimal /nologo && ^
 msbuild pugixml_vs2015.vcxproj /t:Rebuild /p:Configuration=Debug /p:Platform=x64 /v:minimal /nologo && ^

--- a/scripts/nuget_build.bat
+++ b/scripts/nuget_build.bat
@@ -1,6 +1,12 @@
 @echo off
 cd %~dp0
 
+"%VS120COMNTOOLS%\VsMSBuildCmd.bat" && ^
+msbuild pugixml_vs2013_static.vcxproj /t:Rebuild /p:Configuration=Debug /p:Platform=x86 /v:minimal /nologo && ^
+msbuild pugixml_vs2013_static.vcxproj /t:Rebuild /p:Configuration=Release /p:Platform=x86 /v:minimal /nologo && ^
+msbuild pugixml_vs2013_static.vcxproj /t:Rebuild /p:Configuration=Debug /p:Platform=x64 /v:minimal /nologo && ^
+msbuild pugixml_vs2013_static.vcxproj /t:Rebuild /p:Configuration=Release /p:Platform=x64 /v:minimal /nologo
+
 "%VS140COMNTOOLS%\VsMSBuildCmd.bat" && ^
 msbuild pugixml_vs2015.vcxproj /t:Rebuild /p:Configuration=Debug /p:Platform=x86 /v:minimal /nologo && ^
 msbuild pugixml_vs2015.vcxproj /t:Rebuild /p:Configuration=Release /p:Platform=x86 /v:minimal /nologo && ^


### PR DESCRIPTION
I have attempted to expand the Nuget configuration to include VS 2013 static builds in addition to the VS 2015 that currently exists.

Closes #107 