### PR TITLE
Adds noexcept specifiers to the move special members of xml_document,…

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -6838,13 +6838,13 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN xml_document::xml_document(xml_document&& rhs): _buffer(0)
+	PUGI__FN xml_document::xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT: _buffer(0)
 	{
 		_create();
 		_move(rhs);
 	}
 
-	PUGI__FN xml_document& xml_document::operator=(xml_document&& rhs)
+	PUGI__FN xml_document& xml_document::operator=(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT
 	{
 		if (this == &rhs) return *this;
 
@@ -6952,7 +6952,7 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN void xml_document::_move(xml_document& rhs)
+	PUGI__FN void xml_document::_move(xml_document& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT
 	{
 		impl::xml_document_struct* doc = static_cast<impl::xml_document_struct*>(_root);
 		impl::xml_document_struct* other = static_cast<impl::xml_document_struct*>(rhs._root);

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -92,7 +92,7 @@
 #ifdef PUGIXML_HAS_NOEXCEPT
 #	define PUGIXML_NOEXCEPT noexcept
 #	ifdef PUGIXML_COMPACT
-#		define PUGIXML_NOEXCEPT_IF_NOT_COMPACT noexcept(false)
+#		define PUGIXML_NOEXCEPT_IF_NOT_COMPACT
 #	else
 #		define PUGIXML_NOEXCEPT_IF_NOT_COMPACT noexcept
 #	endif

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -91,8 +91,14 @@
 #endif
 #ifdef PUGIXML_HAS_NOEXCEPT
 #	define PUGIXML_NOEXCEPT noexcept
+#	ifdef PUGIXML_COMPACT
+#		define PUGIXML_NOEXCEPT_IF_NOT_COMPACT noexcept(false)
+#	else
+#		define PUGIXML_NOEXCEPT_IF_NOT_COMPACT noexcept
+#	endif
 #else
 #	define PUGIXML_NOEXCEPT
+#	define PUGIXML_NOEXCEPT_IF_NOT_COMPACT
 #endif
 
 // If C++ is 2011 or higher, add 'override' qualifiers
@@ -999,7 +1005,7 @@ namespace pugi
 
 		void _create();
 		void _destroy();
-		void _move(xml_document& rhs);
+		void _move(xml_document& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT;
 
 	public:
 		// Default constructor, makes empty document
@@ -1010,8 +1016,8 @@ namespace pugi
 
 	#ifdef PUGIXML_HAS_MOVE
 		// Move semantics support
-		xml_document(xml_document&& rhs);
-		xml_document& operator=(xml_document&& rhs);
+		xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT;
+		xml_document& operator=(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT;
 	#endif
 
 		// Removes all nodes, leaving the empty document


### PR DESCRIPTION
… but only #ifndef PUGIXML_COMPACT

As discussed in #183 but I named the macro PUGIXML_NOEXCEPT_IF_NOT_COMPACT.
Originally I wanted to go with something like you proposed but that name might give wrong hints to a reader who only looks at the move special members and not an the macro definition. The current name clearly expresses when the member is `noexcept` and when it is not.

Also I would have liked to use the `noexcept(static_condition)` syntax, but it is not possible to use it with a macro without [uglyl hacks](https://stackoverflow.com/a/41268349/1969455).