### PR TITLE
fixed gcc build ptrdiff_t should be in std namespace

### DIFF
--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -651,7 +651,7 @@ namespace pugi
 		xml_object_range<xml_attribute_iterator> attributes() const;
 
 		// Get node offset in parsed file/string (in char_t units) for debugging purposes
-		ptrdiff_t offset_debug() const;
+		std::ptrdiff_t offset_debug() const;
 
 		// Get hash value (unique for handles to the same object)
 		size_t hash_value() const;
@@ -768,7 +768,7 @@ namespace pugi
 
 	public:
 		// Iterator traits
-		typedef ptrdiff_t difference_type;
+		typedef std::ptrdiff_t difference_type;
 		typedef xml_node value_type;
 		typedef xml_node* pointer;
 		typedef xml_node& reference;
@@ -810,7 +810,7 @@ namespace pugi
 
 	public:
 		// Iterator traits
-		typedef ptrdiff_t difference_type;
+		typedef std::ptrdiff_t difference_type;
 		typedef xml_attribute value_type;
 		typedef xml_attribute* pointer;
 		typedef xml_attribute& reference;
@@ -846,7 +846,7 @@ namespace pugi
 
 	public:
 		// Iterator traits
-		typedef ptrdiff_t difference_type;
+		typedef std::ptrdiff_t difference_type;
 		typedef xml_node value_type;
 		typedef xml_node* pointer;
 		typedef xml_node& reference;
@@ -942,7 +942,7 @@ namespace pugi
 		xml_parse_status status;
 
 		// Last parsed offset (in char_t units from start of input data)
-		ptrdiff_t offset;
+		std::ptrdiff_t offset;
 
 		// Source document encoding
 		xml_encoding encoding;
@@ -1047,7 +1047,7 @@ namespace pugi
 		const char* error;
 
 		// Last parsed offset (in char_t units from string start)
-		ptrdiff_t offset;
+		std::ptrdiff_t offset;
 
 		// Default constructor, initializes object to failed state
 		xpath_parse_result();


### PR DESCRIPTION
The compilation of pugixml started to fail for me due to prdiff_t error.
.../thirdparty/pugixml/src/pugixml.hpp:771:11: error: ‘ptrdiff_t’ does not name a type
   typedef ptrdiff_t difference_type;
           ^
So I've checked that c++ version of ptrdiff_t should has std namespace, unless you are compiling c code. However pugi isn't c - friendly so we have to follow c++ doc.
http://en.cppreference.com/w/cpp/types/ptrdiff_t

Signed-off-by: Eugene Smirnov o1o2o3o4o5@gmail.com
