### PR TITLE
Override operators into xml_node

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5496,6 +5496,11 @@ namespace pugi
 		return (_root >= r._root);
 	}
 
+	PUGI__FN xml_node xml_node::operator[](const char_t* name_)
+	{
+		return append_child(name_);
+	}
+
 	PUGI__FN bool xml_node::empty() const
 	{
 		return !_root;

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5501,6 +5501,14 @@ namespace pugi
 		return append_child(name_);
 	}
 
+	PUGI__FN xml_node& xml_node::operator=(const char_t* rhs)
+	{
+		xml_node node = append_child(node_pcdata);
+
+		node.set_value(rhs);
+		return *this;
+	}
+
 	PUGI__FN bool xml_node::empty() const
 	{
 		return !_root;

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5691,6 +5691,16 @@ namespace pugi
 		return impl::strcpy_insitu(_root->value, _root->header, impl::xml_memory_page_value_allocated_mask, rhs, impl::strlength(rhs));
 	}
 
+	PUGI__FN bool xml_node::set_value(const bool rhs)
+	{
+	#ifdef PUGIXML_WCHAR_MODE
+		const char_t* text = rhs ? L"true" : L"false";
+	#else
+		const char_t* text = rhs ? "true" : "false";
+	#endif
+		return set_value(text);
+	}
+
 	PUGI__FN xml_attribute xml_node::append_attribute(const char_t* name_)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -38,6 +38,8 @@
 #	include <string>
 #endif
 
+#include <type_traits>
+
 // Macro for deprecated features
 #ifndef PUGIXML_DEPRECATED
 #	if defined(__GNUC__)
@@ -491,6 +493,21 @@ namespace pugi
 		xml_node operator[](const char_t* name_);
 		xml_node& operator=(const char_t* rhs);
 
+	#ifndef PUGIXML_NO_STL
+		template <typename T> xml_node& operator=(const T& rhs)
+		{
+			if (std::is_arithmetic<T>::value)
+			{
+				xml_node node = append_child(node_pcdata);
+
+				node.set_value(rhs);
+			}
+
+			return *this;
+		}
+
+	#endif
+
 		// Check if node is empty.
 		bool empty() const;
 
@@ -543,6 +560,22 @@ namespace pugi
 		// Set node name/value (returns false if node is empty, there is not enough memory, or node can not have name/value)
 		bool set_name(const char_t* rhs);
 		bool set_value(const char_t* rhs);
+		bool set_value(const bool rhs);
+
+	#ifndef PUGIXML_NO_STL
+		template <typename T> bool set_value(const T& rhs)
+		{
+			if (!std::is_arithmetic<T>::value)
+				return false;
+
+#	ifdef PUGIXML_WCHAR_MODE
+			const string_t& _str = std::to_wstring(rhs);
+#	else
+			const string_t& _str = std::to_string(rhs);
+#	endif
+			return set_value(_str.c_str());
+		}
+	#endif
 
 		// Add attribute with specified name. Returns added attribute, or empty attribute on errors.
 		xml_attribute append_attribute(const char_t* name);

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -489,6 +489,7 @@ namespace pugi
 		bool operator>=(const xml_node& r) const;
 
 		xml_node operator[](const char_t* name_);
+		xml_node& operator=(const char_t* rhs);
 
 		// Check if node is empty.
 		bool empty() const;

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -488,6 +488,8 @@ namespace pugi
 		bool operator<=(const xml_node& r) const;
 		bool operator>=(const xml_node& r) const;
 
+		xml_node operator[](const char_t* name_);
+
 		// Check if node is empty.
 		bool empty() const;
 


### PR DESCRIPTION
Hello, 
I am a user who is using `pugixml` well. Thank you for managing very useful library.

Currently, to configure `xml_node` (add a new node or set a value, call each API (`append_child()` or `set_values()`).
If repeatedly insert xml_node, `operator[]` may be more useful than using this function. 
And in case of setting a value, `set_value()` can be specified only as string data.

This PR modifies to override operator to make more useful when configure xml_node.

Considering that `xml` is configured as below:

```cpp
pugi::xml_document doc;

pugi::xml_node root = doc.append_child("nodeA")
                         .append_child("nodeB")
                         .append_child("nodeC");

pugi::xml_node node = root.append_child("node00");
root.append_child(pugi::node_pcdata).set_value(std::to_string(1234).c_str());

node = root.append_child("node10");
node.append_child(pugi::node_pcdata).set_value(std::to_string(3.14).c_str());

node = root.append_child("node20");
node.append_child(pugi::node_pcdata).set_value(std::to_string(false).c_str());

node = root.append_child("node30");
node.append_child(pugi::node_pcdata).set_value("last");
```

The code to aboves is equivalent to:

```cpp
pugi::xml_document doc;
pugi::xml_node root = doc["nodeA"]["nodeB"]["nodeC"];

root["node00"] = 1234;
root["node10"] = 3.14;
root["node20"] = false;
root["node30"] = "last";
```

