### PR TITLE
XPath: Remove exceptional control flow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - DEFINES=standard
   - DEFINES=PUGIXML_WCHAR_MODE
   - DEFINES=PUGIXML_COMPACT
+  - DEFINES=PUGIXML_NO_EXCEPTIONS
 script:
   - make test cxxstd=c++11 defines=$DEFINES config=coverage -j2
   - make test cxxstd=c++11 defines=$DEFINES config=release -j2

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ ifeq ($(config),coverage)
 test: $(EXECUTABLE)
 	-@find $(BUILD) -name '*.gcda' -exec rm {} +
 	./$(EXECUTABLE)
-	@gcov -o $(BUILD)/src/ pugixml.cpp.gcda | sed -e '/./{H;$!d;}' -e 'x;/pugixml.cpp/!d;'
+	@gcov -b -o $(BUILD)/src/ pugixml.cpp.gcda | sed -e '/./{H;$!d;}' -e 'x;/pugixml.cpp/!d;'
 	@find . -name '*.gcov' -and -not -name 'pugixml.cpp.gcov' -exec rm {} +
 else
 test: $(EXECUTABLE)

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -7688,8 +7688,8 @@ PUGI__NS_BEGIN
 				size_t result_length = target_length + source_length;
 
 				// allocate new buffer
-				char_t* result = static_cast<char_t*>(alloc->reallocate_throw(_uses_heap ? const_cast<char_t*>(_buffer) : 0, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
-				assert(result);
+				char_t* result = static_cast<char_t*>(alloc->reallocate_nothrow(_uses_heap ? const_cast<char_t*>(_buffer) : 0, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
+				if (!result) return;
 
 				// append first string to the new buffer in case there was no reallocation
 				if (!_uses_heap) memcpy(result, _buffer, target_length * sizeof(char_t));
@@ -8148,8 +8148,8 @@ PUGI__NS_BEGIN
 
 		// allocate a buffer of suitable length for the number
 		size_t result_size = strlen(mantissa_buffer) + (exponent > 0 ? exponent : -exponent) + 4;
-		char_t* result = static_cast<char_t*>(alloc->allocate_throw(sizeof(char_t) * result_size));
-		assert(result);
+		char_t* result = static_cast<char_t*>(alloc->allocate_nothrow(sizeof(char_t) * result_size));
+		if (!result) return xpath_string();
 
 		// make the number!
 		char_t* s = result;
@@ -8780,8 +8780,8 @@ PUGI__NS_BEGIN
 			if (size_ + count > capacity)
 			{
 				// reallocate the old array or allocate a new one
-				xpath_node* data = static_cast<xpath_node*>(alloc->reallocate_throw(_begin, capacity * sizeof(xpath_node), (size_ + count) * sizeof(xpath_node)));
-				assert(data);
+				xpath_node* data = static_cast<xpath_node*>(alloc->reallocate_nothrow(_begin, capacity * sizeof(xpath_node), (size_ + count) * sizeof(xpath_node)));
+				if (!data) return;
 
 				// finalize
 				_begin = data;
@@ -8832,8 +8832,8 @@ PUGI__NS_BEGIN
 		size_t new_capacity = capacity + capacity / 2 + 1;
 
 		// reallocate the old array or allocate a new one
-		xpath_node* data = static_cast<xpath_node*>(alloc->reallocate_throw(_begin, capacity * sizeof(xpath_node), new_capacity * sizeof(xpath_node)));
-		assert(data);
+		xpath_node* data = static_cast<xpath_node*>(alloc->reallocate_nothrow(_begin, capacity * sizeof(xpath_node), new_capacity * sizeof(xpath_node)));
+		if (!data) return;
 
 		// finalize
 		_begin = data;
@@ -10418,8 +10418,8 @@ PUGI__NS_BEGIN
 			// allocate on-heap for large concats
 			if (count > sizeof(static_buffer) / sizeof(static_buffer[0]))
 			{
-				buffer = static_cast<xpath_string*>(stack.temp->allocate_throw(count * sizeof(xpath_string)));
-				assert(buffer);
+				buffer = static_cast<xpath_string*>(stack.temp->allocate_nothrow(count * sizeof(xpath_string)));
+				if (!buffer) return xpath_string();
 			}
 
 			// evaluate all strings to temporary stack
@@ -10436,8 +10436,8 @@ PUGI__NS_BEGIN
 			for (size_t i = 0; i < count; ++i) length += buffer[i].length();
 
 			// create final string
-			char_t* result = static_cast<char_t*>(stack.result->allocate_throw((length + 1) * sizeof(char_t)));
-			assert(result);
+			char_t* result = static_cast<char_t*>(stack.result->allocate_nothrow((length + 1) * sizeof(char_t)));
+			if (!result) return xpath_string();
 
 			char_t* ri = result;
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -11333,11 +11333,11 @@ PUGI__NS_BEGIN
 			{
 				_lexer.next();
 
-				xpath_ast_node* expr = parse_expression();
-				if (!expr) return 0;
-
 				if (n->rettype() != xpath_type_node_set)
 					return error("Predicate has to be applied to node set");
+
+				xpath_ast_node* expr = parse_expression();
+				if (!expr) return 0;
 
 				n = alloc_node(ast_filter, n, expr, predicate_default);
 				if (!n) return 0;

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -6132,7 +6132,7 @@ namespace pugi
 	{
 		xml_node found = *this; // Current search context.
 
-		if (!_root || !path_ || !path_[0]) return found;
+		if (!_root || !path_[0]) return found;
 
 		if (path_[0] == delimiter)
 		{

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -11823,11 +11823,16 @@ PUGI__NS_BEGIN
 
 		xpath_string r = impl->root->eval_string(c, sd.stack);
 
-	#ifndef PUGIXML_NO_EXCEPTIONS
-		if (sd.oom) throw std::bad_alloc();
-	#endif
+		if (sd.oom)
+		{
+		#ifdef PUGIXML_NO_EXCEPTIONS
+			return xpath_string();
+		#else
+			throw std::bad_alloc();
+		#endif
+		}
 
-		return sd.oom ? xpath_string() : r;
+		return r;
 	}
 
 	PUGI__FN impl::xpath_ast_node* evaluate_node_set_prepare(xpath_query_impl* impl)
@@ -12463,11 +12468,16 @@ namespace pugi
 
 		bool r = static_cast<impl::xpath_query_impl*>(_impl)->root->eval_boolean(c, sd.stack);
 
-	#ifndef PUGIXML_NO_EXCEPTIONS
-		if (sd.oom) throw std::bad_alloc();
-	#endif
+		if (sd.oom)
+		{
+		#ifdef PUGIXML_NO_EXCEPTIONS
+			return false;
+		#else
+			throw std::bad_alloc();
+		#endif
+		}
 
-		return sd.oom ? false : r;
+		return r;
 	}
 
 	PUGI__FN double xpath_query::evaluate_number(const xpath_node& n) const
@@ -12479,11 +12489,16 @@ namespace pugi
 
 		double r = static_cast<impl::xpath_query_impl*>(_impl)->root->eval_number(c, sd.stack);
 
-	#ifndef PUGIXML_NO_EXCEPTIONS
-		if (sd.oom) throw std::bad_alloc();
-	#endif
+		if (sd.oom)
+		{
+		#ifdef PUGIXML_NO_EXCEPTIONS
+			return impl::gen_nan();
+		#else
+			throw std::bad_alloc();
+		#endif
+		}
 
-		return sd.oom ? impl::gen_nan() : r;
+		return r;
 	}
 
 #ifndef PUGIXML_NO_STL
@@ -12527,11 +12542,16 @@ namespace pugi
 
 		impl::xpath_node_set_raw r = root->eval_node_set(c, sd.stack, impl::nodeset_eval_all);
 
-	#ifndef PUGIXML_NO_EXCEPTIONS
-		if (sd.oom) throw std::bad_alloc();
-	#endif
+		if (sd.oom)
+		{
+		#ifdef PUGIXML_NO_EXCEPTIONS
+			return xpath_node_set();
+		#else
+			throw std::bad_alloc();
+		#endif
+		}
 
-		return sd.oom ? xpath_node_set() : xpath_node_set(r.begin(), r.end(), r.type());
+		return xpath_node_set(r.begin(), r.end(), r.type());
 	}
 
 	PUGI__FN xpath_node xpath_query::evaluate_node(const xpath_node& n) const
@@ -12544,11 +12564,16 @@ namespace pugi
 
 		impl::xpath_node_set_raw r = root->eval_node_set(c, sd.stack, impl::nodeset_eval_first);
 
-	#ifndef PUGIXML_NO_EXCEPTIONS
-		if (sd.oom) throw std::bad_alloc();
-	#endif
+		if (sd.oom)
+		{
+		#ifdef PUGIXML_NO_EXCEPTIONS
+			return xpath_node();
+		#else
+			throw std::bad_alloc();
+		#endif
+		}
 
-		return sd.oom ? xpath_node() : r.first();
+		return r.first();
 	}
 
 	PUGI__FN const xpath_parse_result& xpath_query::result() const

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -11398,11 +11398,17 @@ PUGI__NS_BEGIN
 			{
 				_lexer.next();
 
+				if (_lexer.current() == lex_open_square_brace)
+					return error("Predicates are not allowed after an abbreviated step");
+
 				return alloc_node(ast_step, set, axis_self, nodetest_type_node, 0);
 			}
 			else if (_lexer.current() == lex_double_dot)
 			{
 				_lexer.next();
+
+				if (_lexer.current() == lex_open_square_brace)
+					return error("Predicates are not allowed after an abbreviated step");
 
 				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, 0);
 			}

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -11272,7 +11272,7 @@ PUGI__NS_BEGIN
 				if (!n) return 0;
 
 				if (_lexer.current() != lex_close_brace)
-					return error("Unmatched braces");
+					return error("Expected ')' to match an opening '('");
 
 				_lexer.next();
 
@@ -11366,7 +11366,7 @@ PUGI__NS_BEGIN
 				if (!n) return 0;
 
 				if (_lexer.current() != lex_close_square_brace)
-					return error("Unmatched square brace");
+					return error("Expected ']' to match an opening '['");
 
 				_lexer.next();
 			}
@@ -11535,7 +11535,7 @@ PUGI__NS_BEGIN
 				if (!pred) return 0;
 
 				if (_lexer.current() != lex_close_square_brace)
-					return error("Unmatched square brace");
+					return error("Expected ']' to match an opening '['");
 				_lexer.next();
 
 				if (last) last->set_next(pred);

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -10968,16 +10968,6 @@ PUGI__NS_BEGIN
 			return c;
 		}
 
-		xpath_ast_node* parse_function_helper(ast_type_t type0, ast_type_t type1, size_t argc, xpath_ast_node* args[2])
-		{
-			assert(argc <= 1);
-
-			if (argc == 1 && args[0]->rettype() != xpath_type_node_set)
-				throw_error("Function has to be applied to node set");
-
-			return new (alloc_node()) xpath_ast_node(argc == 0 ? type0 : type1, xpath_type_string, args[0]);
-		}
-
 		xpath_ast_node* parse_function(const xpath_lexer_string& name, size_t argc, xpath_ast_node* args[2])
 		{
 			switch (name.begin[0])
@@ -10991,9 +10981,7 @@ PUGI__NS_BEGIN
 			case 'c':
 				if (name == PUGIXML_TEXT("count") && argc == 1)
 				{
-					if (args[0]->rettype() != xpath_type_node_set)
-						throw_error("Function has to be applied to node set");
-
+					if (args[0]->rettype() != xpath_type_node_set) throw_error("Function has to be applied to node set");
 					return new (alloc_node()) xpath_ast_node(ast_func_count, xpath_type_number, args[0]);
 				}
 				else if (name == PUGIXML_TEXT("contains") && argc == 2)
@@ -11025,15 +11013,24 @@ PUGI__NS_BEGIN
 				else if (name == PUGIXML_TEXT("lang") && argc == 1)
 					return new (alloc_node()) xpath_ast_node(ast_func_lang, xpath_type_boolean, args[0]);
 				else if (name == PUGIXML_TEXT("local-name") && argc <= 1)
-					return parse_function_helper(ast_func_local_name_0, ast_func_local_name_1, argc, args);
+				{
+					if (argc == 1 && args[0]->rettype() != xpath_type_node_set) throw_error("Function has to be applied to node set");
+					return new (alloc_node()) xpath_ast_node(argc == 0 ? ast_func_local_name_0 : ast_func_local_name_1, xpath_type_string, args[0]);
+				}
 
 				break;
 
 			case 'n':
 				if (name == PUGIXML_TEXT("name") && argc <= 1)
-					return parse_function_helper(ast_func_name_0, ast_func_name_1, argc, args);
+				{
+					if (argc == 1 && args[0]->rettype() != xpath_type_node_set) throw_error("Function has to be applied to node set");
+					return new (alloc_node()) xpath_ast_node(argc == 0 ? ast_func_name_0 : ast_func_name_1, xpath_type_string, args[0]);
+				}
 				else if (name == PUGIXML_TEXT("namespace-uri") && argc <= 1)
-					return parse_function_helper(ast_func_namespace_uri_0, ast_func_namespace_uri_1, argc, args);
+				{
+					if (argc == 1 && args[0]->rettype() != xpath_type_node_set) throw_error("Function has to be applied to node set");
+					return new (alloc_node()) xpath_ast_node(argc == 0 ? ast_func_namespace_uri_0 : ast_func_namespace_uri_1, xpath_type_string, args[0]);
+				}
 				else if (name == PUGIXML_TEXT("normalize-space") && argc <= 1)
 					return new (alloc_node()) xpath_ast_node(argc == 0 ? ast_func_normalize_space_0 : ast_func_normalize_space_1, xpath_type_string, args[0], args[1]);
 				else if (name == PUGIXML_TEXT("not") && argc == 1)

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -6113,7 +6113,7 @@ namespace pugi
 			if (j != _root)
 				result[--offset] = delimiter;
 
-			if (j->name && *j->name)
+			if (j->name)
 			{
 				size_t length = impl::strlength(j->name);
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -10953,20 +10953,19 @@ PUGI__NS_BEGIN
 
 		const char_t* alloc_string(const xpath_lexer_string& value)
 		{
-			if (value.begin)
-			{
-				size_t length = static_cast<size_t>(value.end - value.begin);
+			if (!value.begin)
+				return PUGIXML_TEXT("");
 
-				char_t* c = static_cast<char_t*>(_alloc->allocate_nothrow((length + 1) * sizeof(char_t)));
-				if (!c) throw_error_oom();
-				assert(c); // workaround for clang static analysis
+			size_t length = static_cast<size_t>(value.end - value.begin);
 
-				memcpy(c, value.begin, length * sizeof(char_t));
-				c[length] = 0;
+			char_t* c = static_cast<char_t*>(_alloc->allocate_nothrow((length + 1) * sizeof(char_t)));
+			if (!c) throw_error_oom();
+			assert(c); // workaround for clang static analysis
 
-				return c;
-			}
-			else return 0;
+			memcpy(c, value.begin, length * sizeof(char_t));
+			c[length] = 0;
+
+			return c;
 		}
 
 		xpath_ast_node* parse_function_helper(ast_type_t type0, ast_type_t type1, size_t argc, xpath_ast_node* args[2])

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -10944,10 +10944,45 @@ PUGI__NS_BEGIN
 		void* alloc_node()
 		{
 			void* result = _alloc->allocate_nothrow(sizeof(xpath_ast_node));
-
 			if (!result) throw_error_oom();
 
 			return result;
+		}
+
+		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, const char_t* value)
+		{
+			void* memory = alloc_node();
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : 0;
+		}
+
+		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, double value)
+		{
+			void* memory = alloc_node();
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : 0;
+		}
+
+		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_variable* value)
+		{
+			void* memory = alloc_node();
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : 0;
+		}
+
+		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_ast_node* left = 0, xpath_ast_node* right = 0)
+		{
+			void* memory = alloc_node();
+			return memory ? new (memory) xpath_ast_node(type, rettype, left, right) : 0;
+		}
+
+		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, axis_t axis, nodetest_t test, const char_t* contents)
+		{
+			void* memory = alloc_node();
+			return memory ? new (memory) xpath_ast_node(type, left, axis, test, contents) : 0;
+		}
+
+		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, xpath_ast_node* right, predicate_t test)
+		{
+			void* memory = alloc_node();
+			return memory ? new (memory) xpath_ast_node(type, left, right, test) : 0;
 		}
 
 		const char_t* alloc_string(const xpath_lexer_string& value)
@@ -10973,7 +11008,7 @@ PUGI__NS_BEGIN
 			{
 			case 'b':
 				if (name == PUGIXML_TEXT("boolean") && argc == 1)
-					return new (alloc_node()) xpath_ast_node(ast_func_boolean, xpath_type_boolean, args[0]);
+					return alloc_node(ast_func_boolean, xpath_type_boolean, args[0]);
 
 				break;
 
@@ -10981,40 +11016,40 @@ PUGI__NS_BEGIN
 				if (name == PUGIXML_TEXT("count") && argc == 1)
 				{
 					if (args[0]->rettype() != xpath_type_node_set) return error("Function has to be applied to node set");
-					return new (alloc_node()) xpath_ast_node(ast_func_count, xpath_type_number, args[0]);
+					return alloc_node(ast_func_count, xpath_type_number, args[0]);
 				}
 				else if (name == PUGIXML_TEXT("contains") && argc == 2)
-					return new (alloc_node()) xpath_ast_node(ast_func_contains, xpath_type_boolean, args[0], args[1]);
+					return alloc_node(ast_func_contains, xpath_type_boolean, args[0], args[1]);
 				else if (name == PUGIXML_TEXT("concat") && argc >= 2)
-					return new (alloc_node()) xpath_ast_node(ast_func_concat, xpath_type_string, args[0], args[1]);
+					return alloc_node(ast_func_concat, xpath_type_string, args[0], args[1]);
 				else if (name == PUGIXML_TEXT("ceiling") && argc == 1)
-					return new (alloc_node()) xpath_ast_node(ast_func_ceiling, xpath_type_number, args[0]);
+					return alloc_node(ast_func_ceiling, xpath_type_number, args[0]);
 
 				break;
 
 			case 'f':
 				if (name == PUGIXML_TEXT("false") && argc == 0)
-					return new (alloc_node()) xpath_ast_node(ast_func_false, xpath_type_boolean);
+					return alloc_node(ast_func_false, xpath_type_boolean);
 				else if (name == PUGIXML_TEXT("floor") && argc == 1)
-					return new (alloc_node()) xpath_ast_node(ast_func_floor, xpath_type_number, args[0]);
+					return alloc_node(ast_func_floor, xpath_type_number, args[0]);
 
 				break;
 
 			case 'i':
 				if (name == PUGIXML_TEXT("id") && argc == 1)
-					return new (alloc_node()) xpath_ast_node(ast_func_id, xpath_type_node_set, args[0]);
+					return alloc_node(ast_func_id, xpath_type_node_set, args[0]);
 
 				break;
 
 			case 'l':
 				if (name == PUGIXML_TEXT("last") && argc == 0)
-					return new (alloc_node()) xpath_ast_node(ast_func_last, xpath_type_number);
+					return alloc_node(ast_func_last, xpath_type_number);
 				else if (name == PUGIXML_TEXT("lang") && argc == 1)
-					return new (alloc_node()) xpath_ast_node(ast_func_lang, xpath_type_boolean, args[0]);
+					return alloc_node(ast_func_lang, xpath_type_boolean, args[0]);
 				else if (name == PUGIXML_TEXT("local-name") && argc <= 1)
 				{
 					if (argc == 1 && args[0]->rettype() != xpath_type_node_set) return error("Function has to be applied to node set");
-					return new (alloc_node()) xpath_ast_node(argc == 0 ? ast_func_local_name_0 : ast_func_local_name_1, xpath_type_string, args[0]);
+					return alloc_node(argc == 0 ? ast_func_local_name_0 : ast_func_local_name_1, xpath_type_string, args[0]);
 				}
 
 				break;
@@ -11023,60 +11058,60 @@ PUGI__NS_BEGIN
 				if (name == PUGIXML_TEXT("name") && argc <= 1)
 				{
 					if (argc == 1 && args[0]->rettype() != xpath_type_node_set) return error("Function has to be applied to node set");
-					return new (alloc_node()) xpath_ast_node(argc == 0 ? ast_func_name_0 : ast_func_name_1, xpath_type_string, args[0]);
+					return alloc_node(argc == 0 ? ast_func_name_0 : ast_func_name_1, xpath_type_string, args[0]);
 				}
 				else if (name == PUGIXML_TEXT("namespace-uri") && argc <= 1)
 				{
 					if (argc == 1 && args[0]->rettype() != xpath_type_node_set) return error("Function has to be applied to node set");
-					return new (alloc_node()) xpath_ast_node(argc == 0 ? ast_func_namespace_uri_0 : ast_func_namespace_uri_1, xpath_type_string, args[0]);
+					return alloc_node(argc == 0 ? ast_func_namespace_uri_0 : ast_func_namespace_uri_1, xpath_type_string, args[0]);
 				}
 				else if (name == PUGIXML_TEXT("normalize-space") && argc <= 1)
-					return new (alloc_node()) xpath_ast_node(argc == 0 ? ast_func_normalize_space_0 : ast_func_normalize_space_1, xpath_type_string, args[0], args[1]);
+					return alloc_node(argc == 0 ? ast_func_normalize_space_0 : ast_func_normalize_space_1, xpath_type_string, args[0], args[1]);
 				else if (name == PUGIXML_TEXT("not") && argc == 1)
-					return new (alloc_node()) xpath_ast_node(ast_func_not, xpath_type_boolean, args[0]);
+					return alloc_node(ast_func_not, xpath_type_boolean, args[0]);
 				else if (name == PUGIXML_TEXT("number") && argc <= 1)
-					return new (alloc_node()) xpath_ast_node(argc == 0 ? ast_func_number_0 : ast_func_number_1, xpath_type_number, args[0]);
+					return alloc_node(argc == 0 ? ast_func_number_0 : ast_func_number_1, xpath_type_number, args[0]);
 
 				break;
 
 			case 'p':
 				if (name == PUGIXML_TEXT("position") && argc == 0)
-					return new (alloc_node()) xpath_ast_node(ast_func_position, xpath_type_number);
+					return alloc_node(ast_func_position, xpath_type_number);
 
 				break;
 
 			case 'r':
 				if (name == PUGIXML_TEXT("round") && argc == 1)
-					return new (alloc_node()) xpath_ast_node(ast_func_round, xpath_type_number, args[0]);
+					return alloc_node(ast_func_round, xpath_type_number, args[0]);
 
 				break;
 
 			case 's':
 				if (name == PUGIXML_TEXT("string") && argc <= 1)
-					return new (alloc_node()) xpath_ast_node(argc == 0 ? ast_func_string_0 : ast_func_string_1, xpath_type_string, args[0]);
+					return alloc_node(argc == 0 ? ast_func_string_0 : ast_func_string_1, xpath_type_string, args[0]);
 				else if (name == PUGIXML_TEXT("string-length") && argc <= 1)
-					return new (alloc_node()) xpath_ast_node(argc == 0 ? ast_func_string_length_0 : ast_func_string_length_1, xpath_type_number, args[0]);
+					return alloc_node(argc == 0 ? ast_func_string_length_0 : ast_func_string_length_1, xpath_type_number, args[0]);
 				else if (name == PUGIXML_TEXT("starts-with") && argc == 2)
-					return new (alloc_node()) xpath_ast_node(ast_func_starts_with, xpath_type_boolean, args[0], args[1]);
+					return alloc_node(ast_func_starts_with, xpath_type_boolean, args[0], args[1]);
 				else if (name == PUGIXML_TEXT("substring-before") && argc == 2)
-					return new (alloc_node()) xpath_ast_node(ast_func_substring_before, xpath_type_string, args[0], args[1]);
+					return alloc_node(ast_func_substring_before, xpath_type_string, args[0], args[1]);
 				else if (name == PUGIXML_TEXT("substring-after") && argc == 2)
-					return new (alloc_node()) xpath_ast_node(ast_func_substring_after, xpath_type_string, args[0], args[1]);
+					return alloc_node(ast_func_substring_after, xpath_type_string, args[0], args[1]);
 				else if (name == PUGIXML_TEXT("substring") && (argc == 2 || argc == 3))
-					return new (alloc_node()) xpath_ast_node(argc == 2 ? ast_func_substring_2 : ast_func_substring_3, xpath_type_string, args[0], args[1]);
+					return alloc_node(argc == 2 ? ast_func_substring_2 : ast_func_substring_3, xpath_type_string, args[0], args[1]);
 				else if (name == PUGIXML_TEXT("sum") && argc == 1)
 				{
 					if (args[0]->rettype() != xpath_type_node_set) return error("Function has to be applied to node set");
-					return new (alloc_node()) xpath_ast_node(ast_func_sum, xpath_type_number, args[0]);
+					return alloc_node(ast_func_sum, xpath_type_number, args[0]);
 				}
 
 				break;
 
 			case 't':
 				if (name == PUGIXML_TEXT("translate") && argc == 3)
-					return new (alloc_node()) xpath_ast_node(ast_func_translate, xpath_type_string, args[0], args[1]);
+					return alloc_node(ast_func_translate, xpath_type_string, args[0], args[1]);
 				else if (name == PUGIXML_TEXT("true") && argc == 0)
-					return new (alloc_node()) xpath_ast_node(ast_func_true, xpath_type_boolean);
+					return alloc_node(ast_func_true, xpath_type_boolean);
 
 				break;
 
@@ -11211,7 +11246,7 @@ PUGI__NS_BEGIN
 
 				_lexer.next();
 
-				return new (alloc_node()) xpath_ast_node(ast_variable, var->type(), var);
+				return alloc_node(ast_variable, var->type(), var);
 			}
 
 			case lex_open_brace:
@@ -11236,7 +11271,7 @@ PUGI__NS_BEGIN
 
 				_lexer.next();
 
-				return new (alloc_node()) xpath_ast_node(ast_string_constant, xpath_type_string, value);
+				return alloc_node(ast_string_constant, xpath_type_string, value);
 			}
 
 			case lex_number:
@@ -11248,7 +11283,7 @@ PUGI__NS_BEGIN
 
 				_lexer.next();
 
-				return new (alloc_node()) xpath_ast_node(ast_number_constant, xpath_type_number, value);
+				return alloc_node(ast_number_constant, xpath_type_number, value);
 			}
 
 			case lex_string:
@@ -11312,7 +11347,7 @@ PUGI__NS_BEGIN
 				if (n->rettype() != xpath_type_node_set)
 					return error("Predicate has to be applied to node set");
 
-				n = new (alloc_node()) xpath_ast_node(ast_filter, n, expr, predicate_default);
+				n = alloc_node(ast_filter, n, expr, predicate_default);
 				if (!n) return 0;
 
 				if (_lexer.current() != lex_close_square_brace)
@@ -11348,13 +11383,13 @@ PUGI__NS_BEGIN
 			{
 				_lexer.next();
 
-				return new (alloc_node()) xpath_ast_node(ast_step, set, axis_self, nodetest_type_node, 0);
+				return alloc_node(ast_step, set, axis_self, nodetest_type_node, 0);
 			}
 			else if (_lexer.current() == lex_double_dot)
 			{
 				_lexer.next();
 
-				return new (alloc_node()) xpath_ast_node(ast_step, set, axis_parent, nodetest_type_node, 0);
+				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, 0);
 			}
 
 			nodetest_t nt_type = nodetest_none;
@@ -11463,7 +11498,7 @@ PUGI__NS_BEGIN
 			const char_t* nt_name_copy = alloc_string(nt_name);
 			if (!nt_name_copy) return 0;
 
-			xpath_ast_node* n = new (alloc_node()) xpath_ast_node(ast_step, set, axis, nt_type, nt_name_copy);
+			xpath_ast_node* n = alloc_node(ast_step, set, axis, nt_type, nt_name_copy);
 			if (!n) return 0;
 
 			xpath_ast_node* last = 0;
@@ -11475,7 +11510,7 @@ PUGI__NS_BEGIN
 				xpath_ast_node* expr = parse_expression();
 				if (!expr) return 0;
 
-				xpath_ast_node* pred = new (alloc_node()) xpath_ast_node(ast_predicate, 0, expr, predicate_default);
+				xpath_ast_node* pred = alloc_node(ast_predicate, 0, expr, predicate_default);
 				if (!pred) return 0;
 
 				if (_lexer.current() != lex_close_square_brace)
@@ -11504,7 +11539,7 @@ PUGI__NS_BEGIN
 
 				if (l == lex_double_slash)
 				{
-					n = new (alloc_node()) xpath_ast_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
+					n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
 					if (!n) return 0;
 				}
 
@@ -11523,7 +11558,7 @@ PUGI__NS_BEGIN
 			{
 				_lexer.next();
 
-				xpath_ast_node* n = new (alloc_node()) xpath_ast_node(ast_step_root, xpath_type_node_set);
+				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
 				if (!n) return 0;
 
 				// relative location path can start from axis_attribute, dot, double_dot, multiply and string lexemes; any other lexeme means standalone root path
@@ -11538,10 +11573,10 @@ PUGI__NS_BEGIN
 			{
 				_lexer.next();
 
-				xpath_ast_node* n = new (alloc_node()) xpath_ast_node(ast_step_root, xpath_type_node_set);
+				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
 				if (!n) return 0;
 
-				n = new (alloc_node()) xpath_ast_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
+				n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
 				if (!n) return 0;
 
 				return parse_relative_location_path(n);
@@ -11597,7 +11632,7 @@ PUGI__NS_BEGIN
 						if (n->rettype() != xpath_type_node_set)
 							return error("Step has to be applied to node set");
 
-						n = new (alloc_node()) xpath_ast_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
+						n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
 						if (!n) return 0;
 					}
 
@@ -11615,7 +11650,7 @@ PUGI__NS_BEGIN
 				xpath_ast_node* n = parse_expression(7);
 				if (!n) return 0;
 
-				return new (alloc_node()) xpath_ast_node(ast_op_negate, xpath_type_number, n);
+				return alloc_node(ast_op_negate, xpath_type_number, n);
 			}
 			else
 			{
@@ -11713,7 +11748,7 @@ PUGI__NS_BEGIN
 				if (op.asttype == ast_op_union && (lhs->rettype() != xpath_type_node_set || rhs->rettype() != xpath_type_node_set))
 					return error("Union operator has to be applied to node sets");
 
-				lhs = new (alloc_node()) xpath_ast_node(op.asttype, op.rettype, lhs, rhs);
+				lhs = alloc_node(op.asttype, op.rettype, lhs, rhs);
 				if (!lhs) return 0;
 
 				op = binary_op_t::parse(_lexer);

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -11870,6 +11870,10 @@ PUGI__NS_BEGIN
 
 		xpath_string r = impl->root->eval_string(c, sd.stack);
 
+	#ifndef PUGIXML_NO_EXCEPTIONS
+		if (sd.error) throw std::bad_alloc();
+	#endif
+
 		return sd.error ? xpath_string() : r;
 	}
 
@@ -12510,6 +12514,10 @@ namespace pugi
 
 		bool r = static_cast<impl::xpath_query_impl*>(_impl)->root->eval_boolean(c, sd.stack);
 
+	#ifndef PUGIXML_NO_EXCEPTIONS
+		if (sd.error) throw std::bad_alloc();
+	#endif
+
 		return sd.error ? false : r;
 	}
 
@@ -12525,6 +12533,10 @@ namespace pugi
 	#endif
 
 		double r = static_cast<impl::xpath_query_impl*>(_impl)->root->eval_number(c, sd.stack);
+
+	#ifndef PUGIXML_NO_EXCEPTIONS
+		if (sd.error) throw std::bad_alloc();
+	#endif
 
 		return sd.error ? impl::gen_nan() : r;
 	}
@@ -12574,6 +12586,10 @@ namespace pugi
 
 		impl::xpath_node_set_raw r = root->eval_node_set(c, sd.stack, impl::nodeset_eval_all);
 
+	#ifndef PUGIXML_NO_EXCEPTIONS
+		if (sd.error) throw std::bad_alloc();
+	#endif
+
 		return sd.error ? xpath_node_set() : xpath_node_set(r.begin(), r.end(), r.type());
 	}
 
@@ -12590,6 +12606,10 @@ namespace pugi
 	#endif
 
 		impl::xpath_node_set_raw r = root->eval_node_set(c, sd.stack, impl::nodeset_eval_first);
+
+	#ifndef PUGIXML_NO_EXCEPTIONS
+		if (sd.error) throw std::bad_alloc();
+	#endif
 
 		return sd.error ? xpath_node() : r.first();
 	}

--- a/tests/test_compact.cpp
+++ b/tests/test_compact.cpp
@@ -1,0 +1,110 @@
+#ifdef PUGIXML_COMPACT
+#include "common.hpp"
+
+static void overflow_hash_table(xml_document& doc)
+{
+	xml_node n = doc.child(STR("n"));
+
+	// compact encoding assumes next_sibling is a forward-only pointer so we can allocate hash entries by reordering nodes
+	// we allocate enough hash entries to be exactly on the edge of rehash threshold
+	for (int i = 0; i < 8; ++i)
+		CHECK(n.prepend_child(node_element));
+}
+
+TEST_XML(compact_out_of_memory_string, "<n/>")
+{
+	test_runner::_memory_fail_threshold = 1;
+
+	overflow_hash_table(doc);
+
+	xml_node n = doc.child(STR("n"));
+
+	CHECK_ALLOC_FAIL(CHECK(!n.set_name(STR("name"))));
+}
+
+TEST_XML(compact_out_of_memory_attribute, "<n a='v'/>")
+{
+	test_runner::_memory_fail_threshold = 1;
+
+	overflow_hash_table(doc);
+
+	xml_node n = doc.child(STR("n"));
+	xml_attribute a = n.attribute(STR("a"));
+
+	CHECK_ALLOC_FAIL(CHECK(!n.append_attribute(STR(""))));
+	CHECK_ALLOC_FAIL(CHECK(!n.prepend_attribute(STR(""))));
+	CHECK_ALLOC_FAIL(CHECK(!n.insert_attribute_after(STR(""), a)));
+	CHECK_ALLOC_FAIL(CHECK(!n.insert_attribute_before(STR(""), a)));
+}
+
+TEST_XML(compact_out_of_memory_attribute_copy, "<n a='v'/>")
+{
+	test_runner::_memory_fail_threshold = 1;
+
+	overflow_hash_table(doc);
+
+	xml_node n = doc.child(STR("n"));
+	xml_attribute a = n.attribute(STR("a"));
+
+	CHECK_ALLOC_FAIL(CHECK(!n.append_copy(a)));
+	CHECK_ALLOC_FAIL(CHECK(!n.prepend_copy(a)));
+	CHECK_ALLOC_FAIL(CHECK(!n.insert_copy_after(a, a)));
+	CHECK_ALLOC_FAIL(CHECK(!n.insert_copy_before(a, a)));
+}
+
+TEST_XML(compact_out_of_memory_node, "<n/>")
+{
+	test_runner::_memory_fail_threshold = 1;
+
+	overflow_hash_table(doc);
+
+	xml_node n = doc.child(STR("n"));
+
+	CHECK_ALLOC_FAIL(CHECK(!doc.append_child(node_element)));
+	CHECK_ALLOC_FAIL(CHECK(!doc.prepend_child(node_element)));
+	CHECK_ALLOC_FAIL(CHECK(!doc.insert_child_after(node_element, n)));
+	CHECK_ALLOC_FAIL(CHECK(!doc.insert_child_before(node_element, n)));
+}
+
+TEST_XML(compact_out_of_memory_node_copy, "<n/>")
+{
+	test_runner::_memory_fail_threshold = 1;
+
+	overflow_hash_table(doc);
+
+	xml_node n = doc.child(STR("n"));
+
+	CHECK_ALLOC_FAIL(CHECK(!doc.append_copy(n)));
+	CHECK_ALLOC_FAIL(CHECK(!doc.prepend_copy(n)));
+	CHECK_ALLOC_FAIL(CHECK(!doc.insert_copy_after(n, n)));
+	CHECK_ALLOC_FAIL(CHECK(!doc.insert_copy_before(n, n)));
+}
+
+TEST_XML(compact_out_of_memory_node_move, "<n/><ne/>")
+{
+	test_runner::_memory_fail_threshold = 1;
+
+	overflow_hash_table(doc);
+
+	xml_node n = doc.child(STR("n"));
+	xml_node ne = doc.child(STR("ne"));
+
+	CHECK_ALLOC_FAIL(CHECK(!doc.append_move(n)));
+	CHECK_ALLOC_FAIL(CHECK(!doc.prepend_move(n)));
+	CHECK_ALLOC_FAIL(CHECK(!doc.insert_move_after(n, ne)));
+	CHECK_ALLOC_FAIL(CHECK(!doc.insert_move_before(n, ne)));
+}
+
+TEST_XML(compact_out_of_memory_remove, "<n a='v'/>")
+{
+	test_runner::_memory_fail_threshold = 1;
+
+	overflow_hash_table(doc);
+
+	xml_node n = doc.child(STR("n"));
+	xml_attribute a = n.attribute(STR("a"));
+
+	CHECK_ALLOC_FAIL(CHECK(!n.remove_attribute(a)));
+	CHECK_ALLOC_FAIL(CHECK(!doc.remove_child(n)));
+}
+#endif

--- a/tests/test_compact.cpp
+++ b/tests/test_compact.cpp
@@ -11,15 +11,19 @@ static void overflow_hash_table(xml_document& doc)
 		CHECK(n.prepend_child(node_element));
 }
 
-TEST_XML(compact_out_of_memory_string, "<n/>")
+TEST_XML_FLAGS(compact_out_of_memory_string, "<n a='v'/><?n v?>", parse_pi)
 {
 	test_runner::_memory_fail_threshold = 1;
 
 	overflow_hash_table(doc);
 
-	xml_node n = doc.child(STR("n"));
+	xml_attribute a = doc.child(STR("n")).attribute(STR("a"));
+	xml_node pi = doc.last_child();
 
-	CHECK_ALLOC_FAIL(CHECK(!n.set_name(STR("name"))));
+	CHECK_ALLOC_FAIL(CHECK(!pi.set_name(STR("name"))));
+	CHECK_ALLOC_FAIL(CHECK(!pi.set_value(STR("value"))));
+	CHECK_ALLOC_FAIL(CHECK(!a.set_name(STR("name"))));
+	CHECK_ALLOC_FAIL(CHECK(!a.set_value(STR("value"))));
 }
 
 TEST_XML(compact_out_of_memory_attribute, "<n a='v'/>")

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -496,6 +496,15 @@ TEST_XML(document_save_declaration_latin1, "<node/>")
 	CHECK(writer.as_narrow() == "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<node />\n");
 }
 
+TEST_XML(document_save_declaration_raw, "<node/>")
+{
+	xml_writer_string writer;
+
+	doc.save(writer, STR(""), pugi::format_raw, get_native_encoding());
+
+	CHECK(writer.as_string() == STR("<?xml version=\"1.0\"?><node/>"));
+}
+
 struct temp_file
 {
 	char path[512];

--- a/tests/test_dom_modify.cpp
+++ b/tests/test_dom_modify.cpp
@@ -389,7 +389,7 @@ TEST_XML(dom_node_append_copy_attribute, "<node a1='v1'><child a2='v2'/><child/>
 	CHECK_NODE(doc, STR("<node a1=\"v1\" a3=\"v3\" a4=\"v4\"><child a2=\"v2\"/><child a5=\"v5\"/></node>"));
 }
 
-TEST_XML(dom_node_insert_copy_after_attribute, "<node a1='v1'><child a2='v2'/></node>")
+TEST_XML(dom_node_insert_copy_after_attribute, "<node a1='v1'><child a2='v2'/>text</node>")
 {
 	CHECK(xml_node().insert_copy_after(xml_attribute(), xml_attribute()) == xml_attribute());
 
@@ -402,6 +402,7 @@ TEST_XML(dom_node_insert_copy_after_attribute, "<node a1='v1'><child a2='v2'/></
 	CHECK(node.insert_copy_after(a1, xml_attribute()) == xml_attribute());
 	CHECK(node.insert_copy_after(xml_attribute(), a1) == xml_attribute());
 	CHECK(node.insert_copy_after(a2, a2) == xml_attribute());
+	CHECK(node.last_child().insert_copy_after(a2, a2) == xml_attribute());
 
 	xml_attribute a3 = node.insert_copy_after(a1, a1);
 	CHECK(a3 && a3 != a2 && a3 != a1);
@@ -414,7 +415,7 @@ TEST_XML(dom_node_insert_copy_after_attribute, "<node a1='v1'><child a2='v2'/></
 
 	CHECK(child.insert_copy_after(a4, a4) == xml_attribute());
 
-	CHECK_NODE(doc, STR("<node a1=\"v1\" a2=\"v2\" a2=\"v2\" a1=\"v1\"><child a2=\"v2\"/></node>"));
+	CHECK_NODE(doc, STR("<node a1=\"v1\" a2=\"v2\" a2=\"v2\" a1=\"v1\"><child a2=\"v2\"/>text</node>"));
 
 	a3.set_name(STR("a3"));
 	a3 = STR("v3");
@@ -425,10 +426,10 @@ TEST_XML(dom_node_insert_copy_after_attribute, "<node a1='v1'><child a2='v2'/></
 	a5.set_name(STR("a5"));
 	a5 = STR("v5");
 
-	CHECK_NODE(doc, STR("<node a1=\"v1\" a5=\"v5\" a4=\"v4\" a3=\"v3\"><child a2=\"v2\"/></node>"));
+	CHECK_NODE(doc, STR("<node a1=\"v1\" a5=\"v5\" a4=\"v4\" a3=\"v3\"><child a2=\"v2\"/>text</node>"));
 }
 
-TEST_XML(dom_node_insert_copy_before_attribute, "<node a1='v1'><child a2='v2'/></node>")
+TEST_XML(dom_node_insert_copy_before_attribute, "<node a1='v1'><child a2='v2'/>text</node>")
 {
 	CHECK(xml_node().insert_copy_before(xml_attribute(), xml_attribute()) == xml_attribute());
 
@@ -441,6 +442,7 @@ TEST_XML(dom_node_insert_copy_before_attribute, "<node a1='v1'><child a2='v2'/><
 	CHECK(node.insert_copy_before(a1, xml_attribute()) == xml_attribute());
 	CHECK(node.insert_copy_before(xml_attribute(), a1) == xml_attribute());
 	CHECK(node.insert_copy_before(a2, a2) == xml_attribute());
+	CHECK(node.last_child().insert_copy_before(a2, a2) == xml_attribute());
 
 	xml_attribute a3 = node.insert_copy_before(a1, a1);
 	CHECK(a3 && a3 != a2 && a3 != a1);
@@ -453,7 +455,7 @@ TEST_XML(dom_node_insert_copy_before_attribute, "<node a1='v1'><child a2='v2'/><
 
 	CHECK(child.insert_copy_before(a4, a4) == xml_attribute());
 
-	CHECK_NODE(doc, STR("<node a1=\"v1\" a2=\"v2\" a2=\"v2\" a1=\"v1\"><child a2=\"v2\"/></node>"));
+	CHECK_NODE(doc, STR("<node a1=\"v1\" a2=\"v2\" a2=\"v2\" a1=\"v1\"><child a2=\"v2\"/>text</node>"));
 
 	a3.set_name(STR("a3"));
 	a3 = STR("v3");
@@ -464,7 +466,7 @@ TEST_XML(dom_node_insert_copy_before_attribute, "<node a1='v1'><child a2='v2'/><
 	a5.set_name(STR("a5"));
 	a5 = STR("v5");
 
-	CHECK_NODE(doc, STR("<node a3=\"v3\" a4=\"v4\" a5=\"v5\" a1=\"v1\"><child a2=\"v2\"/></node>"));
+	CHECK_NODE(doc, STR("<node a3=\"v3\" a4=\"v4\" a5=\"v5\" a1=\"v1\"><child a2=\"v2\"/>text</node>"));
 }
 
 TEST_XML(dom_node_remove_attribute, "<node a1='v1' a2='v2' a3='v3'><child a4='v4'/></node>")
@@ -550,6 +552,7 @@ TEST_XML(dom_node_insert_child_after, "<node>foo<child/></node>")
 	xml_node node = doc.child(STR("node"));
 	xml_node child = node.child(STR("child"));
 
+	CHECK(node.insert_child_after(node_element, xml_node()) == xml_node());
 	CHECK(node.insert_child_after(node_element, node) == xml_node());
 	CHECK(child.insert_child_after(node_element, node) == xml_node());
 
@@ -584,6 +587,7 @@ TEST_XML(dom_node_insert_child_before, "<node>foo<child/></node>")
 	xml_node node = doc.child(STR("node"));
 	xml_node child = node.child(STR("child"));
 
+	CHECK(node.insert_child_before(node_element, xml_node()) == xml_node());
 	CHECK(node.insert_child_before(node_element, node) == xml_node());
 	CHECK(child.insert_child_before(node_element, node) == xml_node());
 
@@ -770,13 +774,16 @@ TEST_XML(dom_node_append_copy, "<node>foo<child/></node>")
 
 TEST_XML(dom_node_insert_copy_after, "<node>foo<child/></node>")
 {
+	xml_node child = doc.child(STR("node")).child(STR("child"));
+
 	CHECK(xml_node().insert_copy_after(xml_node(), xml_node()) == xml_node());
 	CHECK(doc.child(STR("node")).first_child().insert_copy_after(doc.child(STR("node")), doc.child(STR("node"))) == xml_node());
 	CHECK(doc.insert_copy_after(doc, doc) == xml_node());
 	CHECK(doc.insert_copy_after(xml_node(), doc.child(STR("node"))) == xml_node());
 	CHECK(doc.insert_copy_after(doc.child(STR("node")), xml_node()) == xml_node());
+	CHECK(doc.insert_copy_after(doc.child(STR("node")), child) == xml_node());
 
-	xml_node n1 = doc.child(STR("node")).insert_copy_after(doc.child(STR("node")).child(STR("child")), doc.child(STR("node")).first_child());
+	xml_node n1 = doc.child(STR("node")).insert_copy_after(child, doc.child(STR("node")).first_child());
 	CHECK(n1);
 	CHECK_STRING(n1.name(), STR("child"));
 	CHECK_NODE(doc, STR("<node>foo<child/><child/></node>"));
@@ -794,13 +801,16 @@ TEST_XML(dom_node_insert_copy_after, "<node>foo<child/></node>")
 
 TEST_XML(dom_node_insert_copy_before, "<node>foo<child/></node>")
 {
+	xml_node child = doc.child(STR("node")).child(STR("child"));
+
 	CHECK(xml_node().insert_copy_before(xml_node(), xml_node()) == xml_node());
 	CHECK(doc.child(STR("node")).first_child().insert_copy_before(doc.child(STR("node")), doc.child(STR("node"))) == xml_node());
 	CHECK(doc.insert_copy_before(doc, doc) == xml_node());
 	CHECK(doc.insert_copy_before(xml_node(), doc.child(STR("node"))) == xml_node());
 	CHECK(doc.insert_copy_before(doc.child(STR("node")), xml_node()) == xml_node());
+	CHECK(doc.insert_copy_before(doc.child(STR("node")), child) == xml_node());
 
-	xml_node n1 = doc.child(STR("node")).insert_copy_before(doc.child(STR("node")).child(STR("child")), doc.child(STR("node")).first_child());
+	xml_node n1 = doc.child(STR("node")).insert_copy_before(child, doc.child(STR("node")).first_child());
 	CHECK(n1);
 	CHECK_STRING(n1.name(), STR("child"));
 	CHECK_NODE(doc, STR("<node><child/>foo<child/></node>"));
@@ -1314,6 +1324,7 @@ TEST_XML(dom_node_insert_move_after, "<node>foo<child>bar</child></node>")
 	CHECK(doc.insert_move_after(doc, doc) == xml_node());
 	CHECK(doc.insert_move_after(xml_node(), doc.child(STR("node"))) == xml_node());
 	CHECK(doc.insert_move_after(doc.child(STR("node")), xml_node()) == xml_node());
+	CHECK(doc.insert_move_after(doc.child(STR("node")), child) == xml_node());
 
 	xml_node n1 = doc.child(STR("node")).insert_move_after(child, doc.child(STR("node")).first_child());
 	CHECK(n1 && n1 == child);
@@ -1340,6 +1351,7 @@ TEST_XML(dom_node_insert_move_before, "<node>foo<child>bar</child></node>")
 	CHECK(doc.insert_move_before(doc, doc) == xml_node());
 	CHECK(doc.insert_move_before(xml_node(), doc.child(STR("node"))) == xml_node());
 	CHECK(doc.insert_move_before(doc.child(STR("node")), xml_node()) == xml_node());
+	CHECK(doc.insert_move_before(doc.child(STR("node")), child) == xml_node());
 
 	xml_node n1 = doc.child(STR("node")).insert_move_before(child, doc.child(STR("node")).first_child());
 	CHECK(n1 && n1 == child);

--- a/tests/test_dom_traverse.cpp
+++ b/tests/test_dom_traverse.cpp
@@ -736,6 +736,9 @@ TEST_XML(dom_node_path, "<node><child1>text<child2/></child1></node>")
 	CHECK(doc.child(STR("node")).child(STR("child1")).first_child().path() == STR("/node/child1/"));
 
 	CHECK(doc.child(STR("node")).child(STR("child1")).path('\\') == STR("\\node\\child1"));
+
+	doc.append_child(node_element);
+	CHECK(doc.last_child().path() == STR("/"));
 }
 #endif
 
@@ -1273,4 +1276,18 @@ TEST_XML(dom_as_int_plus, "<node attr1='+1' attr2='+0xa' />")
 	CHECK(node.attribute(STR("attr2")).as_llong() == 10);
 	CHECK(node.attribute(STR("attr2")).as_ullong() == 10);
 #endif
+}
+
+TEST(dom_node_anonymous)
+{
+	xml_document doc;
+	doc.append_child(node_element);
+	doc.append_child(node_element);
+	doc.append_child(node_pcdata);
+
+	CHECK(doc.child(STR("node")) == xml_node());
+	CHECK(doc.first_child().next_sibling(STR("node")) == xml_node());
+	CHECK(doc.last_child().previous_sibling(STR("node")) == xml_node());
+	CHECK_STRING(doc.child_value(), STR(""));
+	CHECK_STRING(doc.last_child().child_value(), STR(""));
 }

--- a/tests/test_dom_traverse.cpp
+++ b/tests/test_dom_traverse.cpp
@@ -137,6 +137,10 @@ TEST_XML(dom_attr_as_integer_space, "<node attr1=' \t1234' attr2='\t 0x123' attr
 	CHECK(node.attribute(STR("attr2")).as_int() == 291);
 	CHECK(node.attribute(STR("attr3")).as_int() == 0);
 	CHECK(node.attribute(STR("attr4")).as_int() == 0);
+
+#ifdef PUGIXML_HAS_LONG_LONG
+	CHECK(node.attribute(STR("attr1")).as_llong() == 1234);
+#endif
 }
 
 TEST_XML(dom_attr_as_float, "<node attr1='0' attr2='1' attr3='0.12' attr4='-5.1' attr5='3e-4' attr6='3.14159265358979323846'/>")

--- a/tests/test_parse.cpp
+++ b/tests/test_parse.cpp
@@ -928,12 +928,23 @@ TEST(parse_out_of_memory_halfway_attr)
 
 TEST(parse_out_of_memory_conversion)
 {
-	test_runner::_memory_fail_threshold = 256;
+	test_runner::_memory_fail_threshold = 1;
 
 	xml_document doc;
 	CHECK_ALLOC_FAIL(CHECK(doc.load_buffer("<foo\x90/>", 7, parse_default, encoding_latin1).status == status_out_of_memory));
 	CHECK(!doc.first_child());
 }
+
+#ifdef PUGIXML_WCHAR_MODE
+TEST(parse_out_of_memory_conversion_wchar)
+{
+	test_runner::_memory_fail_threshold = 1;
+
+	xml_document doc;
+	CHECK_ALLOC_FAIL(CHECK(doc.load_buffer("<foo />", 7).status == status_out_of_memory));
+	CHECK(!doc.first_child());
+}
+#endif
 
 TEST(parse_out_of_memory_allocator_state_sync)
 {

--- a/tests/test_parse.cpp
+++ b/tests/test_parse.cpp
@@ -746,6 +746,36 @@ TEST(parse_attribute_quot_inside)
 			}
 }
 
+TEST(parse_attribute_wnorm_coverage)
+{
+	xml_document doc;
+	CHECK(doc.load_string(STR("<n a1='v' a2=' ' a3='x y' a4='x  y' a5='x   y' />"), parse_wnorm_attribute));
+	CHECK_NODE(doc, STR("<n a1=\"v\" a2=\"\" a3=\"x y\" a4=\"x y\" a5=\"x y\"/>"));
+
+	CHECK(doc.load_string(STR("<n a1='v' a2=' ' a3='x y' a4='x  y' a5='x   y' />"), parse_wnorm_attribute | parse_escapes));
+	CHECK_NODE(doc, STR("<n a1=\"v\" a2=\"\" a3=\"x y\" a4=\"x y\" a5=\"x y\"/>"));
+}
+
+TEST(parse_attribute_wconv_coverage)
+{
+	xml_document doc;
+	CHECK(doc.load_string(STR("<n a1='v' a2='\r' a3='\r\n\n' a4='\n' />"), parse_wconv_attribute));
+	CHECK_NODE(doc, STR("<n a1=\"v\" a2=\" \" a3=\"  \" a4=\" \"/>"));
+
+	CHECK(doc.load_string(STR("<n a1='v' a2='\r' a3='\r\n\n' a4='\n' />"), parse_wconv_attribute | parse_escapes));
+	CHECK_NODE(doc, STR("<n a1=\"v\" a2=\" \" a3=\"  \" a4=\" \"/>"));
+}
+
+TEST(parse_attribute_eol_coverage)
+{
+	xml_document doc;
+	CHECK(doc.load_string(STR("<n a1='v' a2='\r' a3='\r\n\n' a4='\n' />"), parse_eol));
+	CHECK_NODE(doc, STR("<n a1=\"v\" a2=\"&#10;\" a3=\"&#10;&#10;\" a4=\"&#10;\"/>"));
+
+	CHECK(doc.load_string(STR("<n a1='v' a2='\r' a3='\r\n\n' a4='\n' />"), parse_eol | parse_escapes));
+	CHECK_NODE(doc, STR("<n a1=\"v\" a2=\"&#10;\" a3=\"&#10;&#10;\" a4=\"&#10;\"/>"));
+}
+
 TEST(parse_tag_single)
 {
 	xml_document doc;

--- a/tests/test_parse.cpp
+++ b/tests/test_parse.cpp
@@ -88,6 +88,16 @@ TEST(parse_pi_error)
 	CHECK(doc.load_string(STR("<?name& x?>"), parse_fragment | parse_pi).status == status_bad_pi);
 }
 
+TEST(parse_pi_error_buffer_boundary)
+{
+	char buf1[] = "<?name?>";
+	char buf2[] = "<?name?x";
+
+	xml_document doc;
+	CHECK(doc.load_buffer_inplace(buf1, 8, parse_fragment | parse_pi));
+	CHECK(doc.load_buffer_inplace(buf2, 8, parse_fragment | parse_pi).status == status_bad_pi);
+}
+
 TEST(parse_comments_skip)
 {
 	xml_document doc;
@@ -1211,6 +1221,13 @@ TEST(parse_embed_pcdata)
 		CHECK_NODE_EX(doc, STR("<node>\n<key>value</key>\n<child>\n<inner1>value1</inner1>\n<inner2>value2</inner2>outer</child>\n<two>text<data />\n</two>\n</node>\n"), STR("\t"), 0);
 		CHECK_NODE_EX(doc, STR("<node>\n\t<key>value</key>\n\t<child>\n\t\t<inner1>value1</inner1>\n\t\t<inner2>value2</inner2>outer</child>\n\t<two>text<data />\n\t</two>\n</node>\n"), STR("\t"), format_indent);
 	}
+}
+
+TEST_XML_FLAGS(parse_embed_pcdata_fragment, "text", parse_fragment | parse_embed_pcdata)
+{
+	CHECK_NODE(doc, STR("text"));
+	CHECK(doc.first_child().type() == node_pcdata);
+	CHECK_STRING(doc.first_child().value(), STR("text"));
 }
 
 TEST(parse_encoding_detect)

--- a/tests/test_parse.cpp
+++ b/tests/test_parse.cpp
@@ -1230,6 +1230,26 @@ TEST_XML_FLAGS(parse_embed_pcdata_fragment, "text", parse_fragment | parse_embed
 	CHECK_STRING(doc.first_child().value(), STR("text"));
 }
 
+TEST_XML_FLAGS(parse_embed_pcdata_child, "<n><child/>text</n>", parse_embed_pcdata)
+{
+	xml_node n = doc.child(STR("n"));
+
+	CHECK_NODE(doc, STR("<n><child/>text</n>"));
+	CHECK(n.last_child().type() == node_pcdata);
+	CHECK_STRING(n.last_child().value(), STR("text"));
+}
+
+TEST_XML_FLAGS(parse_embed_pcdata_comment, "<n>text1<!---->text2</n>", parse_embed_pcdata)
+{
+	xml_node n = doc.child(STR("n"));
+
+	CHECK_NODE(doc, STR("<n>text1text2</n>"));
+	CHECK_STRING(n.value(), STR("text1"));
+	CHECK(n.first_child() == n.last_child());
+	CHECK(n.last_child().type() == node_pcdata);
+	CHECK_STRING(n.last_child().value(), STR("text2"));
+}
+
 TEST(parse_encoding_detect)
 {
 	char test[] = "<?xml version='1.0' encoding='utf-8'?><n/>";

--- a/tests/test_parse.cpp
+++ b/tests/test_parse.cpp
@@ -965,17 +965,6 @@ TEST(parse_out_of_memory_conversion)
 	CHECK(!doc.first_child());
 }
 
-#ifdef PUGIXML_WCHAR_MODE
-TEST(parse_out_of_memory_conversion_wchar)
-{
-	test_runner::_memory_fail_threshold = 1;
-
-	xml_document doc;
-	CHECK_ALLOC_FAIL(CHECK(doc.load_buffer("<foo />", 7).status == status_out_of_memory));
-	CHECK(!doc.first_child());
-}
-#endif
-
 TEST(parse_out_of_memory_allocator_state_sync)
 {
 	const unsigned int count = 10000;

--- a/tests/test_write.cpp
+++ b/tests/test_write.cpp
@@ -69,6 +69,12 @@ TEST_XML_FLAGS(write_cdata_escape, "<![CDATA[value]]>", parse_cdata | parse_frag
 
 	doc.first_child().set_value(STR("1]]>2]]>3"));
 	CHECK_NODE(doc, STR("<![CDATA[1]]]]><![CDATA[>2]]]]><![CDATA[>3]]>"));
+
+	doc.first_child().set_value(STR("1]"));
+	CHECK_NODE(doc, STR("<![CDATA[1]]]>"));
+
+	doc.first_child().set_value(STR("1]]"));
+	CHECK_NODE(doc, STR("<![CDATA[1]]]]>"));
 }
 
 TEST_XML(write_cdata_inner, "<node><![CDATA[value]]></node>")

--- a/tests/test_xpath.cpp
+++ b/tests/test_xpath.cpp
@@ -475,6 +475,38 @@ TEST_XML(xpath_out_of_memory_evaluate_translate_table, "<node> a b c d e f g h i
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(doc).empty()));
 }
 
+TEST(xpath_out_of_memory_evaluate_string_append)
+{
+	test_runner::_memory_fail_threshold = 32768 + 4096 * 2;
+
+	std::basic_string<char_t> literal(5000, 'a');
+
+	std::basic_string<char_t> buf;
+	buf += STR("<n><c>text</c><c>");
+	buf += literal;
+	buf += STR("</c></n>");
+
+	xml_document doc;
+	CHECK(doc.load_buffer_inplace(&buf[0], buf.size() * sizeof(char_t)));
+
+	pugi::xpath_query q(STR("string(n)"));
+	CHECK(q);
+
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(doc).empty()));
+}
+
+TEST(xpath_out_of_memory_evaluate_number_to_string)
+{
+	test_runner::_memory_fail_threshold = 4096 + 128;
+
+	xpath_variable_set vars;
+	vars.set(STR("x"), 1e+308);
+
+	xpath_query q(STR("concat($x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x)"), &vars);
+
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(xml_node()).empty()));
+}
+
 TEST(xpath_memory_concat_massive)
 {
 	pugi::xml_document doc;

--- a/tests/test_xpath.cpp
+++ b/tests/test_xpath.cpp
@@ -439,6 +439,42 @@ TEST_XML(xpath_out_of_memory_evaluate_predicate, "<node><a/><a/><a/><a/><a/><a/>
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_node_set(doc).empty()));
 }
 
+TEST_XML(xpath_out_of_memory_evaluate_normalize_space_0, "<node> a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z </node>")
+{
+	test_runner::_memory_fail_threshold = 32768 + 4096 * 2;
+
+	pugi::xpath_query q(STR("concat(normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space())"));
+
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(doc.first_child()).empty()));
+}
+
+TEST_XML(xpath_out_of_memory_evaluate_normalize_space_1, "<node> a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z </node>")
+{
+	test_runner::_memory_fail_threshold = 32768 + 4096 * 2;
+
+	pugi::xpath_query q(STR("concat(normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node))"));
+
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(doc).empty()));
+}
+
+TEST_XML(xpath_out_of_memory_evaluate_translate, "<node> a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z </node>")
+{
+	test_runner::_memory_fail_threshold = 32768 + 4096 * 2;
+
+	pugi::xpath_query q(STR("concat(translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'))"));
+
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(doc).empty()));
+}
+
+TEST_XML(xpath_out_of_memory_evaluate_translate_table, "<node> a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z </node>")
+{
+	test_runner::_memory_fail_threshold = 32768 + 4096 * 2;
+
+	pugi::xpath_query q(STR("concat(translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'))"));
+
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(doc).empty()));
+}
+
 TEST(xpath_memory_concat_massive)
 {
 	pugi::xml_document doc;

--- a/tests/test_xpath.cpp
+++ b/tests/test_xpath.cpp
@@ -672,6 +672,17 @@ TEST(xpath_sort_crossdoc_different_depth)
 	CHECK((ns[0] == ns1[0] && ns[1] == ns2[0]) || (ns[0] == ns2[0] && ns[1] == ns1[0]));
 }
 
+TEST_XML(xpath_sort_empty_node, "<node><child1/><child2/></node>")
+{
+	xml_node n = doc.child(STR("node"));
+	xpath_node nodes[] = { n.child(STR("child2")), xml_node(), n.child(STR("child1")), xml_node() };
+	xpath_node_set ns(nodes, nodes + sizeof(nodes) / sizeof(nodes[0]));
+
+	ns.sort();
+
+	CHECK(!ns[0] && !ns[1] && ns[2] == nodes[2] && ns[3] == nodes[0]);
+}
+
 TEST(xpath_allocate_string_out_of_memory)
 {
 	std::basic_string<char_t> query;

--- a/tests/test_xpath.cpp
+++ b/tests/test_xpath.cpp
@@ -430,11 +430,11 @@ TEST_XML(xpath_out_of_memory_evaluate_union, "<node><a/><a/><a/><a/><a/><a/><a/>
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_node_set(doc.child(STR("node"))).empty()));
 }
 
-TEST_XML(xpath_out_of_memory_evaluate_predicate, "<node><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/></node>")
+TEST_XML(xpath_out_of_memory_evaluate_predicate, "<node><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/></node>")
 {
 	test_runner::_memory_fail_threshold = 32768 + 4096 * 2;
 
-	pugi::xpath_query q(STR("//a[//a[//a[//a[//a[//a[//a[//a[//a[//a[//a[//a[//a[//a[true()]]]]]]]]]]]]]]"));
+	pugi::xpath_query q(STR("//a[//a[//a[//a[true()]]]]"));
 
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_node_set(doc).empty()));
 }

--- a/tests/test_xpath_api.cpp
+++ b/tests/test_xpath_api.cpp
@@ -573,6 +573,18 @@ TEST(xpath_api_nodeset_move_assign_empty)
 	CHECK(move.type() == xpath_node_set::type_sorted);
 }
 
+TEST_XML(xpath_api_nodeset_move_assign_self, "<node><foo/><foo/><bar/></node>")
+{
+	xpath_node_set set = doc.select_nodes(STR("node/bar"));
+
+	CHECK(set.size() == 1);
+	CHECK(set.type() == xpath_node_set::type_sorted);
+
+	test_runner::_memory_fail_threshold = 1;
+
+	set = std::move(*&set);
+}
+
 TEST(xpath_api_query_move)
 {
 	xml_node c;

--- a/tests/test_xpath_api.cpp
+++ b/tests/test_xpath_api.cpp
@@ -107,6 +107,7 @@ TEST_XML(xpath_api_nodeset_accessors, "<node><foo/><foo/></node>")
 
 TEST_XML(xpath_api_nodeset_copy, "<node><foo/><foo/></node>")
 {
+	xpath_node_set empty;
 	xpath_node_set set = doc.select_nodes(STR("node/foo"));
 
 	xpath_node_set copy1 = set;
@@ -132,7 +133,7 @@ TEST_XML(xpath_api_nodeset_copy, "<node><foo/><foo/></node>")
 
 	xpath_node_set copy5;
 	copy5 = set;
-	copy5 = xpath_node_set();
+	copy5 = empty;
 	CHECK(copy5.size() == 0);
 }
 
@@ -416,13 +417,6 @@ TEST(xpath_api_empty)
 	xpath_query q;
 	CHECK(!q);
 	CHECK(!q.evaluate_boolean(c));
-}
-
-TEST(xpath_api_query_out_of_memory)
-{
-	test_runner::_memory_fail_threshold = 1;
-
-	CHECK_ALLOC_FAIL(xpath_query q(STR("node")));
 }
 
 #ifdef PUGIXML_HAS_MOVE

--- a/tests/test_xpath_api.cpp
+++ b/tests/test_xpath_api.cpp
@@ -418,6 +418,13 @@ TEST(xpath_api_empty)
 	CHECK(!q.evaluate_boolean(c));
 }
 
+TEST(xpath_api_query_out_of_memory)
+{
+	test_runner::_memory_fail_threshold = 1;
+
+	CHECK_ALLOC_FAIL(xpath_query q(STR("node")));
+}
+
 #ifdef PUGIXML_HAS_MOVE
 TEST_XML(xpath_api_nodeset_move_ctor, "<node><foo/><foo/><bar/></node>")
 {

--- a/tests/test_xpath_functions.cpp
+++ b/tests/test_xpath_functions.cpp
@@ -566,6 +566,7 @@ TEST(xpath_string_translate_table)
 
 	CHECK_XPATH_STRING(c, STR("translate('abcd\xe9 ', 'abc', 'ABC')"), STR("ABCd\xe9 "));
 	CHECK_XPATH_STRING(c, STR("translate('abcd\xe9 ', 'abc\xe9', 'ABC!')"), STR("ABCd! "));
+	CHECK_XPATH_STRING(c, STR("translate('abcd! ', 'abc!', 'ABC\xe9')"), STR("ABCd\xe9 "));
 	CHECK_XPATH_STRING(c, STR("translate('abcde', concat('abc', 'd'), 'ABCD')"), STR("ABCDe"));
 	CHECK_XPATH_STRING(c, STR("translate('abcde', 'abcd', concat('ABC', 'D'))"), STR("ABCDe"));
 }
@@ -799,4 +800,17 @@ TEST_XML(xpath_string_concat_translate, "<node>foobar</node>")
 	CHECK_XPATH_STRING(doc, STR("concat('a', 'b', 'c', translate(node, 'o', 'a'), 'd')"), STR("abcfaabard"));
 }
 
+TEST(xpath_unknown_functions)
+{
+	char_t query[] = STR("a()");
+
+	for (char ch = 'a'; ch <= 'z'; ++ch)
+	{
+		query[0] = ch;
+		CHECK_XPATH_FAIL(query);
+
+		query[0] = ch - 32;
+		CHECK_XPATH_FAIL(query);
+	}
+}
 #endif

--- a/tests/test_xpath_operators.cpp
+++ b/tests/test_xpath_operators.cpp
@@ -332,11 +332,21 @@ TEST_XML(xpath_operators_inequality_node_set_node_set, "<node><c1><v>1</v><v>-1<
 	CHECK_XPATH_BOOLEAN(n, STR("c1/v < c3/v"), true);
 	CHECK_XPATH_BOOLEAN(n, STR("c1/v <= c3/v"), true);
 
+	CHECK_XPATH_BOOLEAN(n, STR("c1/v[1] > c1/v[1]"), false);
+	CHECK_XPATH_BOOLEAN(n, STR("c1/v[1] < c1/v[1]"), false);
+	CHECK_XPATH_BOOLEAN(n, STR("c1/v[1] >= c1/v[1]"), true);
+	CHECK_XPATH_BOOLEAN(n, STR("c1/v[1] <= c1/v[1]"), true);
+
 #ifndef MSVC6_NAN_BUG
 	CHECK_XPATH_BOOLEAN(n, STR("c1/v > c2/v"), false);
 	CHECK_XPATH_BOOLEAN(n, STR("c1/v >= c2/v"), true);
 	CHECK_XPATH_BOOLEAN(n, STR("c1/v < c2/v"), true);
 	CHECK_XPATH_BOOLEAN(n, STR("c1/v <= c2/v"), true);
+
+	CHECK_XPATH_BOOLEAN(n, STR("c2/v[2] < c2/v[2]"), false);
+	CHECK_XPATH_BOOLEAN(n, STR("c2/v[2] > c2/v[2]"), false);
+	CHECK_XPATH_BOOLEAN(n, STR("c2/v[2] <= c2/v[2]"), false);
+	CHECK_XPATH_BOOLEAN(n, STR("c2/v[2] >= c2/v[2]"), false);
 #endif
 }
 

--- a/tests/test_xpath_parse.cpp
+++ b/tests/test_xpath_parse.cpp
@@ -293,6 +293,27 @@ TEST(xpath_parse_out_of_memory_string_to_number)
 	CHECK_ALLOC_FAIL(CHECK_XPATH_FAIL(STR("0.11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")));
 }
 
+TEST(xpath_parse_out_of_memory_quoted_string)
+{
+	test_runner::_memory_fail_threshold = 4096 + 128;
+
+	std::basic_string<char_t> literal(5000, 'a');
+	std::basic_string<char_t> query = STR("'") + literal + STR("'");
+
+	CHECK_ALLOC_FAIL(CHECK_XPATH_FAIL(query.c_str()));
+}
+
+TEST(xpath_parse_out_of_memory_variable)
+{
+	test_runner::_memory_fail_threshold = 4096 + 128;
+
+	std::basic_string<char_t> literal(5000, 'a');
+	std::basic_string<char_t> query = STR("$") + literal;
+
+	xpath_variable_set vars;
+	CHECK_ALLOC_FAIL(CHECK_XPATH_FAIL_VAR(query.c_str(), &vars));
+}
+
 TEST(xpath_parse_qname_error)
 {
 	CHECK_XPATH_FAIL(STR("foo: bar"));
@@ -315,7 +336,7 @@ TEST(xpath_parse_result_default)
 
 TEST(xpath_parse_error_propagation)
 {
-	char_t query[] = STR("(//foo[count(. | @*)] | /foo | /foo/bar//more/ancestor-or-self::foobar | /text() | a[1 + 2 * 3 div (1+0) mod 2]//b[1]/c | a[$x])[true()]");
+	char_t query[] = STR("(//foo[count(. | @*)] | ((a)//b)[1] | /foo | /foo/bar//more/ancestor-or-self::foobar | /text() | a[1 + 2 * 3 div (1+0) mod 2]//b[1]/c | a[$x])[true()]");
 
 	xpath_variable_set vars;
 	vars.set(STR("x"), 1.0);
@@ -337,7 +358,7 @@ TEST(xpath_parse_error_propagation)
 
 TEST(xpath_parse_oom_propagation)
 {
-	const char_t* query_base = STR("(//foo[count(. | @*)] | /foo | /foo/bar//more/ancestor-or-self::foobar | /text() | a[1 + 2 * 3 div (1+0) mod 2]//b[1]/c | a[$x])[true()]");
+	const char_t* query_base = STR("(//foo[count(. | @*)] | ((a)//b)[1] | /foo | /foo/bar//more/ancestor-or-self::foobar | /text() | a[1 + 2 * 3 div (1+0) mod 2]//b[1]/c | a[$x])[true()]");
 
 	xpath_variable_set vars;
 	vars.set(STR("x"), 1.0);

--- a/tests/test_xpath_parse.cpp
+++ b/tests/test_xpath_parse.cpp
@@ -335,4 +335,12 @@ TEST(xpath_parse_error_propagation)
 	}
 }
 
+TEST_XML(xpath_parse_location_path, "<node><child/></node>")
+{
+	CHECK_XPATH_NODESET(doc, STR("/node")) % 2;
+	CHECK_XPATH_NODESET(doc, STR("/@*"));
+	CHECK_XPATH_NODESET(doc, STR("/.")) % 1;
+	CHECK_XPATH_NODESET(doc, STR("/.."));
+	CHECK_XPATH_NODESET(doc, STR("/*")) % 2;
+}
 #endif

--- a/tests/test_xpath_parse.cpp
+++ b/tests/test_xpath_parse.cpp
@@ -313,4 +313,26 @@ TEST(xpath_parse_result_default)
 	CHECK(result.offset == 0);
 }
 
+TEST(xpath_parse_error_propagation)
+{
+	char_t query[] = STR("(//foo[count(. | @*)] | /foo | /foo/bar//more/ancestor-or-self::foobar | /text() | a[1 + 2 * 3 div (1+0) mod 2]//b[1]/c | a[$x])[true()]");
+
+	xpath_variable_set vars;
+	vars.set(STR("x"), 1.0);
+
+	xpath_query q(query, &vars);
+	CHECK(q);
+
+	for (size_t i = 0; i + 1 < sizeof(query) / sizeof(query[0]); ++i)
+	{
+		char_t ch = query[i];
+
+		query[i] = '%';
+
+		CHECK_XPATH_FAIL(query);
+
+		query[i] = ch;
+	}
+}
+
 #endif

--- a/tests/test_xpath_paths.cpp
+++ b/tests/test_xpath_paths.cpp
@@ -358,6 +358,13 @@ TEST_XML_FLAGS(xpath_paths_nodetest_principal, "<node attr='value'>pcdata<child/
 	CHECK_XPATH_NODESET(doc, STR("child::abra:*/attribute::abra:*/descendant-or-self::abra:*")); // attribute is not of element type
 }
 
+TEST_XML(xpath_paths_nodetest_attribute_namespace, "<node a1='v1' xmlns:x='?' />")
+{
+	CHECK_XPATH_NODESET(doc, STR("node/attribute::node()")) % 3;
+	CHECK_XPATH_NODESET(doc, STR("node/attribute::xmlns:x"));
+	CHECK_XPATH_NODESET(doc, STR("node/attribute::xmlns:*"));
+}
+
 TEST_XML(xpath_paths_absolute, "<node attr='value'><foo><foo/><foo/></foo></node>")
 {
 	xml_node c;


### PR DESCRIPTION
Instead of relying on either exceptions or setjmp during XPath parsing and evaluation, we now do manual error handling & propagate the error to the root of the parse/evaluate call stack, at which point it's converted to a result code or an exception based on PUGIXML_NO_EXCEPTIONS define.

This means we now no longer rely on setjmp in exception-free builds which improves compatibility, and also unifies the error handling between exception/no-exception cases. Additionally, we can switch to no-exception mode in the future (which is likely going to be the case for 2.0 - this breaks compatibility) without causing issues with setjmp which is not always safe to use in the presence of exceptions being thrown (e.g. an allocation function throwing an exception).

Finally, this change re-enables branch probability for gcov and adds a lot of tests to fill coverage gaps. No-exception configuration is now part of the CI build as well.