### PR TITLE
Add PUGIXML as prefix to CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ cmake_dependent_option(PUGIXML_BUILD_TESTS
   "Build pugixml tests" OFF
   "BUILD_TESTING;CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
+# Custom build defines
+set(PUGIXML_BUILD_DEFINES CACHE STRING "Build defines")
+
 option(PUGIXML_BUILD_SHARED_AND_STATIC_LIBS "Build both shared and static libraries" OFF)
  
  # Expose option to build PUGIXML as static even when the global BUILD_SHARED_LIBS variable is set
@@ -42,6 +45,12 @@ endif()
 
 if (NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
+endif()
+
+if (DEFINED PUGIXML_BUILD_DEFINES)
+  foreach(DEFINE ${PUGIXML_BUILD_DEFINES})
+    add_definitions("-D" ${DEFINE})
+  endforeach()
 endif()
 
 if (PUGIXML_USE_POSTFIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,32 +7,33 @@ include(GNUInstallDirs)
 include(CTest)
 
 
-cmake_dependent_option(USE_VERSIONED_LIBDIR
+cmake_dependent_option(PUGIXML_USE_VERSIONED_LIBDIR
   "Use a private subdirectory to install the headers and libraries" OFF
   "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
-cmake_dependent_option(USE_POSTFIX
+cmake_dependent_option(PUGIXML_USE_POSTFIX
   "Use separate postfix for each configuration to make sure you can install multiple build outputs" OFF
   "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
-cmake_dependent_option(STATIC_CRT
+cmake_dependent_option(PUGIXML_STATIC_CRT
   "Use static MSVC RT libraries" OFF
   "MSVC" OFF)
 
-cmake_dependent_option(BUILD_TESTS
+cmake_dependent_option(PUGIXML_BUILD_TESTS
   "Build pugixml tests" OFF
   "BUILD_TESTING;CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
-option(BUILD_SHARED_AND_STATIC_LIBS "Build both shared and static libraries" OFF)
- # Technically not needed for this file. This is builtin.
-option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF) 
-
-set(BUILD_DEFINES CACHE STRING "Build defines")
+option(PUGIXML_BUILD_SHARED_AND_STATIC_LIBS "Build both shared and static libraries" OFF)
+ 
+ # Expose option to build PUGIXML as static even when the global BUILD_SHARED_LIBS variable is set
+cmake_dependent_option(PUGIXML_BUILD_SHARED_LIBS 
+  "Build shared instead of static library" OFF
+  "BUILD_SHARED_LIBS" ON)
 
 # This is used to backport a CMake 3.15 feature, but is also forwards compatible
 if (NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
   set(CMAKE_MSVC_RUNTIME_LIBRARY
-    MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<NOT:$<BOOL:${STATIC_CRT}>>:DLL>)
+    MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<NOT:$<BOOL:${PUGIXML_STATIC_CRT}>>:DLL>)
 endif()
 
 if (NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
@@ -43,7 +44,7 @@ if (NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
 endif()
 
-if (USE_POSTFIX)
+if (PUGIXML_USE_POSTFIX)
   set(CMAKE_RELWITHDEBINFO_POSTFIX _r)
   set(CMAKE_MINSIZEREL_POSTFIX _m)
   set(CMAKE_DEBUG_POSTFIX _d)
@@ -64,11 +65,11 @@ if (CMAKE_VERSION VERSION_LESS 3.15)
   set(msvc-rt-mt-static $<${msvc-rt-mt-static}:-MT>)
 endif()
 
-set(versioned-dir $<$<BOOL:${USE_VERSIONED_LIBDIR}>:/pugixml-${PROJECT_VERSION}>)
+set(versioned-dir $<$<BOOL:${PUGIXML_USE_VERSIONED_LIBDIR}>:/pugixml-${PROJECT_VERSION}>)
 
 set(libs)
 
-if (BUILD_SHARED_LIBS OR BUILD_SHARED_AND_STATIC_LIBS)
+if (PUGIXML_BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
   add_library(pugixml-shared SHARED
     ${PROJECT_SOURCE_DIR}/scripts/pugixml_dll.rc
     ${PROJECT_SOURCE_DIR}/src/pugixml.cpp)
@@ -90,7 +91,7 @@ if (BUILD_SHARED_LIBS OR BUILD_SHARED_AND_STATIC_LIBS)
       ${msvc-rt-mt-static})
 endif()
 
-if (NOT BUILD_SHARED_LIBS OR BUILD_SHARED_AND_STATIC_LIBS)
+if (NOT PUGIXML_BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
   add_library(pugixml-static STATIC
     ${PROJECT_SOURCE_DIR}/src/pugixml.cpp)
   add_library(pugixml::static ALIAS pugixml-static)
@@ -108,7 +109,7 @@ if (NOT BUILD_SHARED_LIBS OR BUILD_SHARED_AND_STATIC_LIBS)
       ${msvc-rt-mt-static})
 endif()
 
-if (BUILD_SHARED_LIBS)
+if (PUGIXML_BUILD_SHARED_LIBS)
   set(pugixml-alias pugixml-shared)
 else()
   set(pugixml-alias pugixml-static)
@@ -142,7 +143,7 @@ write_basic_package_version_file(
   "${PROJECT_BINARY_DIR}/pugixml-config-version.cmake"
   COMPATIBILITY SameMajorVersion)
 
-if (USE_POSTFIX)
+if (PUGIXML_USE_POSTFIX)
   if(CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
     set(LIB_POSTFIX ${CMAKE_RELWITHDEBINFO_POSTFIX})
   elseif(CMAKE_BUILD_TYPE MATCHES MinSizeRel)
@@ -199,7 +200,7 @@ install(
   DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}${versioned-dir} COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
 
-if (BUILD_TESTS)
+if (PUGIXML_BUILD_TESTS)
   set(fuzz-pattern "tests/fuzz_*.cpp")
   set(test-pattern "tests/*.cpp")
   if (CMAKE_VERSION VERSION_GREATER 3.11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,13 @@ cmake_dependent_option(PUGIXML_BUILD_TESTS
 set(PUGIXML_BUILD_DEFINES CACHE STRING "Build defines for custom options")
 separate_arguments(PUGIXML_BUILD_DEFINES)
 
-option(PUGIXML_BUILD_SHARED_AND_STATIC_LIBS "Build both shared and static libraries" OFF)
- 
- # Expose option to build PUGIXML as static even when the global BUILD_SHARED_LIBS variable is set
-cmake_dependent_option(PUGIXML_BUILD_SHARED_LIBS 
-  "Build shared instead of static library" OFF
-  "BUILD_SHARED_LIBS" ON)
+# Technically not needed for this file. This is builtin CMAKE global variable.
+option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF) 
+
+# Expose option to build PUGIXML as static as well when the global BUILD_SHARED_LIBS variable is set
+cmake_dependent_option(PUGIXML_BUILD_SHARED_AND_STATIC_LIBS
+  "Build both shared and static libraries" OFF
+  "BUILD_SHARED_LIBS" OFF)
 
 # This is used to backport a CMake 3.15 feature, but is also forwards compatible
 if (NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
@@ -73,7 +74,7 @@ set(versioned-dir $<$<BOOL:${PUGIXML_USE_VERSIONED_LIBDIR}>:/pugixml-${PROJECT_V
 
 set(libs)
 
-if (PUGIXML_BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
+if (BUILD_SHARED_LIBS)
   add_library(pugixml-shared SHARED
     ${PROJECT_SOURCE_DIR}/scripts/pugixml_dll.rc
     ${PROJECT_SOURCE_DIR}/src/pugixml.cpp)
@@ -97,7 +98,7 @@ if (PUGIXML_BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
       ${msvc-rt-mt-static})
 endif()
 
-if (NOT PUGIXML_BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
+if (NOT BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
   add_library(pugixml-static STATIC
     ${PROJECT_SOURCE_DIR}/src/pugixml.cpp)
   add_library(pugixml::static ALIAS pugixml-static)
@@ -118,7 +119,7 @@ if (NOT PUGIXML_BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
       ${msvc-rt-mt-static})
 endif()
 
-if (PUGIXML_BUILD_SHARED_LIBS)
+if (BUILD_SHARED_LIBS)
   set(pugixml-alias pugixml-shared)
 else()
   set(pugixml-alias pugixml-static)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,8 @@ cmake_dependent_option(PUGIXML_BUILD_TESTS
   "BUILD_TESTING;CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
 # Custom build defines
-set(PUGIXML_BUILD_DEFINES CACHE STRING "Build defines")
+set(PUGIXML_BUILD_DEFINES CACHE STRING "Build defines for custom options")
+separate_arguments(PUGIXML_BUILD_DEFINES)
 
 option(PUGIXML_BUILD_SHARED_AND_STATIC_LIBS "Build both shared and static libraries" OFF)
  
@@ -45,12 +46,6 @@ endif()
 
 if (NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
-endif()
-
-if (DEFINED PUGIXML_BUILD_DEFINES)
-  foreach(DEFINE ${PUGIXML_BUILD_DEFINES})
-    add_definitions("-D" ${DEFINE})
-  endforeach()
 endif()
 
 if (PUGIXML_USE_POSTFIX)
@@ -90,6 +85,8 @@ if (PUGIXML_BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
     PUBLIC
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
   target_compile_definitions(pugixml-shared
+    PUBLIC
+      ${PUGIXML_BUILD_DEFINES}
     PRIVATE
       $<$<CXX_COMPILER_ID:MSVC>:PUGIXML_API=__declspec\(dllexport\)>)
   target_compile_options(pugixml-shared
@@ -110,6 +107,9 @@ if (NOT PUGIXML_BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
   target_include_directories(pugixml-static
     PUBLIC
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+    target_compile_definitions(pugixml-static
+    PUBLIC
+      ${PUGIXML_BUILD_DEFINES})
   target_compile_options(pugixml-static
     PRIVATE
       ${msvc-rt-mtd-shared}


### PR DESCRIPTION
Added PUGIXML as prefix to all CMake options to avoid naming collisions
with downstream projects.

Removed the cached variable BUILD_DEFINES, since it was unused.