### PR TITLE
make pugixml build static and shared via cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.0)
 
 project(pugixml VERSION 1.9)
 
-option(BUILD_SHARED_AND_STATIC_LIBS "Build both shared and static libraries" OFF)
 option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
 option(BUILD_TESTS "Build tests" OFF)
 option(USE_VERSIONED_LIBDIR "Use a private subdirectory to install the headers and libs" OFF)
@@ -38,90 +37,41 @@ if(DEFINED BUILD_DEFINES)
 	endforeach()
 endif()
 
-# if both are set turn both on.
-if(BUILD_SHARED_AND_STATIC_LIBS)
-  set(BUILD_SHARED_LIBS ON)
-  set(BUILD_STATIC_LIBS ON)
-else()
-  if(BUILD_SHARED_LIBS)
-    set(BUILD_STATIC_LIBS OFF)
-  else()
-    set(BUILD_SHARED_LIBS OFF)
-    set(BUILD_STATIC_LIBS ON)
-  endif()
-endif()
-
 if(BUILD_SHARED_LIBS)
-  add_library(pugixml-shared SHARED ${HEADERS} ${SOURCES})
-  set_target_properties(pugixml-shared PROPERTIES OUTPUT_NAME pugixml)
-endif()
-
-if(BUILD_STATIC_LIBS)
-  add_library(pugixml-static STATIC ${HEADERS} ${SOURCES})
-  set_target_properties(pugixml-static PROPERTIES OUTPUT_NAME pugixml)
+	add_library(pugixml SHARED ${HEADERS} ${SOURCES})
+else()
+	add_library(pugixml STATIC ${HEADERS} ${SOURCES})
 endif()
 
 # Export symbols for shared library builds
 if(BUILD_SHARED_LIBS AND MSVC)
-	target_compile_definitions(pugixml-shared PRIVATE "PUGIXML_API=__declspec(dllexport)")
+	target_compile_definitions(pugixml PRIVATE "PUGIXML_API=__declspec(dllexport)")
 endif()
 
 # Enable C++11 long long for compilers that are capable of it
 if(NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} STRLESS 3.1 AND ";${CMAKE_CXX_COMPILE_FEATURES};" MATCHES ";cxx_long_long_type;")
-	if(BUILD_SHARED_LIBS)
-    target_compile_features(pugixml-shared PUBLIC cxx_long_long_type)
-  endif()
-  if(BUILD_STATIC_LIBS)
-    target_compile_features(pugixml-static PUBLIC cxx_long_long_type)
-  endif()
+	target_compile_features(pugixml PUBLIC cxx_long_long_type)
 endif()
 
-if(BUILD_SHARED_LIBS)
-set_target_properties(pugixml-shared PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
-endif()
-
-if(BUILD_STATIC_LIBS)
-set_target_properties(pugixml-static PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
-endif()
+set_target_properties(pugixml PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 
 if(USE_VERSIONED_LIBDIR)
 	# Install library into its own directory under LIBDIR
 	set(INSTALL_SUFFIX /pugixml-${pugixml_VERSION})
 endif()
 
-if(BUILD_SHARED_LIBS)
-target_include_directories(pugixml-shared PUBLIC
+target_include_directories(pugixml PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX}>)
-endif()
-
-if(BUILD_STATIC_LIBS)
-target_include_directories(pugixml-static PUBLIC
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX}>)
-endif()
 
 if(USE_POSTFIX AND CMAKE_CONFIGURATION_TYPES)
-  if(BUILD_STATIC_LIBS)
-    set_target_properties(pugixml-static PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
-  endif()
-  if(BUILD_SHARED_LIBS)
-    set_target_properties(pugixml-shared PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
-  endif()  
+	set_target_properties(pugixml PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
 endif()
 
-if(BUILD_STATIC_LIBS)
-install(TARGETS pugixml-static EXPORT pugixml-config
+install(TARGETS pugixml EXPORT pugixml-config
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-endif()
-if(BUILD_SHARED_LIBS)
-install(TARGETS pugixml-shared EXPORT pugixml-config
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-endif()
 install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX})
 install(EXPORT pugixml-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml)
 
@@ -134,11 +84,6 @@ if(BUILD_TESTS)
 	list(REMOVE_ITEM TEST_SOURCES ${FUZZ_SOURCES})
 
 	add_executable(check ${TEST_SOURCES})
-if(BUILD_STATIC_LIBS)
-	target_link_libraries(check pugixml-static)
-endif()
-if(BUILD_SHARED_LIBS)
-	target_link_libraries(check pugixml-shared)
-endif()
+	target_link_libraries(check pugixml)
 	add_custom_command(TARGET check POST_BUILD COMMAND check WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(pugixml VERSION 1.9)
 
+option(BUILD_SHARED_AND_STATIC_LIBS "Build both shared and static libraries" OFF)
 option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
 option(BUILD_TESTS "Build tests" OFF)
 option(USE_VERSIONED_LIBDIR "Use a private subdirectory to install the headers and libs" OFF)
@@ -37,41 +38,86 @@ if(DEFINED BUILD_DEFINES)
 	endforeach()
 endif()
 
-if(BUILD_SHARED_LIBS)
-	add_library(pugixml SHARED ${HEADERS} ${SOURCES})
+if(BUILD_SHARED_AND_STATIC_LIBS)
+    add_library(pugixml-static SHARED ${HEADERS} ${SOURCES})
+    add_library(pugixml-shared STATIC ${HEADERS} ${SOURCES})
 else()
-	add_library(pugixml STATIC ${HEADERS} ${SOURCES})
+  if(BUILD_SHARED_LIBS)
+    add_library(pugixml SHARED ${HEADERS} ${SOURCES})
+  else()
+    add_library(pugixml STATIC ${HEADERS} ${SOURCES})
+  endif()
 endif()
 
 # Export symbols for shared library builds
+if(BUILD_SHARED_AND_STATIC_LIBS AND MSVC)
+	target_compile_definitions(pugixml-shared PRIVATE "PUGIXML_API=__declspec(dllexport)")
+endif()
+
 if(BUILD_SHARED_LIBS AND MSVC)
 	target_compile_definitions(pugixml PRIVATE "PUGIXML_API=__declspec(dllexport)")
 endif()
 
 # Enable C++11 long long for compilers that are capable of it
 if(NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} STRLESS 3.1 AND ";${CMAKE_CXX_COMPILE_FEATURES};" MATCHES ";cxx_long_long_type;")
-	target_compile_features(pugixml PUBLIC cxx_long_long_type)
+  if(BUILD_SHARED_AND_STATIC_LIBS)
+    target_compile_features(pugixml-shared PUBLIC cxx_long_long_type)
+    target_compile_features(pugixml-static PUBLIC cxx_long_long_type)	
+  else()
+    target_compile_features(pugixml PUBLIC cxx_long_long_type)
+  endif()
 endif()
 
-set_target_properties(pugixml PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+if(BUILD_SHARED_AND_STATIC_LIBS)
+  set_target_properties(pugixml-static PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+  set_target_properties(pugixml-shared PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+else()
+  set_target_properties(pugixml PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+endif()
 
 if(USE_VERSIONED_LIBDIR)
 	# Install library into its own directory under LIBDIR
 	set(INSTALL_SUFFIX /pugixml-${pugixml_VERSION})
 endif()
 
-target_include_directories(pugixml PUBLIC
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX}>)
-
-if(USE_POSTFIX AND CMAKE_CONFIGURATION_TYPES)
-	set_target_properties(pugixml PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
+if(BUILD_SHARED_AND_STATIC_LIBS)
+  target_include_directories(pugixml-static PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX}>)
+  target_include_directories(pugixml-shared PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX}>)
+else()
+  target_include_directories(pugixml PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX}>)
 endif()
 
-install(TARGETS pugixml EXPORT pugixml-config
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+if(USE_POSTFIX AND CMAKE_CONFIGURATION_TYPES)
+  if(BUILD_SHARED_AND_STATIC_LIBS)
+    set_target_properties(pugixml-static PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
+    set_target_properties(pugixml-shared PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
+  else()
+    set_target_properties(pugixml PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
+  endif()
+endif()
+
+if(BUILD_SHARED_AND_STATIC_LIBS)
+  install(TARGETS pugixml-static EXPORT pugixml-config
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(TARGETS pugixml-shared EXPORT pugixml-config
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+else()
+  install(TARGETS pugixml EXPORT pugixml-config
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+
 install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX})
 install(EXPORT pugixml-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml)
 
@@ -84,6 +130,11 @@ if(BUILD_TESTS)
 	list(REMOVE_ITEM TEST_SOURCES ${FUZZ_SOURCES})
 
 	add_executable(check ${TEST_SOURCES})
-	target_link_libraries(check pugixml)
+  if(BUILD_SHARED_AND_STATIC_LIBS)
+    target_link_libraries(check pugixml-shared)
+    target_link_libraries(check pugixml-static)
+  else()
+    target_link_libraries(check pugixml)
+  endif()
 	add_custom_command(TARGET check POST_BUILD COMMAND check WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(pugixml VERSION 1.9)
 
+option(BUILD_SHARED_AND_STATIC_LIBS "Build both shared and static libraries" OFF)
 option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
 option(BUILD_TESTS "Build tests" OFF)
 option(USE_VERSIONED_LIBDIR "Use a private subdirectory to install the headers and libs" OFF)
@@ -37,41 +38,90 @@ if(DEFINED BUILD_DEFINES)
 	endforeach()
 endif()
 
-if(BUILD_SHARED_LIBS)
-	add_library(pugixml SHARED ${HEADERS} ${SOURCES})
+# if both are set turn both on.
+if(BUILD_SHARED_AND_STATIC_LIBS)
+  set(BUILD_SHARED_LIBS ON)
+  set(BUILD_STATIC_LIBS ON)
 else()
-	add_library(pugixml STATIC ${HEADERS} ${SOURCES})
+  if(BUILD_SHARED_LIBS)
+    set(BUILD_STATIC_LIBS OFF)
+  else()
+    set(BUILD_SHARED_LIBS OFF)
+    set(BUILD_STATIC_LIBS ON)
+  endif()
+endif()
+
+if(BUILD_SHARED_LIBS)
+  add_library(pugixml-shared SHARED ${HEADERS} ${SOURCES})
+  set_target_properties(pugixml-shared PROPERTIES OUTPUT_NAME pugixml)
+endif()
+
+if(BUILD_STATIC_LIBS)
+  add_library(pugixml-static STATIC ${HEADERS} ${SOURCES})
+  set_target_properties(pugixml-static PROPERTIES OUTPUT_NAME pugixml)
 endif()
 
 # Export symbols for shared library builds
 if(BUILD_SHARED_LIBS AND MSVC)
-	target_compile_definitions(pugixml PRIVATE "PUGIXML_API=__declspec(dllexport)")
+	target_compile_definitions(pugixml-shared PRIVATE "PUGIXML_API=__declspec(dllexport)")
 endif()
 
 # Enable C++11 long long for compilers that are capable of it
 if(NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} STRLESS 3.1 AND ";${CMAKE_CXX_COMPILE_FEATURES};" MATCHES ";cxx_long_long_type;")
-	target_compile_features(pugixml PUBLIC cxx_long_long_type)
+	if(BUILD_SHARED_LIBS)
+    target_compile_features(pugixml-shared PUBLIC cxx_long_long_type)
+  endif()
+  if(BUILD_STATIC_LIBS)
+    target_compile_features(pugixml-static PUBLIC cxx_long_long_type)
+  endif()
 endif()
 
-set_target_properties(pugixml PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+if(BUILD_SHARED_LIBS)
+set_target_properties(pugixml-shared PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+endif()
+
+if(BUILD_STATIC_LIBS)
+set_target_properties(pugixml-static PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+endif()
 
 if(USE_VERSIONED_LIBDIR)
 	# Install library into its own directory under LIBDIR
 	set(INSTALL_SUFFIX /pugixml-${pugixml_VERSION})
 endif()
 
-target_include_directories(pugixml PUBLIC
+if(BUILD_SHARED_LIBS)
+target_include_directories(pugixml-shared PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX}>)
-
-if(USE_POSTFIX AND CMAKE_CONFIGURATION_TYPES)
-	set_target_properties(pugixml PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
 endif()
 
-install(TARGETS pugixml EXPORT pugixml-config
+if(BUILD_STATIC_LIBS)
+target_include_directories(pugixml-static PUBLIC
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX}>)
+endif()
+
+if(USE_POSTFIX AND CMAKE_CONFIGURATION_TYPES)
+  if(BUILD_STATIC_LIBS)
+    set_target_properties(pugixml-static PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
+  endif()
+  if(BUILD_SHARED_LIBS)
+    set_target_properties(pugixml-shared PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
+  endif()  
+endif()
+
+if(BUILD_STATIC_LIBS)
+install(TARGETS pugixml-static EXPORT pugixml-config
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+if(BUILD_SHARED_LIBS)
+install(TARGETS pugixml-shared EXPORT pugixml-config
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX})
 install(EXPORT pugixml-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml)
 
@@ -84,6 +134,11 @@ if(BUILD_TESTS)
 	list(REMOVE_ITEM TEST_SOURCES ${FUZZ_SOURCES})
 
 	add_executable(check ${TEST_SOURCES})
-	target_link_libraries(check pugixml)
+if(BUILD_STATIC_LIBS)
+	target_link_libraries(check pugixml-static)
+endif()
+if(BUILD_SHARED_LIBS)
+	target_link_libraries(check pugixml-shared)
+endif()
 	add_custom_command(TARGET check POST_BUILD COMMAND check WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(pugixml VERSION 1.9)
 
-option(BUILD_SHARED_LIBS "Build shared library" OFF)
-option(BUILD_STATIC_LIBS "Build static library" ON)
+option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
 option(BUILD_TESTS "Build tests" OFF)
 option(USE_VERSIONED_LIBDIR "Use a private subdirectory to install the headers and libs" OFF)
 option(USE_POSTFIX "Use separate postfix for each configuration to make sure you can install multiple build outputs" OFF)
@@ -40,11 +39,8 @@ endif()
 
 if(BUILD_SHARED_LIBS)
 	add_library(pugixml SHARED ${HEADERS} ${SOURCES})
-endif()
-
-if(BUILD_STATIC_LIBS)
-  add_library(pugixmlstatic STATIC ${HEADERS} ${SOURCES})
-  set_target_properties(pugixmlstatic PROPERTIES OUTPUT_NAME pugixml)
+else()
+	add_library(pugixml STATIC ${HEADERS} ${SOURCES})
 endif()
 
 # Export symbols for shared library builds
@@ -72,7 +68,7 @@ if(USE_POSTFIX AND CMAKE_CONFIGURATION_TYPES)
 	set_target_properties(pugixml PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
 endif()
 
-install(TARGETS pugixml pugixmlstatic EXPORT pugixml-config
+install(TARGETS pugixml EXPORT pugixml-config
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 
 project(pugixml VERSION 1.9)
 
-option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
+option(BUILD_SHARED_LIBS "Build shared library" OFF)
+option(BUILD_STATIC_LIBS "Build static library" ON)
 option(BUILD_TESTS "Build tests" OFF)
 option(USE_VERSIONED_LIBDIR "Use a private subdirectory to install the headers and libs" OFF)
 option(USE_POSTFIX "Use separate postfix for each configuration to make sure you can install multiple build outputs" OFF)
@@ -39,8 +40,11 @@ endif()
 
 if(BUILD_SHARED_LIBS)
 	add_library(pugixml SHARED ${HEADERS} ${SOURCES})
-else()
-	add_library(pugixml STATIC ${HEADERS} ${SOURCES})
+endif()
+
+if(BUILD_STATIC_LIBS)
+  add_library(pugixmlstatic STATIC ${HEADERS} ${SOURCES})
+  set_target_properties(pugixmlstatic PROPERTIES OUTPUT_NAME pugixml)
 endif()
 
 # Export symbols for shared library builds
@@ -68,7 +72,7 @@ if(USE_POSTFIX AND CMAKE_CONFIGURATION_TYPES)
 	set_target_properties(pugixml PROPERTIES DEBUG_POSTFIX "_d" MINSIZEREL_POSTFIX "_m" RELWITHDEBINFO_POSTFIX "_r")
 endif()
 
-install(TARGETS pugixml EXPORT pugixml-config
+install(TARGETS pugixml pugixmlstatic EXPORT pugixml-config
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
We need to build static and shared libraries at the same time. This patch worked for us. I set building shared libs off, so its default behaviour is the same as before. The only difference is: If you only want to build shared libs, you have to set BUILD_SHARED_LIBS and unset BUILD_STATIC_LIBS.

