### PR TITLE
add empty method

### DIFF
--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -312,6 +312,8 @@ namespace pugi
 		It begin() const { return _begin; }
 		It end() const { return _end; }
 
+		bool empty() const { return _begin == _end; }
+
 	private:
 		It _begin, _end;
 	};


### PR DESCRIPTION
Simple and allows to avoid using std::distance.

Signed-off-by: Rosen Penev <rosenp@gmail.com>