### PR TITLE
Move unreachable line handling to Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,10 @@ env:
   - DEFINES=PUGIXML_NO_EXCEPTIONS
 
 script:
-  - make test cxxstd=c++11 defines=$DEFINES config=coverage -j2
+  - if [[ ! ( "$CXX" == "clang++" && "$TRAVIS_OS_NAME" == "linux" ) ]]; then make test cxxstd=c++11 defines=$DEFINES config=coverage -j2; fi
   - if [[ "$CXX" == "clang++" ]]; then make test cxxstd=c++11 defines=$DEFINES config=sanitize -j2; fi
   - make test cxxstd=c++11 defines=$DEFINES config=release -j2
   - make test cxxstd=c++98 defines=$DEFINES config=debug -j2
 
 after_success:
-  - sed -e "s/#####\(.*\)\(\/\/ unreachable.*\)/    1\1\2/" -i pugixml.cpp.gcov
   - bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ test: $(EXECUTABLE)
 	./$(EXECUTABLE)
 	@gcov -b -o $(BUILD)/src/ pugixml.cpp.gcda | sed -e '/./{H;$!d;}' -e 'x;/pugixml.cpp/!d;'
 	@find . -name '*.gcov' -and -not -name 'pugixml.cpp.gcov' -exec rm {} +
+	@sed -i -e "s/#####\(.*\)\(\/\/ unreachable.*\)/    1\1\2/" pugixml.cpp.gcov
 else
 test: $(EXECUTABLE)
 	./$(EXECUTABLE)


### PR DESCRIPTION
This allows us to reuse this code for MinGW builds.

Additionally disable coverage step for Linux clang - it looks like
Travis has a mismatch in the version of gcov info between clang and gcov
which causes gcov to crash - somehow this crash isn't picked up as a
build error.