### PR TITLE
Symbol visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,25 +44,32 @@ else()
 endif()
 
 # Export symbols for shared library builds
-if(BUILD_SHARED_LIBS AND MSVC)
-	target_compile_definitions(pugixml PRIVATE "PUGIXML_API=__declspec(dllexport)")
-endif()
+include(GenerateExportHeader)
+generate_export_header(${PROJECT_NAME})
 
 # Enable C++11 long long for compilers that are capable of it
 if(NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} STRLESS 3.1 AND ";${CMAKE_CXX_COMPILE_FEATURES};" MATCHES ";cxx_long_long_type;")
 	target_compile_features(pugixml PUBLIC cxx_long_long_type)
 endif()
 
-set_target_properties(pugixml PROPERTIES VERSION ${pugixml_VERSION} SOVERSION 1)
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    POSITION_INDEPENDENT_CODE ON
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON)
 
 if(USE_VERSIONED_LIBDIR)
 	# Install library into its own directory under LIBDIR
 	set(INSTALL_SUFFIX /pugixml-${pugixml_VERSION})
 endif()
 
-target_include_directories(pugixml PUBLIC
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX}>)
+target_include_directories(pugixml
+	PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX}>
+	PRIVATE
+		${CMAKE_CURRENT_BINARY_DIR})
 
 if(USE_POSTFIX AND CMAKE_CONFIGURATION_TYPES)
 	set_target_properties(pugixml PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
@@ -78,12 +85,16 @@ install(EXPORT pugixml-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml)
 configure_file(scripts/pugixml.pc.in ${PROJECT_BINARY_DIR}/pugixml.pc @ONLY)
 install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/pugixml_export.h DESTINATION include)
+
 if(BUILD_TESTS)
 	file(GLOB TEST_SOURCES tests/*.cpp)
 	file(GLOB FUZZ_SOURCES tests/fuzz_*.cpp)
 	list(REMOVE_ITEM TEST_SOURCES ${FUZZ_SOURCES})
 
 	add_executable(check ${TEST_SOURCES})
+	target_include_directories(check PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 	target_link_libraries(check pugixml)
 	add_custom_command(TARGET check POST_BUILD COMMAND check WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 endif()

--- a/src/pugiconfig.hpp
+++ b/src/pugiconfig.hpp
@@ -14,6 +14,9 @@
 #ifndef HEADER_PUGICONFIG_HPP
 #define HEADER_PUGICONFIG_HPP
 
+// Import the cmake-generated shared object visibility header:
+#include <pugixml_export.h>
+
 // Uncomment this to enable wchar_t mode
 // #define PUGIXML_WCHAR_MODE
 
@@ -30,10 +33,8 @@
 // #define PUGIXML_NO_EXCEPTIONS
 
 // Set this to control attributes for public classes/functions, i.e.:
-// #define PUGIXML_API __declspec(dllexport) // to export all public symbols from DLL
-// #define PUGIXML_CLASS __declspec(dllimport) // to import all classes from DLL
 // #define PUGIXML_FUNCTION __fastcall // to set calling conventions to all public functions to fastcall
-// In absence of PUGIXML_CLASS/PUGIXML_FUNCTION definitions PUGIXML_API is used instead
+// In absence of PUGIXML_FUNCTION definition PUGIXML_EXPORT is used instead
 
 // Tune these constants to adjust memory-related behavior
 // #define PUGIXML_MEMORY_PAGE_SIZE 32768

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -48,19 +48,9 @@
 #	endif
 #endif
 
-// If no API is defined, assume default
-#ifndef PUGIXML_API
-#	define PUGIXML_API
-#endif
-
-// If no API for classes is defined, assume default
-#ifndef PUGIXML_CLASS
-#	define PUGIXML_CLASS PUGIXML_API
-#endif
-
 // If no API for functions is defined, assume default
 #ifndef PUGIXML_FUNCTION
-#	define PUGIXML_FUNCTION PUGIXML_API
+#	define PUGIXML_FUNCTION PUGIXML_EXPORT
 #endif
 
 // If the platform is known to have long long support, enable long long functions
@@ -298,7 +288,7 @@ namespace pugi
 	};
 
 	// Writer interface for node printing (see xml_node::print)
-	class PUGIXML_CLASS xml_writer
+	class PUGIXML_EXPORT xml_writer
 	{
 	public:
 		virtual ~xml_writer() {}
@@ -308,7 +298,7 @@ namespace pugi
 	};
 
 	// xml_writer implementation for FILE*
-	class PUGIXML_CLASS xml_writer_file: public xml_writer
+	class PUGIXML_EXPORT xml_writer_file: public xml_writer
 	{
 	public:
 		// Construct writer from a FILE* object; void* is used to avoid header dependencies on stdio
@@ -322,7 +312,7 @@ namespace pugi
 
 	#ifndef PUGIXML_NO_STL
 	// xml_writer implementation for streams
-	class PUGIXML_CLASS xml_writer_stream: public xml_writer
+	class PUGIXML_EXPORT xml_writer_stream: public xml_writer
 	{
 	public:
 		// Construct writer from an output stream object
@@ -338,7 +328,7 @@ namespace pugi
 	#endif
 
 	// A light-weight handle for manipulating attributes in DOM tree
-	class PUGIXML_CLASS xml_attribute
+	class PUGIXML_EXPORT xml_attribute
 	{
 		friend class xml_attribute_iterator;
 		friend class xml_node;
@@ -444,7 +434,7 @@ namespace pugi
 #endif
 
 	// A light-weight handle for manipulating nodes in DOM tree
-	class PUGIXML_CLASS xml_node
+	class PUGIXML_EXPORT xml_node
 	{
 		friend class xml_attribute_iterator;
 		friend class xml_node_iterator;
@@ -699,7 +689,7 @@ namespace pugi
 #endif
 
 	// A helper for working with text inside PCDATA nodes
-	class PUGIXML_CLASS xml_text
+	class PUGIXML_EXPORT xml_text
 	{
 		friend class xml_node;
 
@@ -788,7 +778,7 @@ namespace pugi
 #endif
 
 	// Child node iterator (a bidirectional iterator over a collection of xml_node)
-	class PUGIXML_CLASS xml_node_iterator
+	class PUGIXML_EXPORT xml_node_iterator
 	{
 		friend class xml_node;
 
@@ -830,7 +820,7 @@ namespace pugi
 	};
 
 	// Attribute iterator (a bidirectional iterator over a collection of xml_attribute)
-	class PUGIXML_CLASS xml_attribute_iterator
+	class PUGIXML_EXPORT xml_attribute_iterator
 	{
 		friend class xml_node;
 
@@ -872,7 +862,7 @@ namespace pugi
 	};
 
 	// Named node range helper
-	class PUGIXML_CLASS xml_named_node_iterator
+	class PUGIXML_EXPORT xml_named_node_iterator
 	{
 		friend class xml_node;
 
@@ -915,7 +905,7 @@ namespace pugi
 	};
 
 	// Abstract tree walker class (see xml_node::traverse)
-	class PUGIXML_CLASS xml_tree_walker
+	class PUGIXML_EXPORT xml_tree_walker
 	{
 		friend class xml_node;
 
@@ -968,7 +958,7 @@ namespace pugi
 	};
 
 	// Parsing result
-	struct PUGIXML_CLASS xml_parse_result
+	struct PUGIXML_EXPORT xml_parse_result
 	{
 		// Parsing status (see xml_parse_status)
 		xml_parse_status status;
@@ -990,7 +980,7 @@ namespace pugi
 	};
 
 	// Document class (DOM tree root)
-	class PUGIXML_CLASS xml_document: public xml_node
+	class PUGIXML_EXPORT xml_document: public xml_node
 	{
 	private:
 		char_t* _buffer;
@@ -1080,7 +1070,7 @@ namespace pugi
 	};
 
 	// XPath parsing result
-	struct PUGIXML_CLASS xpath_parse_result
+	struct PUGIXML_EXPORT xpath_parse_result
 	{
 		// Error message (0 if no error)
 		const char* error;
@@ -1099,7 +1089,7 @@ namespace pugi
 	};
 
 	// A single XPath variable
-	class PUGIXML_CLASS xpath_variable
+	class PUGIXML_EXPORT xpath_variable
 	{
 		friend class xpath_variable_set;
 
@@ -1134,7 +1124,7 @@ namespace pugi
 	};
 
 	// A set of XPath variables
-	class PUGIXML_CLASS xpath_variable_set
+	class PUGIXML_EXPORT xpath_variable_set
 	{
 	private:
 		xpath_variable* _data[64];
@@ -1177,7 +1167,7 @@ namespace pugi
 	};
 
 	// A compiled XPath query object
-	class PUGIXML_CLASS xpath_query
+	class PUGIXML_EXPORT xpath_query
 	{
 	private:
 		void* _impl;
@@ -1252,7 +1242,7 @@ namespace pugi
 
 	#ifndef PUGIXML_NO_EXCEPTIONS
 	// XPath exception class
-	class PUGIXML_CLASS xpath_exception: public std::exception
+	class PUGIXML_EXPORT xpath_exception: public std::exception
 	{
 	private:
 		xpath_parse_result _result;
@@ -1270,7 +1260,7 @@ namespace pugi
 	#endif
 
 	// XPath node class (either xml_node or xml_attribute)
-	class PUGIXML_CLASS xpath_node
+	class PUGIXML_EXPORT xpath_node
 	{
 	private:
 		xml_node _node;
@@ -1311,7 +1301,7 @@ namespace pugi
 #endif
 
 	// A fixed-size collection of XPath nodes
-	class PUGIXML_CLASS xpath_node_set
+	class PUGIXML_EXPORT xpath_node_set
 	{
 	public:
 		// Collection type


### PR DESCRIPTION
This PR replaces the current manually defined PUGIXML_API PUGIXML_CLASS with the cmake auto-generated PUGIXML_EXPORT. This should work for correct symbol visibility on all platforms. It can be used also on Un*x in combination with `symbol visibility hidden`.

Honestly, I did not fully understand the current logic of PUGIXML_API and PUGIXML_CLASS, so maybe this PR misses something? Please let me know if you find it useful or if it requires improvements.