### PR TITLE
Remove static pivot from NuGet autopkg.

### DIFF
--- a/scripts/nuget.autopkg
+++ b/scripts/nuget.autopkg
@@ -32,13 +32,13 @@ nuget {
 	files {
 		include: { "..\src\*.hpp" };
 		
-		[x86,v120,static,release] { lib: vs2013\x32\pugixmls.lib; }
-		[x86,v120,static,debug] { lib: vs2013\x32\pugixmlsd.lib; }
-		[x64,v120,static,release] { lib: vs2013\x64\pugixmls.lib; }
-		[x64,v120,static,debug] { lib: vs2013\x64\pugixmlsd.lib; }
-		[x86,v140,static,release] { lib: vs2015\Win32_Release\pugixml.lib; }
-		[x86,v140,static,debug] { lib: vs2015\Win32_Debug\pugixml.lib; }
-		[x64,v140,static,release] { lib: vs2015\x64_Release\pugixml.lib; }
-		[x64,v140,static,debug] { lib: vs2015\x64_Debug\pugixml.lib; }
+		[x86,v120,release] { lib: vs2013\x32\pugixmls.lib; }
+		[x86,v120,debug] { lib: vs2013\x32\pugixmlsd.lib; }
+		[x64,v120,release] { lib: vs2013\x64\pugixmls.lib; }
+		[x64,v120,debug] { lib: vs2013\x64\pugixmlsd.lib; }
+		[x86,v140,release] { lib: vs2015\Win32_Release\pugixml.lib; }
+		[x86,v140,debug] { lib: vs2015\Win32_Debug\pugixml.lib; }
+		[x64,v140,release] { lib: vs2015\x64_Release\pugixml.lib; }
+		[x64,v140,debug] { lib: vs2015\x64_Debug\pugixml.lib; }
 	}
 }


### PR DESCRIPTION
This pivot seemed to be causing issues because the NuGet package thought it was actually dynamic.

Refs #107 