### PR TITLE
tests: Fix OSX test failure

### DIFF
--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -598,7 +598,9 @@ TEST(document_load_file_special_folder)
 	// status_out_of_memory is somewhat counter-intuitive but on Linux ftell returns LONG_MAX for directories
 	CHECK(result.status == status_file_not_found || result.status == status_io_error || result.status == status_out_of_memory);
 }
+#endif
 
+#if defined(__linux__)
 TEST(document_load_file_special_device)
 {
 	xml_document doc;


### PR DESCRIPTION
Apparently at some point OSX behavior when reading /dev/tty switched
from "can't open the file" to "the file can be opened and 0 bytes can be
read from it" which generates a wrong error and doesn't exercise the
code path we care about.