### PR TITLE
cmake: avoid ALIAS target

### DIFF
--- a/scripts/pugixml-config.cmake.in
+++ b/scripts/pugixml-config.cmake.in
@@ -6,5 +6,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/pugixml-targets.cmake")
 # version or not requesting one at all), provide the old imported target name
 # for compatibility.
 if (NOT DEFINED PACKAGE_FIND_VERSION OR PACKAGE_FIND_VERSION VERSION_LESS "1.11")
-  add_library(pugixml ALIAS pugixml::pugixml)
+  add_library(pugixml INTERFACE IMPORTED)
+  target_link_libraries(pugixml INTERFACE pugixml::pugixml)
 endif ()


### PR DESCRIPTION
This is not allowed on IMPORTED targets.

---
@randyfan Sorry about that. Thanks for the report. I thought I had tested it, but apparently not.

@zeux 1.11.2 it appears :/ .