### PR TITLE
cmake: always install the pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(pugixml)
 
 option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
 option(BUILD_TESTS "Build tests" OFF)
-option(BUILD_PKGCONFIG "Build in PKGCONFIG mode" OFF)
+option(USE_VERSIONED_LIBDIR "Use a private subdirectory to install the headers and libs" OFF)
 
 set(BUILD_DEFINES "" CACHE STRING "Build defines")
 
@@ -55,7 +55,7 @@ endif()
 set_target_properties(pugixml PROPERTIES VERSION 1.9 SOVERSION 1)
 get_target_property(PUGIXML_VERSION_STRING pugixml VERSION)
 
-if(BUILD_PKGCONFIG)
+if(USE_VERSIONED_LIBDIR)
 	# Install library into its own directory under LIBDIR
 	set(INSTALL_SUFFIX /pugixml-${PUGIXML_VERSION_STRING})
 endif()
@@ -71,10 +71,8 @@ install(TARGETS pugixml EXPORT pugixml-config
 install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX})
 install(EXPORT pugixml-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml)
 
-if(BUILD_PKGCONFIG)
-	configure_file(scripts/pugixml.pc.in ${PROJECT_BINARY_DIR}/pugixml.pc @ONLY)
-	install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
-endif()
+configure_file(scripts/pugixml.pc.in ${PROJECT_BINARY_DIR}/pugixml.pc @ONLY)
+install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 
 if(BUILD_TESTS)
 	file(GLOB TEST_SOURCES tests/*.cpp)

--- a/scripts/pugixml.pc.in
+++ b/scripts/pugixml.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-includedir=${prefix}/include/pugixml-@PUGIXML_VERSION_STRING@
-libdir=${exec_prefix}/lib/pugixml-@PUGIXML_VERSION_STRING@
+includedir=${prefix}/include@INSTALL_SUFFIX@
+libdir=${exec_prefix}/lib@INSTALL_SUFFIX@
 
 Name: pugixml
 Description: Light-weight, simple and fast XML parser for C++ with XPath support.


### PR DESCRIPTION
There's really never a reason to *not* want this installed. If an option
is needed to specify installing in a versioned subdirectory, this option
should be explicitly described rather than hidden in something else.

As an added bonus, this makes the CMake install code slightly *less*
complicated.