### PR TITLE
Add VS2013 check for C++11 availability

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -11923,7 +11923,7 @@ namespace pugi
 		}
 	}
 
-#if __cplusplus >= 201103
+#if __cplusplus >= 201103 || _MSC_VER >= 1800
 	PUGI__FN void xpath_node_set::_move(xpath_node_set& rhs)
 	{
 		_type = rhs._type;
@@ -11966,7 +11966,7 @@ namespace pugi
 		return *this;
 	}
 
-#if __cplusplus >= 201103
+#if __cplusplus >= 201103 || _MSC_VER >= 1800
 	PUGI__FN xpath_node_set::xpath_node_set(xpath_node_set&& rhs): _type(type_unsorted), _begin(&_storage), _end(&_storage)
 	{
 		_move(rhs);
@@ -12166,7 +12166,7 @@ namespace pugi
 		return *this;
 	}
 
-#if __cplusplus >= 201103
+#if __cplusplus >= 201103 || _MSC_VER >= 1800
 	PUGI__FN xpath_variable_set::xpath_variable_set(xpath_variable_set&& rhs)
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
@@ -12360,7 +12360,7 @@ namespace pugi
 			impl::xpath_query_impl::destroy(static_cast<impl::xpath_query_impl*>(_impl));
 	}
 
-#if __cplusplus >= 201103
+#if __cplusplus >= 201103 || _MSC_VER >= 1800
 	PUGI__FN xpath_query::xpath_query(xpath_query&& rhs)
 	{
 		_impl = rhs._impl;

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -11923,7 +11923,7 @@ namespace pugi
 		}
 	}
 
-#if __cplusplus >= 201103 || _MSC_VER >= 1800
+#if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1800)
 	PUGI__FN void xpath_node_set::_move(xpath_node_set& rhs)
 	{
 		_type = rhs._type;
@@ -11966,7 +11966,7 @@ namespace pugi
 		return *this;
 	}
 
-#if __cplusplus >= 201103 || _MSC_VER >= 1800
+#if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1800)
 	PUGI__FN xpath_node_set::xpath_node_set(xpath_node_set&& rhs): _type(type_unsorted), _begin(&_storage), _end(&_storage)
 	{
 		_move(rhs);
@@ -12166,7 +12166,7 @@ namespace pugi
 		return *this;
 	}
 
-#if __cplusplus >= 201103 || _MSC_VER >= 1800
+#if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1800)
 	PUGI__FN xpath_variable_set::xpath_variable_set(xpath_variable_set&& rhs)
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
@@ -12360,7 +12360,7 @@ namespace pugi
 			impl::xpath_query_impl::destroy(static_cast<impl::xpath_query_impl*>(_impl));
 	}
 
-#if __cplusplus >= 201103 || _MSC_VER >= 1800
+#if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1800)
 	PUGI__FN xpath_query::xpath_query(xpath_query&& rhs)
 	{
 		_impl = rhs._impl;

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -1117,7 +1117,7 @@ namespace pugi
 		xpath_variable_set(const xpath_variable_set& rhs);
 		xpath_variable_set& operator=(const xpath_variable_set& rhs);
 
-	#if __cplusplus >= 201103
+	#if __cplusplus >= 201103 || _MSC_VER >= 1800
 		// Move semantics support
 		xpath_variable_set(xpath_variable_set&& rhs);
 		xpath_variable_set& operator=(xpath_variable_set&& rhs);
@@ -1161,7 +1161,7 @@ namespace pugi
 		// Destructor
 		~xpath_query();
 
-	#if __cplusplus >= 201103
+	#if __cplusplus >= 201103 || _MSC_VER >= 1800
 		// Move semantics support
 		xpath_query(xpath_query&& rhs);
 		xpath_query& operator=(xpath_query&& rhs);
@@ -1302,7 +1302,7 @@ namespace pugi
 		xpath_node_set(const xpath_node_set& ns);
 		xpath_node_set& operator=(const xpath_node_set& ns);
 
-	#if __cplusplus >= 201103
+	#if __cplusplus >= 201103 || _MSC_VER >= 1800
 		// Move semantics support
 		xpath_node_set(xpath_node_set&& rhs);
 		xpath_node_set& operator=(xpath_node_set&& rhs);

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -1117,7 +1117,7 @@ namespace pugi
 		xpath_variable_set(const xpath_variable_set& rhs);
 		xpath_variable_set& operator=(const xpath_variable_set& rhs);
 
-	#if __cplusplus >= 201103 || _MSC_VER >= 1800
+	#if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1800)
 		// Move semantics support
 		xpath_variable_set(xpath_variable_set&& rhs);
 		xpath_variable_set& operator=(xpath_variable_set&& rhs);
@@ -1161,7 +1161,7 @@ namespace pugi
 		// Destructor
 		~xpath_query();
 
-	#if __cplusplus >= 201103 || _MSC_VER >= 1800
+	#if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1800)
 		// Move semantics support
 		xpath_query(xpath_query&& rhs);
 		xpath_query& operator=(xpath_query&& rhs);
@@ -1302,7 +1302,7 @@ namespace pugi
 		xpath_node_set(const xpath_node_set& ns);
 		xpath_node_set& operator=(const xpath_node_set& ns);
 
-	#if __cplusplus >= 201103 || _MSC_VER >= 1800
+	#if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1800)
 		// Move semantics support
 		xpath_node_set(xpath_node_set&& rhs);
 		xpath_node_set& operator=(xpath_node_set&& rhs);


### PR DESCRIPTION
VS 2013 supports C++11, but __cplusplus macro hasn't updated, and its value is still 199711 (C++98?) so the old check always fails, even though the compiler supports C++11. Fun fact is they haven't even updated it in the most recent VS versions that i'm currently using (2015 w/ update 3 and 15 w/ Preview 5)