### PR TITLE
Fix Wdouble-promotion warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ EXECUTABLE=$(BUILD)/test
 VERSION=$(shell sed -n 's/.*version \(.*\).*/\1/p' src/pugiconfig.hpp)
 RELEASE=$(filter-out scripts/archive.py docs/%.adoc,$(shell git ls-files contrib docs scripts src CMakeLists.txt readme.txt))
 
-CXXFLAGS=-g -Wall -Wextra -Werror -pedantic -Wundef -Wshadow -Wcast-align -Wcast-qual -Wold-style-cast
+CXXFLAGS=-g -Wall -Wextra -Werror -pedantic -Wundef -Wshadow -Wcast-align -Wcast-qual -Wold-style-cast -Wdouble-promotion
 LDFLAGS=
 
 ifeq ($(config),release)

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4656,7 +4656,7 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, float value)
 	{
 		char buf[128];
-		PUGI__SNPRINTF(buf, "%.9g", value);
+		PUGI__SNPRINTF(buf, "%.9g", double(value));
 
 		return set_value_ascii(dest, header, header_mask, buf);
 	}
@@ -8070,7 +8070,7 @@ PUGI__NS_BEGIN
 		typedef uint32_t UI; // BCC5 workaround
 		union { float f; UI i; } u;
 		u.i = 0x7fc00000;
-		return u.f;
+		return double(u.f);
 	#else
 		// fallback
 		const volatile double zero = 0.0;

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -117,7 +117,7 @@ bool test_xpath_number(const pugi::xpath_node& node, const pugi::char_t* query, 
 	double value = q.evaluate_number(node);
 	double absolute_error = fabs(value - expected);
 
-	const double tolerance = 1e-15f;
+	const double tolerance = 1e-15;
 	return absolute_error < tolerance || absolute_error < fabs(expected) * tolerance;
 }
 

--- a/tests/test_dom_text.cpp
+++ b/tests/test_dom_text.cpp
@@ -124,12 +124,12 @@ TEST_XML(dom_text_as_float, "<node><text1>0</text1><text2>1</text2><text3>0.12</
 	xml_node node = doc.child(STR("node"));
 
 	CHECK(xml_text().as_float() == 0);
-	CHECK_DOUBLE(node.child(STR("text1")).text().as_float(), 0);
-	CHECK_DOUBLE(node.child(STR("text2")).text().as_float(), 1);
-	CHECK_DOUBLE(node.child(STR("text3")).text().as_float(), 0.12);
-	CHECK_DOUBLE(node.child(STR("text4")).text().as_float(), -5.1);
-	CHECK_DOUBLE(node.child(STR("text5")).text().as_float(), 3e-4);
-	CHECK_DOUBLE(node.child(STR("text6")).text().as_float(), 3.14159265358979323846);
+	CHECK_DOUBLE(double(node.child(STR("text1")).text().as_float()), 0);
+	CHECK_DOUBLE(double(node.child(STR("text2")).text().as_float()), 1);
+	CHECK_DOUBLE(double(node.child(STR("text3")).text().as_float()), 0.12);
+	CHECK_DOUBLE(double(node.child(STR("text4")).text().as_float()), -5.1);
+	CHECK_DOUBLE(double(node.child(STR("text5")).text().as_float()), 3e-4);
+	CHECK_DOUBLE(double(node.child(STR("text6")).text().as_float()), 3.14159265358979323846);
 }
 
 TEST_XML(dom_text_as_double, "<node><text1>0</text1><text2>1</text2><text3>0.12</text3><text4>-5.1</text4><text5>3e-4</text5><text6>3.14159265358979323846</text6></node>")

--- a/tests/test_dom_traverse.cpp
+++ b/tests/test_dom_traverse.cpp
@@ -150,12 +150,12 @@ TEST_XML(dom_attr_as_float, "<node attr1='0' attr2='1' attr3='0.12' attr4='-5.1'
 	xml_node node = doc.child(STR("node"));
 
 	CHECK(xml_attribute().as_float() == 0);
-	CHECK_DOUBLE(node.attribute(STR("attr1")).as_float(), 0);
-	CHECK_DOUBLE(node.attribute(STR("attr2")).as_float(), 1);
-	CHECK_DOUBLE(node.attribute(STR("attr3")).as_float(), 0.12);
-	CHECK_DOUBLE(node.attribute(STR("attr4")).as_float(), -5.1);
-	CHECK_DOUBLE(node.attribute(STR("attr5")).as_float(), 3e-4);
-	CHECK_DOUBLE(node.attribute(STR("attr6")).as_float(), 3.14159265358979323846);
+	CHECK_DOUBLE(double(node.attribute(STR("attr1")).as_float()), 0);
+	CHECK_DOUBLE(double(node.attribute(STR("attr2")).as_float()), 1);
+	CHECK_DOUBLE(double(node.attribute(STR("attr3")).as_float()), 0.12);
+	CHECK_DOUBLE(double(node.attribute(STR("attr4")).as_float()), -5.1);
+	CHECK_DOUBLE(double(node.attribute(STR("attr5")).as_float()), 3e-4);
+	CHECK_DOUBLE(double(node.attribute(STR("attr6")).as_float()), 3.14159265358979323846);
 }
 
 TEST_XML(dom_attr_as_double, "<node attr1='0' attr2='1' attr3='0.12' attr4='-5.1' attr5='3e-4' attr6='3.14159265358979323846'/>")

--- a/tests/test_xpath.cpp
+++ b/tests/test_xpath.cpp
@@ -205,8 +205,8 @@ TEST(xpath_long_numbers_parse)
 	xml_node c;
 
 	// check parsing
-	CHECK_XPATH_NUMBER(c, str_flt_max, std::numeric_limits<float>::max());
-	CHECK_XPATH_NUMBER(c, str_flt_max_dec, std::numeric_limits<float>::max());
+	CHECK_XPATH_NUMBER(c, str_flt_max, double(std::numeric_limits<float>::max()));
+	CHECK_XPATH_NUMBER(c, str_flt_max_dec, double(std::numeric_limits<float>::max()));
 	CHECK_XPATH_NUMBER(c, str_dbl_max, std::numeric_limits<double>::max());
 	CHECK_XPATH_NUMBER(c, str_dbl_max_dec, std::numeric_limits<double>::max());
 }


### PR DESCRIPTION
We had a couple of places in test code and one place in library source
where we used an implicit float->double cast; while it should preserve
the value exactly, gcc/clang implement this warning to make sure uses of
double are intentional.

Fixes #243.