### PR TITLE
Don't define pugixml import target if it already exists

### DIFF
--- a/scripts/pugixml-config.cmake.in
+++ b/scripts/pugixml-config.cmake.in
@@ -5,7 +5,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/pugixml-targets.cmake")
 # If the user is not requiring 1.11 (either by explicitly requesting an older
 # version or not requesting one at all), provide the old imported target name
 # for compatibility.
-if (NOT DEFINED PACKAGE_FIND_VERSION OR PACKAGE_FIND_VERSION VERSION_LESS "1.11")
+if (NOT TARGET pugixml AND (NOT DEFINED PACKAGE_FIND_VERSION OR PACKAGE_FIND_VERSION VERSION_LESS "1.11"))
   add_library(pugixml INTERFACE IMPORTED)
   # Equivalent to target_link_libraries INTERFACE, but compatible with CMake 3.10
   set_target_properties(pugixml PROPERTIES INTERFACE_LINK_LIBRARIES pugixml::pugixml)


### PR DESCRIPTION
This fixes duplicate target definition errors when find_package(pugixml)
is called twice in a build.

Fixes #393.