### PR TITLE
XPath: Fix stack overflow in functions with long argument lists

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -11541,6 +11541,8 @@ PUGI__NS_BEGIN
 					return error("Unrecognized function call");
 				_lexer.next();
 
+				size_t old_depth = _depth;
+
 				while (_lexer.current() != lex_close_brace)
 				{
 					if (argc > 0)
@@ -11549,6 +11551,9 @@ PUGI__NS_BEGIN
 							return error("No comma between function arguments");
 						_lexer.next();
 					}
+
+					if (++_depth > xpath_ast_depth_limit)
+						return error_rec();
 
 					xpath_ast_node* n = parse_expression();
 					if (!n) return 0;
@@ -11561,6 +11566,8 @@ PUGI__NS_BEGIN
 				}
 
 				_lexer.next();
+
+				_depth = old_depth;
 
 				return parse_function(function, argc, args);
 			}

--- a/tests/test_xpath_parse.cpp
+++ b/tests/test_xpath_parse.cpp
@@ -401,6 +401,7 @@ TEST(xpath_parse_depth_limit)
 	CHECK_XPATH_FAIL((STR("/foo") + rep(STR("[1]"), limit)).c_str());
 	CHECK_XPATH_FAIL((STR("/foo") + rep(STR("/x"), limit)).c_str());
 	CHECK_XPATH_FAIL((STR("1") + rep(STR("+1"), limit)).c_str());
+	CHECK_XPATH_FAIL((STR("concat(") + rep(STR("1,"), limit) + STR("1)")).c_str());
 }
 
 TEST_XML(xpath_parse_location_path, "<node><child/></node>")


### PR DESCRIPTION
Function call arguments are stored in a list which is processed
recursively during optimize(). We now limit the depth of this construct
as well to make sure optimize() doesn't run out of stack space.

Technically optimize() could use a stackless traversal for _next pointer,
but it only seems to meaningfully affect concat and predicate list, so it's
probably better to treat all links as recursive uniformly for now.