### PR TITLE
#342 escape non-ascii characters too

### DIFF
--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -259,6 +259,9 @@ namespace pugi
 	// Use single quotes ' instead of double quotes " for enclosing attribute values. This flag is off by default.
 	const unsigned int format_attribute_single_quote = 0x200;
 
+	// Escape non-ascii attribute values and PCDATA contents. This flag is off by default.
+	const unsigned int format_escape_nonascii = 0x400;
+
 	// The default set of formatting flags.
 	// Nodes are indented depending on their depth in DOM tree, a default declaration is output if document has none.
 	const unsigned int format_default = format_indent;

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -58,6 +58,11 @@ bool test_node(const pugi::xml_node& node, const pugi::char_t* contents, const p
 
 	node.print(writer, indent, flags, get_native_encoding());
 
+	if (writer.as_string() != contents)
+	{
+		printf("found: %s\n", writer.as_string().c_str());
+	}
+
 	return writer.as_string() == contents;
 }
 

--- a/tests/test_write.cpp
+++ b/tests/test_write.cpp
@@ -188,13 +188,28 @@ TEST(write_doctype_null)
 	CHECK_NODE(doc, STR("<!DOCTYPE>"));
 }
 
-TEST_XML(write_escape, "<node attr=''>text</node>")
+TEST_XML(write_escape_1, "<node attr=''>text</node>")
 {
 	doc.child(STR("node")).attribute(STR("attr")) = STR("<>'\"&\x04\r\n\t");
 	doc.child(STR("node")).first_child().set_value(STR("<>'\"&\x04\r\n\t"));
 
 	CHECK_NODE(doc, STR("<node attr=\"&lt;>'&quot;&amp;&#04;&#13;&#10;&#09;\">&lt;&gt;'\"&amp;&#04;\r\n\t</node>"));
+}
+
+TEST_XML(write_escape_2, "<node attr=''>text</node>")
+{
+	doc.child(STR("node")).attribute(STR("attr")) = STR("<>'\"&\x04\r\n\t");
+	doc.child(STR("node")).first_child().set_value(STR("<>'\"&\x04\r\n\t"));
+
 	CHECK_NODE_EX(doc, STR("<node attr='&lt;>&apos;\"&amp;&#04;&#13;&#10;&#09;'>&lt;&gt;'\"&amp;&#04;\r\n\t</node>"), STR(""), format_raw | format_attribute_single_quote);
+}
+
+TEST_XML(write_escape_3, "<node attr=''>text</node>")
+{
+	doc.child(STR("node")).attribute(STR("attr")) = STR("<>'\"&äöü");
+	doc.child(STR("node")).first_child().set_value(STR("<>'\"&äöü"));
+
+	CHECK_NODE_EX(doc, STR("<node attr=\"&lt;&gt;'&quot;&amp;&#228;&#246;&#252;\">&lt;&gt;'&quot;&amp;&#228;&#246;&#252;</node>"), STR(""), format_raw | format_escape_nonascii);
 }
 
 TEST_XML(write_escape_roundtrip, "<node attr=''>text</node>")


### PR DESCRIPTION
see #342 

Things to discuss first:
- I am not sure sure with the name of the flag format_escape_nonascii
- Should format_escape_nonascii be on by default and we add a no flag? Other xml libs (e.g. Python's xml.etree.cElementTree) are doing this.