### PR TITLE
pkg-config: Use CMake GnuInstallDirs FULL vars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX
 install(EXPORT pugixml-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml)
 
 configure_file(scripts/pugixml.pc.in ${PROJECT_BINARY_DIR}/pugixml.pc @ONLY)
-install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig)
 
 if(BUILD_TESTS)
 	file(GLOB TEST_SOURCES tests/*.cpp)

--- a/scripts/pugixml.pc.in
+++ b/scripts/pugixml.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-includedir=${prefix}/include@INSTALL_SUFFIX@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@@INSTALL_SUFFIX@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@@INSTALL_SUFFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@@INSTALL_SUFFIX@
 
 Name: pugixml
 Description: Light-weight, simple and fast XML parser for C++ with XPath support.


### PR DESCRIPTION
Hello,

This commit uses [GNUInstallDirs](https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html) absolute path variables instead of creating such paths manually.
- Use `CMAKE_INSTALL_FULL_LIBDIR` instead of `CMAKE_INSTALL_PREFIX}`/`CMAKE_INSTALL_LIBDIR`
- Use `CMAKE_INSTALL_FULL_INCLUDEDIR` instead of `CMAKE_INSTALL_PREFIX}`/`CMAKE_INSTALL_INCLUDEDIR`

This fixes an installation problem in [Nix](https://nixos.org/nix/) packages, as non-FULL variables are already absolute paths in this case.