### PR TITLE
Fix debug postfix in pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,16 @@ write_basic_package_version_file(
   "${PROJECT_BINARY_DIR}/pugixml-config-version.cmake"
   COMPATIBILITY SameMajorVersion)
 
+if (USE_POSTFIX)
+  if(CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
+    set(LIB_POSTFIX ${CMAKE_RELWITHDEBINFO_POSTFIX})
+  elseif(CMAKE_BUILD_TYPE MATCHES MinSizeRel)
+    set(LIB_POSTFIX ${CMAKE_MINSIZEREL_POSTFIX})
+  elseif(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(LIB_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+  endif()
+endif()
+
 configure_file(scripts/pugixml.pc.in pugixml.pc @ONLY)
 
 if (NOT DEFINED PUGIXML_RUNTIME_COMPONENT)

--- a/scripts/pugixml.pc.in
+++ b/scripts/pugixml.pc.in
@@ -8,4 +8,4 @@ Description: Light-weight, simple and fast XML parser for C++ with XPath support
 URL: https://pugixml.org/
 Version: @pugixml_VERSION@
 Cflags: -I${includedir}
-Libs: -L${libdir} -lpugixml
+Libs: -L${libdir} -lpugixml@LIB_POSTFIX@


### PR DESCRIPTION
In case of `USE_POSTFIX`, the `POSTFIX` is dependent
on the `CMAKE_BUILD_TYPE`.
Use the correct `POSTFIX` also in the generated **`pugixml.pc`** file.

This results in the following contents of **`pugixml.pc`**:
- Release:
`  Libs: -L${libdir} -lpugixml`
- RelWithDebInfo
`  Libs: -L${libdir} -lpugixml_r`
- MinSizeRel:
`  Libs: -L${libdir} -lpugixml_m`
- Debug:
`  Libs: -L${libdir} -lpugixml_d`