### PR TITLE
Add generic member functions to get/set attribute value or text.

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5169,9 +5169,9 @@ namespace pugi
 #endif
 
 #ifndef PUGIXML_NO_STL
-	PUGI__FN std::istringstream xml_attribute::as_stringstream() const
+	PUGI__FN istringstream_t xml_attribute::as_stringstream() const
 	{
-		return (_attr && _attr->value) ? std::istringstream(std::string(static_cast<char_t*>(_attr->value))) : std::istringstream();
+		return (_attr && _attr->value) ? istringstream_t(string_t(static_cast<char_t*>(_attr->value))) : istringstream_t();
 	}
 #endif
 
@@ -6426,11 +6426,11 @@ namespace pugi
 #endif
 
 #ifndef PUGIXML_NO_STL
-	PUGI__FN std::istringstream xml_text::as_stringstream() const
+	PUGI__FN istringstream_t xml_text::as_stringstream() const
 	{
 		xml_node_struct* d = _data();
 
-		return (d && d->value) ? std::istringstream(std::string(static_cast<char_t*>(d->value))) : std::istringstream();
+		return (d && d->value) ? istringstream_t(string_t(static_cast<char_t*>(d->value))) : istringstream_t();
 	}
 #endif
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5168,10 +5168,12 @@ namespace pugi
 	}
 #endif
 
+#ifndef PUGIXML_NO_STL
 	PUGI__FN std::istringstream xml_attribute::as_stringstream() const
 	{
-		return (_attr && _attr->value) ? std::istringstream(_attr->value) : std::istringstream();
+		return (_attr && _attr->value) ? std::istringstream(std::string(static_cast<char_t*>(_attr->value))) : std::istringstream();
 	}
+#endif
 
 	PUGI__FN bool xml_attribute::empty() const
 	{
@@ -6423,12 +6425,14 @@ namespace pugi
 	}
 #endif
 
+#ifndef PUGIXML_NO_STL
 	PUGI__FN std::istringstream xml_text::as_stringstream() const
 	{
 		xml_node_struct* d = _data();
 
-		return (d && d->value) ? std::istringstream(d->value) : std::istringstream();
+		return (d && d->value) ? std::istringstream(std::string(static_cast<char_t*>(d->value))) : std::istringstream();
 	}
+#endif
 
 	PUGI__FN bool xml_text::set(const char_t* rhs)
 	{

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5168,6 +5168,11 @@ namespace pugi
 	}
 #endif
 
+	PUGI__FN std::istringstream xml_attribute::as_stringstream() const
+	{
+		return (_attr && _attr->value) ? std::istringstream(_attr->value) : std::istringstream();
+	}
+
 	PUGI__FN bool xml_attribute::empty() const
 	{
 		return !_attr;
@@ -6417,6 +6422,13 @@ namespace pugi
 		return (d && d->value) ? impl::get_value_ullong(d->value) : def;
 	}
 #endif
+
+	PUGI__FN std::istringstream xml_text::as_stringstream() const
+	{
+		xml_node_struct* d = _data();
+
+		return (d && d->value) ? std::istringstream(d->value) : std::istringstream();
+	}
 
 	PUGI__FN bool xml_text::set(const char_t* rhs)
 	{

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -108,6 +108,7 @@ namespace pugi
 #ifndef PUGIXML_NO_STL
 	// String type used for operations that work with STL string; depends on PUGIXML_WCHAR_MODE
 	typedef std::basic_string<PUGIXML_CHAR, std::char_traits<PUGIXML_CHAR>, std::allocator<PUGIXML_CHAR> > string_t;
+	typedef std::basic_istringstream<PUGIXML_CHAR, std::char_traits<PUGIXML_CHAR>, std::allocator<PUGIXML_CHAR> > istringstream_t;
 #endif
 }
 
@@ -376,13 +377,13 @@ namespace pugi
 
     #ifndef PUGIXML_NO_STL
 		// Get attribute value as std::istringstream, an empty std::istringstream if the attribute is empty
-		std::istringstream as_stringstream() const;
+		istringstream_t as_stringstream() const;
 
 		// Get attribute value as Type (template parameter: try to read a Type value from the attribute value string)
 		template <typename Type>
 		Type as() const
 		{
-			std::istringstream stream = as_stringstream();
+			istringstream_t stream = as_stringstream();
 			Type value;
 			stream >> value;
 			return value;
@@ -753,13 +754,13 @@ namespace pugi
 
     #ifndef PUGIXML_NO_STL
 		// Get attribute value as std::istringstream, an empty std::istringstream if the attribute is empty
-    	std::istringstream as_stringstream() const;
+		istringstream_t as_stringstream() const;
 
 		// Get attribute value as Type (template parameter: try to read a Type value from the attribute value string)
     	template <typename Type>
     	Type as() const
     	{
-    		std::istringstream stream = as_stringstream();
+    		istringstream_t stream = as_stringstream();
     		Type value;
     		stream >> value;
     		return value;

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -383,7 +383,7 @@ namespace pugi
 		template <typename Type>
 		Type as() const
 		{
-			istringstream_t stream = as_stringstream();
+			istringstream_t stream(as_stringstream());
 			Type value;
 			stream >> value;
 			return value;
@@ -760,7 +760,7 @@ namespace pugi
     	template <typename Type>
     	Type as() const
     	{
-    		istringstream_t stream = as_stringstream();
+    		istringstream_t stream(as_stringstream());
     		Type value;
     		stream >> value;
     		return value;

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -32,6 +32,7 @@
 
 // Include STL headers
 #ifndef PUGIXML_NO_STL
+#	include <sstream>
 #	include <iterator>
 #	include <iosfwd>
 #	include <string>
@@ -373,6 +374,21 @@ namespace pugi
 		// Get attribute value as bool (returns true if first character is in '1tTyY' set), or the default value if attribute is empty
 		bool as_bool(bool def = false) const;
 
+    #ifndef PUGIXML_NO_STL
+		// Get attribute value as std::istringstream, an empty std::istringstream if the attribute is empty
+		std::istringstream as_stringstream() const;
+
+		// Get attribute value as Type (template parameter: try to read a Type value from the attribute value string)
+		template <typename Type>
+		Type as() const
+		{
+			std::istringstream stream = as_stringstream();
+			Type value;
+			stream >> value;
+			return value;
+		}
+    #endif
+
 		// Set attribute name/value (returns false if attribute is empty or there is not enough memory)
 		bool set_name(const char_t* rhs);
 		bool set_value(const char_t* rhs);
@@ -390,6 +406,16 @@ namespace pugi
 		bool set_value(long long rhs);
 		bool set_value(unsigned long long rhs);
 	#endif
+
+    #ifndef PUGIXML_NO_STL
+    	template <typename Type>
+    	bool set_value(const Type& rhs) const
+    	{
+    		std::ostringstream stream;
+    		stream << rhs;
+    		return set_value(stream.str().c_str());
+    	}
+    #endif
 
 		// Set attribute value (equivalent to set_value without error checking)
 		xml_attribute& operator=(const char_t* rhs);
@@ -725,6 +751,21 @@ namespace pugi
 		// Get text as bool (returns true if first character is in '1tTyY' set), or the default value if object is empty
 		bool as_bool(bool def = false) const;
 
+    #ifndef PUGIXML_NO_STL
+		// Get attribute value as std::istringstream, an empty std::istringstream if the attribute is empty
+    	std::istringstream as_stringstream() const;
+
+		// Get attribute value as Type (template parameter: try to read a Type value from the attribute value string)
+    	template <typename Type>
+    	Type as() const
+    	{
+    		std::istringstream stream = as_stringstream();
+    		Type value;
+    		stream >> value;
+    		return value;
+    	}
+    #endif
+
 		// Set text (returns false if object is empty or there is not enough memory)
 		bool set(const char_t* rhs);
 
@@ -741,6 +782,16 @@ namespace pugi
 		bool set(long long rhs);
 		bool set(unsigned long long rhs);
 	#endif
+
+    #ifndef PUGIXML_NO_STL
+    	template <typename Type>
+    	bool set(const Type& rhs)
+    	{
+    		std::ostringstream stream;
+    		stream << rhs;
+    		return set(stream.str().c_str());
+    	}
+    #endif
 
 		// Set text (equivalent to set without error checking)
 		xml_text& operator=(const char_t* rhs);


### PR DESCRIPTION
Add generic member functions to get/set attribute value or text:
- xml_attribute::as_stringstream()
- xml_attribute::as<T>()
- xml_text::as_stringstream()
- xml_text::as<T>()
- xml_text::set() 
