### PR TITLE
Enable config=sanitize in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - DEFINES=PUGIXML_NO_EXCEPTIONS
 script:
   - make test cxxstd=c++11 defines=$DEFINES config=coverage -j2
+  - if [[ "$CXX" == "clang++" ]]; then make test cxxstd=c++11 defines=$DEFINES config=sanitize -j2; fi
   - make test cxxstd=c++11 defines=$DEFINES config=release -j2
   - make test cxxstd=c++98 defines=$DEFINES config=debug -j2
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifeq ($(config),coverage)
 endif
 
 ifeq ($(config),sanitize)
-	CXXFLAGS+=-fsanitize=address,undefined
+	CXXFLAGS+=-fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,float-cast-overflow -fno-sanitize-recover=all
 	LDFLAGS+=-fsanitize=address,undefined
 endif
 

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -590,14 +590,12 @@ TEST(document_load_file_wide_out_of_memory)
 	CHECK(result.status == status_out_of_memory || result.status == status_file_not_found);
 }
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__APPLE__)
 TEST(document_load_file_special_folder)
 {
 	xml_document doc;
 	xml_parse_result result = doc.load_file(".");
-	// status_out_of_memory is somewhat counter-intuitive but on Linux ftell returns LONG_MAX for directories
-	// on some Debian systems the folder is also read as empty, hence status_no_document_element check
-	CHECK(result.status == status_file_not_found || result.status == status_io_error || result.status == status_out_of_memory || result.status == status_no_document_element);
+	CHECK(result.status == status_io_error);
 }
 #endif
 


### PR DESCRIPTION
This commit changes sanitize configuration to fail on the first error
and ignore floating-point division and overflow "errors" that trigger
when we test the corresponding functionality. This makes it possible to
run this on all commits - if new UB or memory safety issues are introduced,
asan/ubsan will catch them.