### PR TITLE
Fix install locations for pkgconfig *and* cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,10 +173,10 @@ install(EXPORT pugixml-targets
 install(FILES
   "${PROJECT_BINARY_DIR}/pugixml-config-version.cmake"
   "${PROJECT_BINARY_DIR}/pugixml-config.cmake"
-  DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/pugixml)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml)
 
 install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc
-  DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 install(
   FILES


### PR DESCRIPTION
Per @eli-schwartz's recommendations, this PR fixes the pkgconfig file locations. In an attempt to also future-proof it for CMake's config files, we now install them to libdir as well.