### PR TITLE
Fix include in test_document.cpp when building against libc++

### DIFF
--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -22,12 +22,11 @@
 #	include <stdexcept>
 #endif
 
-#ifdef __MINGW32__
-#	include <io.h> // for unlink in C++0x mode
-#endif
-
-#if defined(__CELLOS_LV2__) || defined(ANDROID) || defined(_GLIBCXX_HAVE_UNISTD_H) || defined(__APPLE__)
-#	include <unistd.h> // for unlink
+// for unlink
+#ifdef _WIN32
+#	include <io.h>
+#else
+#	include <unistd.h>
 #endif
 
 using namespace pugi;


### PR DESCRIPTION
The _GLIBCXX_HAVE_UNISTD_H relies on pugixml and its tests being built against libstdc++, with LLVM's libc++ this won't be defined. On modern compilers/preprocessors, luckily we can test for includes.

We do so here to include the needed header for unlink, when a) not building for mingw b) we have the __has_include preprocessor facility available and c) the header is in fact available