### PR TITLE
Enables usage of override specifier for MSVC compilers

### DIFF
--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -85,6 +85,8 @@
 #ifndef PUGIXML_OVERRIDE
 #	if __cplusplus >= 201103
 #		define PUGIXML_OVERRIDE override
+#	elif defined(_MSC_VER) && _MSC_VER >= 1700
+#		define PUGIXML_OVERRIDE override
 #	else
 #		define PUGIXML_OVERRIDE
 #	endif


### PR DESCRIPTION
MS won't be able to increase __cplusplus soon so as a workaround this pull request adds special treatment of the MSVC compiler. (similar to the support of move semantics)
The override specifier is [supported with compiler 17.0](http://en.cppreference.com/w/cpp/compiler_support) which is part of Visual Studio 2012.