### PR TITLE
Fix compatibility issue with CMake 3.10

### DIFF
--- a/scripts/pugixml-config.cmake.in
+++ b/scripts/pugixml-config.cmake.in
@@ -7,5 +7,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/pugixml-targets.cmake")
 # for compatibility.
 if (NOT DEFINED PACKAGE_FIND_VERSION OR PACKAGE_FIND_VERSION VERSION_LESS "1.11")
   add_library(pugixml INTERFACE IMPORTED)
-  target_link_libraries(pugixml INTERFACE pugixml::pugixml)
+  # Equivalent to target_link_libraries INTERFACE, but compatible with CMake 3.10
+  set_target_properties(pugixml PROPERTIES INTERFACE_LINK_LIBRARIES pugixml::pugixml)
 endif ()


### PR DESCRIPTION
target_link_libraries/INTERFACE doesn't seem to work on CMake 3.10, but
directly setting the property does work.

Fixes #390.