### PR TITLE
Silence g++ 7.0.1 -Wimplicit-fallthrough warnings

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -10110,10 +10110,9 @@ PUGI__NS_BEGIN
 
 				if (_rettype == xpath_type_boolean)
 					return _data.variable->get_boolean();
-
-				// fallthrough to type conversion
 			}
 
+			// fallthrough
 			default:
 			{
 				switch (_rettype)
@@ -10246,10 +10245,9 @@ PUGI__NS_BEGIN
 
 				if (_rettype == xpath_type_number)
 					return _data.variable->get_number();
-
-				// fallthrough to type conversion
 			}
 
+			// fallthrough
 			default:
 			{
 				switch (_rettype)
@@ -10538,10 +10536,9 @@ PUGI__NS_BEGIN
 
 				if (_rettype == xpath_type_string)
 					return xpath_string::from_const(_data.variable->get_string());
-
-				// fallthrough to type conversion
 			}
 
+			// fallthrough
 			default:
 			{
 				switch (_rettype)
@@ -10688,10 +10685,9 @@ PUGI__NS_BEGIN
 
 					return ns;
 				}
-
-				// fallthrough to type conversion
 			}
 
+			// fallthrough
 			default:
 				assert(false && "Wrong expression for return type node set");
 				return xpath_node_set_raw();


### PR DESCRIPTION
This is accomplished by explicitly marking the fallthrough
using the C++17's `[[fallthrough]]` attribute.
Although `[[fallthrough]]` is C++17, it is supported by
clang++ and g++ >= 7 even if you use, e.g., -std=c++11.
This is a good thing because it allows us to easily silence
these warnings regardless of the used -std flag. (Otherwise
we would have to use `__attribute__((fallthrough))` for g++;
luckily there is no need to do so.)