### PR TITLE
XPath: Make remove_duplicates generate stable order

### DIFF
--- a/tests/test_xpath.cpp
+++ b/tests/test_xpath.cpp
@@ -449,16 +449,41 @@ TEST(xpath_out_of_memory_evaluate_substring)
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(0, 0, xml_node()) == 1));
 }
 
-/*
-TEST_XML(xpath_out_of_memory_evaluate_union, "<node><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/></node>")
+TEST_XML(xpath_out_of_memory_evaluate_union, "<node />")
 {
-	test_runner::_memory_fail_threshold = 32768 + 4096 * 2;
+	// left hand side: size * sizeof(xpath_node) (8 on 32-bit, 16 on 64-bit)
+	// right hand side: same
+	// to make sure that when we append right hand side to left hand side, we run out of an XPath stack page (4K), we need slightly more than 2K/8 = 256 nodes on 32-bit, 128 nodes on 64-bit
+	size_t count = sizeof(void*) == 4 ? 300 : 150;
 
-	xpath_query q(STR("a|(a|(a|(a|(a|(a|(a|(a|(a|(a|(a|(a|(a|(a|(a|(a|(a|(a|(a|(a|a)))))))))))))))))))"));
+	for (size_t i = 0; i < count; ++i)
+		doc.first_child().append_child(STR("a"));
+
+	xpath_query q(STR("a|a"));
+
+	test_runner::_memory_fail_threshold = 1;
 
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_node_set(doc.child(STR("node"))).empty()));
 }
-*/
+
+TEST_XML(xpath_out_of_memory_evaluate_union_hash, "<node />")
+{
+	// left hand side: size * sizeof(xpath_node) (8 on 32-bit, 16 on 64-bit)
+	// right hand side: same
+	// hash table: size * 1.5 * sizeof(void*)
+	// to make sure that when we append right hand side to left hand side, we do *not* run out of an XPath stack page (4K), we need slightly less than 2K/8 = 256 nodes on 32-bit, 128 nodes on 64-bit
+	size_t count = sizeof(void*) == 4 ? 200 : 100;
+
+	for (size_t i = 0; i < count; ++i)
+		doc.first_child().append_child(STR("a"));
+
+	xpath_query q(STR("a|a"));
+
+	test_runner::_memory_fail_threshold = 1;
+
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_node_set(doc.child(STR("node"))).empty()));
+}
+
 
 TEST_XML(xpath_out_of_memory_evaluate_predicate, "<node><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/></node>")
 {

--- a/tests/test_xpath_operators.cpp
+++ b/tests/test_xpath_operators.cpp
@@ -435,6 +435,24 @@ TEST_XML(xpath_operators_union, "<node><employee/><employee secretary=''/><emplo
 	CHECK_XPATH_NODESET(n, STR(". | tail/preceding-sibling::employee | .")) % 2 % 3 % 4 % 6 % 8 % 11;
 }
 
+TEST_XML(xpath_operators_union_order, "<node />")
+{
+	xml_node n = doc.child(STR("node"));
+
+	n.append_child(STR("c"));
+	n.prepend_child(STR("b"));
+	n.append_child(STR("d"));
+	n.prepend_child(STR("a"));
+
+	xpath_node_set ns = n.select_nodes(STR("d | d | b | c | b | a | c | d | b"));
+
+	CHECK(ns.size() == 4);
+	CHECK_STRING(ns[0].node().name(), STR("d"));
+	CHECK_STRING(ns[1].node().name(), STR("b"));
+	CHECK_STRING(ns[2].node().name(), STR("c"));
+	CHECK_STRING(ns[3].node().name(), STR("a"));
+}
+
 TEST(xpath_operators_union_error)
 {
 	CHECK_XPATH_FAIL(STR(". | true()"));


### PR DESCRIPTION
Given an unsorted sequence, remove_duplicates would sort it using the
pointer value of attributes/nodes and then remove consecutive
duplicates.

This was problematic because it meant that the result of XPath queries
was dependent on the memory allocation pattern. While it's technically
incorrect to rely on the order, this results in easy to miss bugs.

This is particularly common when XPath queries use union operators -
although we also will call remove_duplicates in other cases.

This change reworks the code to use a hash set instead, using the same
hash function we use for compact storage. To make sure it performs well,
we allocate enough buckets for count * 1.5 (assuming all elements are
unique); since each bucket is a single pointer unlike xpath_node which
is two pointers, we need somewhere between size * 0.75 and size * 1.5
temporary storage.

The resulting filtering is stable - we remove elements that we have seen
before but we don't change the order - and is actually significantly
faster than sorting was.

With a large union operation, before this change it took ~56 ms per 100
query invocations to remove duplicates, and after this change it takes
~20ms.

Fixes #254.