### PR TITLE
Add Symbols to NuGet Package

### DIFF
--- a/scripts/nuget.autopkg
+++ b/scripts/nuget.autopkg
@@ -32,27 +32,35 @@ nuget {
 		
 		[x86,v120,release] {
 			lib: vs2013\x32\pugixmls.lib;
+			symbols: vs2013\x32\pugixmls.pdb;
 		}
 		[x86,v120,debug] {
 			lib: vs2013\x32\pugixmlsd.lib;
+			symbols: vs2013\x32\pugixmlsd.pdb;
 		}
 		[x64,v120,release] {
 			lib: vs2013\x64\pugixmls.lib;
+			symbols: vs2013\x64\pugixmls.pdb;
 		}
 		[x64,v120,debug] {
 			lib: vs2013\x64\pugixmlsd.lib; 
+			symbols: vs2013\x64\pugixmlsd.pdb;
 		}
 		[x86,v140,release] {
 			lib: vs2015\Win32_Release\pugixml.lib;
+			symbols: vs2015\Win32_Release\pugixml.pdb;
 		}
 		[x86,v140,debug] {
 			lib: vs2015\Win32_Debug\pugixml.lib;
+			symbols: vs2015\Win32_Debug\pugixml.pdb;
 		}
 		[x64,v140,release] {
 			lib: vs2015\x64_Release\pugixml.lib;
+			symbols: vs2015\x64_Release\pugixml.pdb;
 		}
 		[x64,v140,debug] {
 			lib: vs2015\x64_Debug\pugixml.lib;
+			symbols: vs2015\x64_Debug\pugixml.pdb;
 		}
 	}
 }

--- a/scripts/nuget.autopkg
+++ b/scripts/nuget.autopkg
@@ -30,13 +30,29 @@ nuget {
 	files {
 		include: { "..\src\*.hpp" };
 		
-		[x86,v120,release] { lib: vs2013\x32\pugixmls.lib; }
-		[x86,v120,debug] { lib: vs2013\x32\pugixmlsd.lib; }
-		[x64,v120,release] { lib: vs2013\x64\pugixmls.lib; }
-		[x64,v120,debug] { lib: vs2013\x64\pugixmlsd.lib; }
-		[x86,v140,release] { lib: vs2015\Win32_Release\pugixml.lib; }
-		[x86,v140,debug] { lib: vs2015\Win32_Debug\pugixml.lib; }
-		[x64,v140,release] { lib: vs2015\x64_Release\pugixml.lib; }
-		[x64,v140,debug] { lib: vs2015\x64_Debug\pugixml.lib; }
+		[x86,v120,release] {
+			lib: vs2013\x32\pugixmls.lib;
+		}
+		[x86,v120,debug] {
+			lib: vs2013\x32\pugixmlsd.lib;
+		}
+		[x64,v120,release] {
+			lib: vs2013\x64\pugixmls.lib;
+		}
+		[x64,v120,debug] {
+			lib: vs2013\x64\pugixmlsd.lib; 
+		}
+		[x86,v140,release] {
+			lib: vs2015\Win32_Release\pugixml.lib;
+		}
+		[x86,v140,debug] {
+			lib: vs2015\Win32_Debug\pugixml.lib;
+		}
+		[x64,v140,release] {
+			lib: vs2015\x64_Release\pugixml.lib;
+		}
+		[x64,v140,debug] {
+			lib: vs2015\x64_Debug\pugixml.lib;
+		}
 	}
 }


### PR DESCRIPTION
Added debug symbols to the NuGet package for developers looking to step into pugixml code.

Closes #110 