### PR TITLE
Add noexcept specifiers to move special members where possible

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -7591,7 +7591,7 @@ PUGI__NS_BEGIN
 			_root_size = state._root_size;
 		}
 
-		void release()
+		void release() PUGIXML_NOEXCEPT
 		{
 			xpath_memory_block* cur = _root;
 			assert(cur);
@@ -8613,13 +8613,13 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	template <typename T> PUGI__FN void delete_xpath_variable(T* var)
+	template <typename T> PUGI__FN void delete_xpath_variable(T* var) PUGIXML_NOEXCEPT
 	{
 		var->~T();
 		xml_memory::deallocate(var);
 	}
 
-	PUGI__FN void delete_xpath_variable(xpath_value_type type, xpath_variable* var)
+	PUGI__FN void delete_xpath_variable(xpath_value_type type, xpath_variable* var) PUGIXML_NOEXCEPT
 	{
 		switch (type)
 		{
@@ -11872,7 +11872,7 @@ PUGI__NS_BEGIN
 			return new (memory) xpath_query_impl();
 		}
 
-		static void destroy(xpath_query_impl* impl)
+		static void destroy(xpath_query_impl* impl) PUGIXML_NOEXCEPT
 		{
 			// free all allocated pages
 			impl->alloc.release();
@@ -12040,7 +12040,7 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN void xpath_node_set::_move(xpath_node_set& rhs)
+	PUGI__FN void xpath_node_set::_move(xpath_node_set& rhs) PUGIXML_NOEXCEPT
 	{
 		_type = rhs._type;
 		_storage = rhs._storage;
@@ -12083,12 +12083,12 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN xpath_node_set::xpath_node_set(xpath_node_set&& rhs): _type(type_unsorted), _begin(&_storage), _end(&_storage)
+	PUGI__FN xpath_node_set::xpath_node_set(xpath_node_set&& rhs) PUGIXML_NOEXCEPT: _type(type_unsorted), _begin(&_storage), _end(&_storage)
 	{
 		_move(rhs);
 	}
 
-	PUGI__FN xpath_node_set& xpath_node_set::operator=(xpath_node_set&& rhs)
+	PUGI__FN xpath_node_set& xpath_node_set::operator=(xpath_node_set&& rhs) PUGIXML_NOEXCEPT
 	{
 		if (this == &rhs) return *this;
 
@@ -12283,7 +12283,7 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN xpath_variable_set::xpath_variable_set(xpath_variable_set&& rhs)
+	PUGI__FN xpath_variable_set::xpath_variable_set(xpath_variable_set&& rhs) PUGIXML_NOEXCEPT
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
 		{
@@ -12292,7 +12292,7 @@ namespace pugi
 		}
 	}
 
-	PUGI__FN xpath_variable_set& xpath_variable_set::operator=(xpath_variable_set&& rhs)
+	PUGI__FN xpath_variable_set& xpath_variable_set::operator=(xpath_variable_set&& rhs) PUGIXML_NOEXCEPT
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
 		{
@@ -12368,7 +12368,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI__FN void xpath_variable_set::_destroy(xpath_variable* var)
+	PUGI__FN void xpath_variable_set::_destroy(xpath_variable* var) PUGIXML_NOEXCEPT
 	{
 		while (var)
 		{
@@ -12486,7 +12486,7 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN xpath_query::xpath_query(xpath_query&& rhs)
+	PUGI__FN xpath_query::xpath_query(xpath_query&& rhs) PUGIXML_NOEXCEPT
 	{
 		_impl = rhs._impl;
 		_result = rhs._result;
@@ -12494,7 +12494,7 @@ namespace pugi
 		rhs._result = xpath_parse_result();
 	}
 
-	PUGI__FN xpath_query& xpath_query::operator=(xpath_query&& rhs)
+	PUGI__FN xpath_query& xpath_query::operator=(xpath_query&& rhs) PUGIXML_NOEXCEPT
 	{
 		if (this == &rhs) return *this;
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -7591,7 +7591,7 @@ PUGI__NS_BEGIN
 			_root_size = state._root_size;
 		}
 
-		void release() PUGIXML_NOEXCEPT
+		void release()
 		{
 			xpath_memory_block* cur = _root;
 			assert(cur);
@@ -8613,13 +8613,13 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	template <typename T> PUGI__FN void delete_xpath_variable(T* var) PUGIXML_NOEXCEPT
+	template <typename T> PUGI__FN void delete_xpath_variable(T* var)
 	{
 		var->~T();
 		xml_memory::deallocate(var);
 	}
 
-	PUGI__FN void delete_xpath_variable(xpath_value_type type, xpath_variable* var) PUGIXML_NOEXCEPT
+	PUGI__FN void delete_xpath_variable(xpath_value_type type, xpath_variable* var)
 	{
 		switch (type)
 		{
@@ -11872,7 +11872,7 @@ PUGI__NS_BEGIN
 			return new (memory) xpath_query_impl();
 		}
 
-		static void destroy(xpath_query_impl* impl) PUGIXML_NOEXCEPT
+		static void destroy(xpath_query_impl* impl)
 		{
 			// free all allocated pages
 			impl->alloc.release();
@@ -12368,7 +12368,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI__FN void xpath_variable_set::_destroy(xpath_variable* var) PUGIXML_NOEXCEPT
+	PUGI__FN void xpath_variable_set::_destroy(xpath_variable* var)
 	{
 		while (var)
 		{

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -81,6 +81,17 @@
 #	endif
 #endif
 
+// If C++ is 2011 or higher, add 'noexcept' specifiers
+#ifndef PUGIXML_NOEXCEPT
+#	if __cplusplus >= 201103
+#		define PUGIXML_NOEXCEPT noexcept
+#	elif defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026
+#		define PUGIXML_NOEXCEPT noexcept
+#	else
+#		define PUGIXML_NOEXCEPT
+#	endif
+#endif
+
 // If C++ is 2011 or higher, add 'override' qualifiers
 #ifndef PUGIXML_OVERRIDE
 #	if __cplusplus >= 201103

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -1136,7 +1136,7 @@ namespace pugi
 		xpath_variable* _find(const char_t* name) const;
 
 		static bool _clone(xpath_variable* var, xpath_variable** out_result);
-		static void _destroy(xpath_variable* var);
+		static void _destroy(xpath_variable* var) PUGIXML_NOEXCEPT;
 
 	public:
 		// Default constructor/destructor
@@ -1149,8 +1149,8 @@ namespace pugi
 
 	#ifdef PUGIXML_HAS_MOVE
 		// Move semantics support
-		xpath_variable_set(xpath_variable_set&& rhs);
-		xpath_variable_set& operator=(xpath_variable_set&& rhs);
+		xpath_variable_set(xpath_variable_set&& rhs) PUGIXML_NOEXCEPT;
+		xpath_variable_set& operator=(xpath_variable_set&& rhs) PUGIXML_NOEXCEPT;
 	#endif
 
 		// Add a new variable or get the existing one, if the types match
@@ -1193,8 +1193,8 @@ namespace pugi
 
 	#ifdef PUGIXML_HAS_MOVE
 		// Move semantics support
-		xpath_query(xpath_query&& rhs);
-		xpath_query& operator=(xpath_query&& rhs);
+		xpath_query(xpath_query&& rhs) PUGIXML_NOEXCEPT;
+		xpath_query& operator=(xpath_query&& rhs) PUGIXML_NOEXCEPT;
 	#endif
 
 		// Get query expression return type
@@ -1334,8 +1334,8 @@ namespace pugi
 
 	#ifdef PUGIXML_HAS_MOVE
 		// Move semantics support
-		xpath_node_set(xpath_node_set&& rhs);
-		xpath_node_set& operator=(xpath_node_set&& rhs);
+		xpath_node_set(xpath_node_set&& rhs) PUGIXML_NOEXCEPT;
+		xpath_node_set& operator=(xpath_node_set&& rhs) PUGIXML_NOEXCEPT;
 	#endif
 
 		// Get collection type
@@ -1369,7 +1369,7 @@ namespace pugi
 		xpath_node* _end;
 
 		void _assign(const_iterator begin, const_iterator end, type_t type);
-		void _move(xpath_node_set& rhs);
+		void _move(xpath_node_set& rhs) PUGIXML_NOEXCEPT;
 	};
 #endif
 

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -82,14 +82,17 @@
 #endif
 
 // If C++ is 2011 or higher, add 'noexcept' specifiers
-#ifndef PUGIXML_NOEXCEPT
+#ifndef PUGIXML_HAS_NOEXCEPT
 #	if __cplusplus >= 201103
-#		define PUGIXML_NOEXCEPT noexcept
+#		define PUGIXML_HAS_NOEXCEPT
 #	elif defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026
-#		define PUGIXML_NOEXCEPT noexcept
-#	else
-#		define PUGIXML_NOEXCEPT
+#		define PUGIXML_HAS_NOEXCEPT
 #	endif
+#endif
+#ifdef PUGIXML_HAS_NOEXCEPT
+#	define PUGIXML_NOEXCEPT noexcept
+#else
+#	define PUGIXML_NOEXCEPT
 #endif
 
 // If C++ is 2011 or higher, add 'override' qualifiers
@@ -1136,7 +1139,7 @@ namespace pugi
 		xpath_variable* _find(const char_t* name) const;
 
 		static bool _clone(xpath_variable* var, xpath_variable** out_result);
-		static void _destroy(xpath_variable* var) PUGIXML_NOEXCEPT;
+		static void _destroy(xpath_variable* var);
 
 	public:
 		// Default constructor/destructor


### PR DESCRIPTION
Having move special members is only half the deal. If they are not noexcept then for example std::vector::push_back will copy instead of move to keep giving the strong exception guarantee.
Therefore this PR adds noexcept to those special move members that can be made noexcept.

Also see these coding guidelines:
- [Core Guidelines](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-move-noexcept)
- [High Integrity C++ Coding Standard](http://www.codingstandard.com/rule/12-5-4-declare-noexcept-the-move-constructor-and-move-assignment-operator/)