### PR TITLE
Add C++11 'override' specifier

### DIFF
--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -72,6 +72,15 @@
 #	endif
 #endif
 
+// If no API for functions is defined, assume default
+#ifndef PUGIXML_OVERRIDE
+#	if __cplusplus >= 201103
+#		define PUGIXML_OVERRIDE override
+#	else
+#		define PUGIXML_OVERRIDE
+#	endif
+#endif
+
 // Character interface macros
 #ifdef PUGIXML_WCHAR_MODE
 #	define PUGIXML_TEXT(t) L ## t
@@ -273,7 +282,7 @@ namespace pugi
 		// Construct writer from a FILE* object; void* is used to avoid header dependencies on stdio
 		xml_writer_file(void* file);
 
-		virtual void write(const void* data, size_t size);
+		virtual void write(const void* data, size_t size) PUGIXML_OVERRIDE;
 
 	private:
 		void* file;
@@ -288,7 +297,7 @@ namespace pugi
 		xml_writer_stream(std::basic_ostream<char, std::char_traits<char> >& stream);
 		xml_writer_stream(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& stream);
 
-		virtual void write(const void* data, size_t size);
+		virtual void write(const void* data, size_t size) PUGIXML_OVERRIDE;
 
 	private:
 		std::basic_ostream<char, std::char_traits<char> >* narrow_stream;
@@ -1214,7 +1223,7 @@ namespace pugi
 		explicit xpath_exception(const xpath_parse_result& result);
 
 		// Get error message
-		virtual const char* what() const throw();
+		virtual const char* what() const throw() PUGIXML_OVERRIDE;
 
 		// Get parse result
 		const xpath_parse_result& result() const;

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -72,7 +72,7 @@
 #	endif
 #endif
 
-// If no API for functions is defined, assume default
+// If C++ is 2011 or higher, add 'override' qualifiers
 #ifndef PUGIXML_OVERRIDE
 #	if __cplusplus >= 201103
 #		define PUGIXML_OVERRIDE override

--- a/tests/test.hpp
+++ b/tests/test.hpp
@@ -78,7 +78,7 @@ struct dummy_fixture {};
 	{ \
 		test_runner_##name(): test_runner(#name) {} \
 		\
-		virtual void run() \
+		virtual void run() PUGIXML_OVERRIDE \
 		{ \
 			test_runner_helper_##name helper; \
 			helper.run(); \

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -187,7 +187,7 @@ public:
         this->setg(begin, begin, end);
     }
 
-    typename std::basic_streambuf<T>::int_type underflow()
+    typename std::basic_streambuf<T>::int_type underflow() PUGIXML_OVERRIDE
     {
         return this->gptr() == this->egptr() ? std::basic_streambuf<T>::traits_type::eof() : std::basic_streambuf<T>::traits_type::to_int_type(*this->gptr());
     }

--- a/tests/test_dom_traverse.cpp
+++ b/tests/test_dom_traverse.cpp
@@ -798,7 +798,7 @@ struct test_walker: xml_tree_walker
 	#endif
 	}
 
-	virtual bool begin(xml_node& node)
+	virtual bool begin(xml_node& node) PUGIXML_OVERRIDE
 	{
 		log += STR("|");
 		log += depthstr();
@@ -810,7 +810,7 @@ struct test_walker: xml_tree_walker
 		return ++call_count != stop_count && xml_tree_walker::begin(node);
 	}
 
-	virtual bool for_each(xml_node& node)
+	virtual bool for_each(xml_node& node) PUGIXML_OVERRIDE
 	{
 		log += STR("|");
 		log += depthstr();
@@ -822,7 +822,7 @@ struct test_walker: xml_tree_walker
 		return ++call_count != stop_count && xml_tree_walker::end(node);
 	}
 
-	virtual bool end(xml_node& node)
+	virtual bool end(xml_node& node) PUGIXML_OVERRIDE
 	{
 		log += STR("|");
 		log += depthstr();

--- a/tests/test_write.cpp
+++ b/tests/test_write.cpp
@@ -213,7 +213,7 @@ struct test_writer: xml_writer
 {
 	std::basic_string<pugi::char_t> contents;
 
-	virtual void write(const void* data, size_t size)
+	virtual void write(const void* data, size_t size) PUGIXML_OVERRIDE
 	{
 		CHECK(size % sizeof(pugi::char_t) == 0);
 		contents.append(static_cast<const pugi::char_t*>(data), size / sizeof(pugi::char_t));
@@ -604,7 +604,7 @@ TEST_XML_FLAGS(write_mixed, "<node><child1/><child2>pre<![CDATA[data]]>mid<!--co
 #ifndef PUGIXML_NO_EXCEPTIONS
 struct throwing_writer: pugi::xml_writer
 {
-	virtual void write(const void*, size_t)
+	virtual void write(const void*, size_t) PUGIXML_OVERRIDE
 	{
 		throw std::runtime_error("write failed");
 	}

--- a/tests/writer_string.hpp
+++ b/tests/writer_string.hpp
@@ -9,7 +9,7 @@ struct xml_writer_string: public pugi::xml_writer
 {
 	std::string contents;
 
-	virtual void write(const void* data, size_t size);
+	virtual void write(const void* data, size_t size) PUGIXML_OVERRIDE;
 
 	std::string as_narrow() const;
 	std::basic_string<wchar_t> as_wide() const;


### PR DESCRIPTION
In a member function declaration or definition, 'override' ensures that the function is virtual and is overriding a virtual function from the base class. The program is ill-formed (a compile-time error is generated) if this is not true. Since version 5.1, GCC supports flag '-Wsuggest-override', which warns if 'override' specifier is misssing. We've enabled this flag in our project and found that the specifier is missing in pugixml headers. Although we've disabled the warning for files including pugixml, it might be useful to add 'override' speficiers for headers as we suggest in this pull request.