### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Documentation for the current release of pugixml is available on-line as two sep
 
 You’re advised to start with the quick-start guide; however, many important library features are either not described in it at all or only mentioned briefly; if you require more information you should read the complete manual.
 
+## Building pugixml with VCPKG
+
+You can build and install pugixml using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install pugixml
+
+The pugixml port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Example
 
 Here's an example of how code using pugixml looks; it opens an XML file, goes over all Tool nodes and prints tools that have a Timeout attribute greater than 0:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Documentation for the current release of pugixml is available on-line as two sep
 
 You’re advised to start with the quick-start guide; however, many important library features are either not described in it at all or only mentioned briefly; if you require more information you should read the complete manual.
 
-## Building pugixml with VCPKG
+## Building pugixml with vcpkg
 
 You can build and install pugixml using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
 


### PR DESCRIPTION
pugixml is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build pugixml , ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for pugixml and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.