### PR TITLE
Implement move support for xml_document

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,8 @@ ifeq ($(config),coverage)
 endif
 
 ifeq ($(config),sanitize)
-	CXXFLAGS+=-fsanitize=address
-	LDFLAGS+=-fsanitize=address
-
-	ifneq ($(shell uname),Darwin)
-		CXXFLAGS+=-fsanitize=undefined
-		LDFLAGS+=-fsanitize=undefined
-	endif
+	CXXFLAGS+=-fsanitize=address,undefined
+	LDFLAGS+=-fsanitize=address,undefined
 endif
 
 ifeq ($(config),analyze)

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -6963,7 +6963,7 @@ namespace pugi
 		if (other_first_child)
 		{
 			size_t other_children = 0;
-			for (xml_node_struct* child = other_first_child; child; child = child->next_sibling)
+			for (xml_node_struct* node = other_first_child; node; node = node->next_sibling)
 				other_children++;
 
 			// in compact mode, each pointer assignment could result in a hash table request

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -6963,8 +6963,7 @@ namespace pugi
 		xml_node_struct* other_first_child = other->first_child;
 
 	#ifdef PUGIXML_COMPACT
-		// move compact hash
-		// TODO: the hash still has pointers to other, do we need to clear them out?
+		// move compact hash; note that the hash table can have pointers to other but they will be "inactive", similarly to nodes removed with remove_child
 		doc->hash = other->hash;
 		doc->_hash = &doc->hash;
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -7010,17 +7010,17 @@ namespace pugi
 		doc->reserve(); // TODO: it's not clear how to handle reserve running out of memory
 		doc->first_child = other_first_child;
 
-		for (xml_node_struct* child = other_first_child; child; child = child->next_sibling)
+		for (xml_node_struct* node = other_first_child; node; node = node->next_sibling)
 		{
 		#ifdef PUGIXML_COMPACT
 			// most children will have migrated when we reassigned compact_shared_parent
-			assert(child->parent == other || child->parent == doc);
+			assert(node->parent == other || node->parent == doc);
 
 			doc->reserve(); // TODO: it's not clear how to handle reserve running out of memory
-			child->parent = doc;
+			node->parent = doc;
 		#else
-			assert(child->parent == other);
-			child->parent = doc;
+			assert(node->parent == other);
+			node->parent = doc;
 		#endif
 		}
 

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -983,6 +983,7 @@ namespace pugi
 
 		void _create();
 		void _destroy();
+		void _move(xml_document& rhs);
 
 	public:
 		// Default constructor, makes empty document
@@ -990,6 +991,12 @@ namespace pugi
 
 		// Destructor, invalidates all node/attribute handles to this document
 		~xml_document();
+
+	#ifdef PUGIXML_HAS_MOVE
+		// Move semantics support
+		xml_document(xml_document&& rhs);
+		xml_document& operator=(xml_document&& rhs);
+	#endif
 
 		// Removes all nodes, leaving the empty document
 		void reset();

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -1621,3 +1621,34 @@ TEST(document_convert_out_of_memory)
 		delete[] files[j].data;
 	}
 }
+
+#ifdef PUGIXML_HAS_MOVE
+TEST_XML(document_move_ctor, "<node1/><node2/>")
+{
+	xml_document other = std::move(doc);
+
+	CHECK(doc.first_child().empty());
+
+	CHECK_STRING(other.first_child().name(), STR("node1"));
+	CHECK(other.first_child().parent() == other);
+
+	CHECK_STRING(other.last_child().name(), STR("node2"));
+	CHECK(other.last_child().parent() == other);
+}
+
+TEST_XML(document_move_assign, "<node1/><node2/>")
+{
+	xml_document other;
+	CHECK(other.load_string(STR("<node3/>")));
+
+	other = std::move(doc);
+
+	CHECK(doc.first_child().empty());
+
+	CHECK_STRING(other.first_child().name(), STR("node1"));
+	CHECK(other.first_child().parent() == other);
+
+	CHECK_STRING(other.last_child().name(), STR("node2"));
+	CHECK(other.last_child().parent() == other);
+}
+#endif

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -1691,15 +1691,38 @@ TEST(document_move_append_child)
 	xml_document other = std::move(*doc);
 	delete doc;
 
-	for (int i = 0; i < 1000; ++i)
+	for (int i = 0; i < 3000; ++i)
 		other.child(STR("node1")).append_child(STR("node"));
 
-	for (int i = 0; i < 1000; ++i)
+	for (int i = 0; i < 3000; ++i)
 		other.child(STR("node1")).remove_child(other.child(STR("node1")).last_child());
 
 	CHECK_NODE(other, STR("<node1 attr1=\"value1\"><node2/></node1>"));
 
 	other.remove_child(other.first_child());
+
+	CHECK(!other.first_child());
+}
+
+TEST(document_move_empty)
+{
+	xml_document* doc = new xml_document();
+	xml_document other = std::move(*doc);
+	delete doc;
+}
+
+TEST(document_move_large)
+{
+	xml_document* doc = new xml_document();
+
+	for (int i = 0; i < 3000; ++i)
+		doc->append_child(STR("node"));
+
+	xml_document other = std::move(*doc);
+	delete doc;
+
+	for (int i = 0; i < 3000; ++i)
+		CHECK(other.remove_child(other.first_child()));
 
 	CHECK(!other.first_child());
 }

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -1750,4 +1750,37 @@ TEST_XML(document_move_append_child_zero_alloc, "<node1/><node2/>")
 
 	CHECK_NODE(other, STR("<node1/><node2/><node3/>"));
 }
+
+#ifndef PUGIXML_COMPACT
+TEST(document_move_empty_zero_alloc)
+{
+	xml_document* docs = new xml_document[32];
+
+	test_runner::_memory_fail_threshold = 1;
+
+	for (int i = 1; i < 32; ++i)
+		docs[i] = std::move(docs[i-1]);
+
+	delete[] docs;
+}
+
+TEST(document_move_repeated_zero_alloc)
+{
+	xml_document* docs = new xml_document[32];
+
+	CHECK(docs[0].load_string(STR("<node><child/></node>")));
+
+	test_runner::_memory_fail_threshold = 1;
+
+	for (int i = 1; i < 32; ++i)
+		docs[i] = std::move(docs[i-1]);
+
+	for (int i = 0; i < 31; ++i)
+		CHECK(!docs[i].first_child());
+
+	CHECK_NODE(docs[31], STR("<node><child/></node>"));
+
+	delete[] docs;
+}
+#endif
 #endif

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -1739,4 +1739,15 @@ TEST_XML(document_move_buffer, "<node1/><node2/>")
 
 	CHECK(other.child(STR("node2")).offset_debug() == 9);
 }
+
+TEST_XML(document_move_append_child_zero_alloc, "<node1/><node2/>")
+{
+	test_runner::_memory_fail_threshold = 1;
+
+	xml_document other = std::move(doc);
+
+	CHECK(other.append_child(STR("node3")));
+
+	CHECK_NODE(other, STR("<node1/><node2/><node3/>"));
+}
 #endif

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -1715,16 +1715,20 @@ TEST(document_move_large)
 {
 	xml_document* doc = new xml_document();
 
+	xml_node dn = doc->append_child(STR("node"));
+
 	for (int i = 0; i < 3000; ++i)
-		doc->append_child(STR("node"));
+		dn.append_child(STR("child"));
 
 	xml_document other = std::move(*doc);
 	delete doc;
 
-	for (int i = 0; i < 3000; ++i)
-		CHECK(other.remove_child(other.first_child()));
+	xml_node on = other.child(STR("node"));
 
-	CHECK(!other.first_child());
+	for (int i = 0; i < 3000; ++i)
+		CHECK(on.remove_child(on.first_child()));
+
+	CHECK(!on.first_child());
 }
 
 TEST_XML(document_move_buffer, "<node1/><node2/>")

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -1726,4 +1726,13 @@ TEST(document_move_large)
 
 	CHECK(!other.first_child());
 }
+
+TEST_XML(document_move_buffer, "<node1/><node2/>")
+{
+	CHECK(doc.child(STR("node2")).offset_debug() == 9);
+
+	xml_document other = std::move(doc);
+
+	CHECK(other.child(STR("node2")).offset_debug() == 9);
+}
 #endif


### PR DESCRIPTION
This change implements move ctor and assign support for xml_document.

All node handles remain valid after the move and point to the new document; the only exception is the document node itself (that remains unmoved).

Move is O(document size) in theory because it needs to relocate immediate document children (there is just one in conformant documents) and all memory pages; in practice the memory pages only need the header adjusted, which is ~0.1% of the actual data size.

Move requires no allocations in general, except when using compact mode where some moves need to grow the hash table which can fail (throw).

Fixes #104 