### PR TITLE
[WIP] string_view support

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5694,7 +5694,7 @@ namespace pugi
 		return impl::strcpy_insitu(_root->value, _root->header, impl::xml_memory_page_value_allocated_mask, rhs.data(), rhs.length());
 	}
 
-	PUGI__FN xml_attribute xml_node::append_attribute(const char_t* name_)
+	PUGI__FN xml_attribute xml_node::append_attribute(string_view name_)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 
@@ -5711,7 +5711,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::prepend_attribute(const char_t* name_)
+	PUGI__FN xml_attribute xml_node::prepend_attribute(string_view name_)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 
@@ -5728,7 +5728,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::insert_attribute_after(const char_t* name_, const xml_attribute& attr)
+	PUGI__FN xml_attribute xml_node::insert_attribute_after(string_view name_, const xml_attribute& attr)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
@@ -5746,7 +5746,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::insert_attribute_before(const char_t* name_, const xml_attribute& attr)
+	PUGI__FN xml_attribute xml_node::insert_attribute_before(string_view name_, const xml_attribute& attr)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
@@ -5904,7 +5904,7 @@ namespace pugi
 		return n;
 	}
 
-	PUGI__FN xml_node xml_node::append_child(const char_t* name_)
+	PUGI__FN xml_node xml_node::append_child(string_view name_)
 	{
 		xml_node result = append_child(node_element);
 
@@ -5913,7 +5913,7 @@ namespace pugi
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::prepend_child(const char_t* name_)
+	PUGI__FN xml_node xml_node::prepend_child(string_view name_)
 	{
 		xml_node result = prepend_child(node_element);
 
@@ -5922,7 +5922,7 @@ namespace pugi
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::insert_child_after(const char_t* name_, const xml_node& node)
+	PUGI__FN xml_node xml_node::insert_child_after(string_view name_, const xml_node& node)
 	{
 		xml_node result = insert_child_after(node_element, node);
 
@@ -5931,7 +5931,7 @@ namespace pugi
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::insert_child_before(const char_t* name_, const xml_node& node)
+	PUGI__FN xml_node xml_node::insert_child_before(string_view name_, const xml_node& node)
 	{
 		xml_node result = insert_child_before(node_element, node);
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5258,7 +5258,7 @@ namespace pugi
 		return _attr;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(const char_t* rhs)
+	PUGI__FN xml_attribute& xml_attribute::operator=(string_view rhs)
 	{
 		set_value(rhs);
 		return *this;
@@ -5300,7 +5300,7 @@ namespace pugi
 		return *this;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(bool rhs)
+	PUGI__FN xml_attribute& xml_attribute::operator=(boolean rhs)
 	{
 		set_value(rhs);
 		return *this;
@@ -5390,7 +5390,7 @@ namespace pugi
 		return impl::set_value_convert(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, precision);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(bool rhs)
+	PUGI__FN bool xml_attribute::set_value(boolean rhs)
 	{
 		if (!_attr) return false;
 
@@ -6537,11 +6537,11 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN bool xml_text::set(const char_t* rhs)
+	PUGI__FN bool xml_text::set(string_view rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::strcpy_insitu(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, impl::strlength(rhs)) : false;
+		return dn ? impl::strcpy_insitu(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs.data(), rhs.length()) : false;
 	}
 
 	PUGI__FN bool xml_text::set(int rhs)
@@ -6600,7 +6600,7 @@ namespace pugi
 		return dn ? impl::set_value_convert(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, precision) : false;
 	}
 
-	PUGI__FN bool xml_text::set(bool rhs)
+	PUGI__FN bool xml_text::set(boolean rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
@@ -6623,7 +6623,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN xml_text& xml_text::operator=(const char_t* rhs)
+	PUGI__FN xml_text& xml_text::operator=(string_view rhs)
 	{
 		set(rhs);
 		return *this;
@@ -6665,7 +6665,7 @@ namespace pugi
 		return *this;
 	}
 
-	PUGI__FN xml_text& xml_text::operator=(bool rhs)
+	PUGI__FN xml_text& xml_text::operator=(boolean rhs)
 	{
 		set(rhs);
 		return *this;

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4648,18 +4648,18 @@ PUGI__NS_BEGIN
 
 	// set value with conversion functions
 	template <typename String, typename Header>
-	PUGI__FN bool set_value_ascii(String& dest, Header& header, uintptr_t header_mask, char* buf)
+	PUGI__FN bool set_value_ascii(String& dest, Header& header, uintptr_t header_mask, char* buf, size_t len)
 	{
 	#ifdef PUGIXML_WCHAR_MODE
 		char_t wbuf[128];
-		assert(strlen(buf) < sizeof(wbuf) / sizeof(wbuf[0]));
+		assert(len < sizeof(wbuf) / sizeof(wbuf[0]));
 
 		size_t offset = 0;
 		for (; buf[offset]; ++offset) wbuf[offset] = buf[offset];
 
 		return strcpy_insitu(dest, header, header_mask, wbuf, offset);
 	#else
-		return strcpy_insitu(dest, header, header_mask, buf, strlen(buf));
+		return strcpy_insitu(dest, header, header_mask, buf, len);
 	#endif
 	}
 
@@ -4677,18 +4677,18 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, float value, int precision)
 	{
 		char buf[128];
-		PUGI__SNPRINTF(buf, "%.*g", precision, double(value));
+		int n = PUGI__SNPRINTF(buf, "%.*g", precision, double(value));
 
-		return set_value_ascii(dest, header, header_mask, buf);
+		return set_value_ascii(dest, header, header_mask, buf, n);
 	}
 
 	template <typename String, typename Header>
 	PUGI__FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, double value, int precision)
 	{
 		char buf[128];
-		PUGI__SNPRINTF(buf, "%.*g", precision, value);
+		int n = PUGI__SNPRINTF(buf, "%.*g", precision, value);
 
-		return set_value_ascii(dest, header, header_mask, buf);
+		return set_value_ascii(dest, header, header_mask, buf, n);
 	}
 
 	template <typename String, typename Header>

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5320,18 +5320,18 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN bool xml_attribute::set_name(const char_t* rhs)
+	PUGI__FN bool xml_attribute::set_name(string_view rhs)
 	{
 		if (!_attr) return false;
 
-		return impl::strcpy_insitu(_attr->name, _attr->header, impl::xml_memory_page_name_allocated_mask, rhs, impl::strlength(rhs));
+		return impl::strcpy_insitu(_attr->name, _attr->header, impl::xml_memory_page_name_allocated_mask, rhs.data(), rhs.length());
 	}
 
-	PUGI__FN bool xml_attribute::set_value(const char_t* rhs)
+	PUGI__FN bool xml_attribute::set_value(string_view rhs)
 	{
 		if (!_attr) return false;
 
-		return impl::strcpy_insitu(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, impl::strlength(rhs));
+		return impl::strcpy_insitu(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs.data(), rhs.length());
 	}
 
 	PUGI__FN bool xml_attribute::set_value(int rhs)
@@ -5674,24 +5674,24 @@ namespace pugi
 		return _root && _root->first_child ? xml_node(_root->first_child->prev_sibling_c) : xml_node();
 	}
 
-	PUGI__FN bool xml_node::set_name(const char_t* rhs)
+	PUGI__FN bool xml_node::set_name(string_view rhs)
 	{
 		xml_node_type type_ = _root ? PUGI__NODETYPE(_root) : node_null;
 
 		if (type_ != node_element && type_ != node_pi && type_ != node_declaration)
 			return false;
 
-		return impl::strcpy_insitu(_root->name, _root->header, impl::xml_memory_page_name_allocated_mask, rhs, impl::strlength(rhs));
+		return impl::strcpy_insitu(_root->name, _root->header, impl::xml_memory_page_name_allocated_mask, rhs.data(), rhs.length());
 	}
 
-	PUGI__FN bool xml_node::set_value(const char_t* rhs)
+	PUGI__FN bool xml_node::set_value(string_view rhs)
 	{
 		xml_node_type type_ = _root ? PUGI__NODETYPE(_root) : node_null;
 
 		if (type_ != node_pcdata && type_ != node_cdata && type_ != node_comment && type_ != node_pi && type_ != node_doctype)
 			return false;
 
-		return impl::strcpy_insitu(_root->value, _root->header, impl::xml_memory_page_value_allocated_mask, rhs, impl::strlength(rhs));
+		return impl::strcpy_insitu(_root->value, _root->header, impl::xml_memory_page_value_allocated_mask, rhs.data(), rhs.length());
 	}
 
 	PUGI__FN xml_attribute xml_node::append_attribute(const char_t* name_)

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5258,7 +5258,7 @@ namespace pugi
 		return _attr;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(string_view rhs)
+	PUGI__FN xml_attribute& xml_attribute::operator=(string_view_t rhs)
 	{
 		set_value(rhs);
 		return *this;
@@ -5320,14 +5320,14 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN bool xml_attribute::set_name(string_view rhs)
+	PUGI__FN bool xml_attribute::set_name(string_view_t rhs)
 	{
 		if (!_attr) return false;
 
 		return impl::strcpy_insitu(_attr->name, _attr->header, impl::xml_memory_page_name_allocated_mask, rhs.data(), rhs.length());
 	}
 
-	PUGI__FN bool xml_attribute::set_value(string_view rhs)
+	PUGI__FN bool xml_attribute::set_value(string_view_t rhs)
 	{
 		if (!_attr) return false;
 
@@ -5674,7 +5674,7 @@ namespace pugi
 		return _root && _root->first_child ? xml_node(_root->first_child->prev_sibling_c) : xml_node();
 	}
 
-	PUGI__FN bool xml_node::set_name(string_view rhs)
+	PUGI__FN bool xml_node::set_name(string_view_t rhs)
 	{
 		xml_node_type type_ = _root ? PUGI__NODETYPE(_root) : node_null;
 
@@ -5684,7 +5684,7 @@ namespace pugi
 		return impl::strcpy_insitu(_root->name, _root->header, impl::xml_memory_page_name_allocated_mask, rhs.data(), rhs.length());
 	}
 
-	PUGI__FN bool xml_node::set_value(string_view rhs)
+	PUGI__FN bool xml_node::set_value(string_view_t rhs)
 	{
 		xml_node_type type_ = _root ? PUGI__NODETYPE(_root) : node_null;
 
@@ -5694,7 +5694,7 @@ namespace pugi
 		return impl::strcpy_insitu(_root->value, _root->header, impl::xml_memory_page_value_allocated_mask, rhs.data(), rhs.length());
 	}
 
-	PUGI__FN xml_attribute xml_node::append_attribute(string_view name_)
+	PUGI__FN xml_attribute xml_node::append_attribute(string_view_t name_)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 
@@ -5711,7 +5711,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::prepend_attribute(string_view name_)
+	PUGI__FN xml_attribute xml_node::prepend_attribute(string_view_t name_)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 
@@ -5728,7 +5728,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::insert_attribute_after(string_view name_, const xml_attribute& attr)
+	PUGI__FN xml_attribute xml_node::insert_attribute_after(string_view_t name_, const xml_attribute& attr)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
@@ -5746,7 +5746,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::insert_attribute_before(string_view name_, const xml_attribute& attr)
+	PUGI__FN xml_attribute xml_node::insert_attribute_before(string_view_t name_, const xml_attribute& attr)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
@@ -5904,7 +5904,7 @@ namespace pugi
 		return n;
 	}
 
-	PUGI__FN xml_node xml_node::append_child(string_view name_)
+	PUGI__FN xml_node xml_node::append_child(string_view_t name_)
 	{
 		xml_node result = append_child(node_element);
 
@@ -5913,7 +5913,7 @@ namespace pugi
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::prepend_child(string_view name_)
+	PUGI__FN xml_node xml_node::prepend_child(string_view_t name_)
 	{
 		xml_node result = prepend_child(node_element);
 
@@ -5922,7 +5922,7 @@ namespace pugi
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::insert_child_after(string_view name_, const xml_node& node)
+	PUGI__FN xml_node xml_node::insert_child_after(string_view_t name_, const xml_node& node)
 	{
 		xml_node result = insert_child_after(node_element, node);
 
@@ -5931,7 +5931,7 @@ namespace pugi
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::insert_child_before(string_view name_, const xml_node& node)
+	PUGI__FN xml_node xml_node::insert_child_before(string_view_t name_, const xml_node& node)
 	{
 		xml_node result = insert_child_before(node_element, node);
 
@@ -6537,7 +6537,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN bool xml_text::set(string_view rhs)
+	PUGI__FN bool xml_text::set(string_view_t rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
@@ -6623,7 +6623,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN xml_text& xml_text::operator=(string_view rhs)
+	PUGI__FN xml_text& xml_text::operator=(string_view_t rhs)
 	{
 		set(rhs);
 		return *this;

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -143,12 +143,12 @@
 // The string_view
 namespace pugi {
 #if defined(PUGI_CXX17_FEATURES) && PUGI_CXX17_FEATURES
-	template <typename C, typename T = std::char_traits<C>>
+	template <typename C, typename T = std::char_traits<C> >
 	using basic_string_view = std::basic_string_view<C, T>;
 	typedef std::string_view string_view;
 	typedef std::wstring_view wstring_view;
 #else
-	template <typename Char, typename Traits = std::char_traits<Char>>
+	template <typename Char, typename Traits = std::char_traits<Char> >
 	struct basic_string_view {
 		std::size_t s;
 		const Char* p;
@@ -231,7 +231,7 @@ namespace pugi {
 		}
 	};
 
-	template <typename Ch, typename Tr = std::char_traits<Ch>>
+	template <typename Ch, typename Tr = std::char_traits<Ch> >
 	struct basic_string_view_hash {
 		typedef basic_string_view<Ch, Tr> argument_type;
 		typedef std::size_t result_type;

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -147,9 +147,6 @@ namespace pugi {
 	using basic_string_view = std::basic_string_view<C, T>;
 	typedef std::string_view string_view;
 	typedef std::wstring_view wstring_view;
-	typedef std::u16string_view u16string_view;
-	typedef std::u32string_view u32string_view;
-	typedef std::hash<std::string_view> string_view_hash;
 #else
 	template <typename Char, typename Traits = std::char_traits<Char>>
 	struct basic_string_view {
@@ -273,11 +270,8 @@ namespace std {
 } // namespace std
 
 namespace pugi {
-	using string_view = basic_string_view<char>;
-	using wstring_view = basic_string_view<wchar_t>;
-	using u16string_view = basic_string_view<char16_t>;
-	using u32string_view = basic_string_view<char32_t>;
-	using string_view_hash = std::hash<string_view>;
+	typedef basic_string_view<char> string_view;
+	typedef basic_string_view<wchar_t> wstring_view;
 #endif
 } // namespace pugi
 

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -262,7 +262,7 @@ namespace pugi {
 
 namespace std {
 	template <typename Ch, typename Tr>
-	struct hash< ::pugi::basic_string_view<Ch, Tr> > : ::pugi::basic_string_view_hash<Ch, Tr> {};
+	struct hash<pugi::basic_string_view<Ch, Tr> > : pugi::basic_string_view_hash<Ch, Tr> {};
 } // namespace std
 
 namespace pugi {

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -230,40 +230,7 @@ namespace pugi {
 			return !(*this == r);
 		}
 	};
-
-	template <typename Ch, typename Tr = std::char_traits<Ch> >
-	struct basic_string_view_hash {
-		typedef basic_string_view<Ch, Tr> argument_type;
-		typedef std::size_t result_type;
-
-		template <typename Al>
-		result_type operator()(const std::basic_string<Ch, Tr, Al>& r) const {
-			return (*this)(argument_type(r.c_str(), r.size()));
-		}
-
-		result_type operator()(const argument_type& r) const {
-			// Modified, from libstdc++
-			// An implementation attempt at Fowler No Voll, 1a.
-			// Supposedly, used in MSVC,
-			// GCC (libstdc++) uses MurmurHash of some sort for 64-bit though...?
-			// But, well. Can't win them all, right?
-			// This should normally only apply when NOT using boost,
-			// so this should almost never be tapped into...
-			std::size_t hash = 0;
-			const unsigned char* cptr = reinterpret_cast<const unsigned char*>(r.data());
-			for (std::size_t sz = r.size(); sz != 0; --sz) {
-				hash ^= static_cast<size_t>(*cptr++);
-				hash *= static_cast<size_t>(1099511628211ULL);
-			}
-			return hash;
-		}
-	};
 } // namespace pugi
-
-namespace std {
-	template <typename Ch, typename Tr>
-	struct hash<pugi::basic_string_view<Ch, Tr> > : pugi::basic_string_view_hash<Ch, Tr> {};
-} // namespace std
 
 namespace pugi {
 	typedef basic_string_view<char> string_view;

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -716,10 +716,10 @@ namespace pugi
 		bool set_value(string_view rhs);
 
 		// Add attribute with specified name. Returns added attribute, or empty attribute on errors.
-		xml_attribute append_attribute(const char_t* name);
-		xml_attribute prepend_attribute(const char_t* name);
-		xml_attribute insert_attribute_after(const char_t* name, const xml_attribute& attr);
-		xml_attribute insert_attribute_before(const char_t* name, const xml_attribute& attr);
+		xml_attribute append_attribute(string_view name);
+		xml_attribute prepend_attribute(string_view name);
+		xml_attribute insert_attribute_after(string_view name, const xml_attribute& attr);
+		xml_attribute insert_attribute_before(string_view name, const xml_attribute& attr);
 
 		// Add a copy of the specified attribute. Returns added attribute, or empty attribute on errors.
 		xml_attribute append_copy(const xml_attribute& proto);
@@ -734,10 +734,10 @@ namespace pugi
 		xml_node insert_child_before(xml_node_type type, const xml_node& node);
 
 		// Add child element with specified name. Returns added node, or empty node on errors.
-		xml_node append_child(const char_t* name);
-		xml_node prepend_child(const char_t* name);
-		xml_node insert_child_after(const char_t* name, const xml_node& node);
-		xml_node insert_child_before(const char_t* name, const xml_node& node);
+		xml_node append_child(string_view name);
+		xml_node prepend_child(string_view name);
+		xml_node insert_child_after(string_view name, const xml_node& node);
+		xml_node insert_child_before(string_view name, const xml_node& node);
 
 		// Add a copy of the specified node as a child. Returns added node, or empty node on errors.
 		xml_node append_copy(const xml_node& proto);

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -38,6 +38,16 @@
 #	include <string>
 #endif
 
+#if (defined(__cplusplus) && __cplusplus == 201703L) || (defined(_MSC_VER) && _MSC_VER > 1900 && ((defined(_HAS_CXX17) && _HAS_CXX17 == 1) || (defined(_MSVC_LANG) && (_MSVC_LANG > 201402L))))
+#ifndef PUGI_CXX17_FEATURES
+#define PUGI_CXX17_FEATURES 1
+#endif // C++17 features macro
+#endif // C++17 features check
+
+#if defined(PUGI_CXX17_FEATURES) && PUGI_CXX17_FEATURES
+#include <string_view>
+#endif // C++17 features
+
 // Macro for deprecated features
 #ifndef PUGIXML_DEPRECATED
 #	if defined(__GNUC__)
@@ -139,6 +149,147 @@ namespace pugi
 	typedef std::basic_string<PUGIXML_CHAR, std::char_traits<PUGIXML_CHAR>, std::allocator<PUGIXML_CHAR> > string_t;
 #endif
 }
+
+// string_view
+namespace pugi {
+#if defined(PUGI_CXX17_FEATURES) && PUGI_CXX17_FEATURES
+	template <typename C, typename T = std::char_traits<C>>
+	using basic_string_view = std::basic_string_view<C, T>;
+	typedef std::string_view string_view;
+	typedef std::wstring_view wstring_view;
+	typedef std::u16string_view u16string_view;
+	typedef std::u32string_view u32string_view;
+	typedef std::hash<std::string_view> string_view_hash;
+#else
+	template <typename Char, typename Traits = std::char_traits<Char>>
+	struct basic_string_view {
+		std::size_t s;
+		const Char* p;
+
+		basic_string_view(const std::string& r)
+			: basic_string_view(r.data(), r.size()) {
+		}
+		basic_string_view(const Char* ptr)
+			: basic_string_view(ptr, Traits::length(ptr)) {
+		}
+		basic_string_view(const Char* ptr, std::size_t sz)
+			: s(sz), p(ptr) {
+		}
+
+		static int compare(const Char* lhs_p, std::size_t lhs_sz, const Char* rhs_p, std::size_t rhs_sz) {
+			int result = Traits::compare(lhs_p, rhs_p, lhs_sz < rhs_sz ? lhs_sz : rhs_sz);
+			if (result != 0)
+				return result;
+			if (lhs_sz < rhs_sz)
+				return -1;
+			if (lhs_sz > rhs_sz)
+				return 1;
+			return 0;
+		}
+
+		const Char* begin() const {
+			return p;
+		}
+
+		const Char* end() const {
+			return p + s;
+		}
+
+		const Char* cbegin() const {
+			return p;
+		}
+
+		const Char* cend() const {
+			return p + s;
+		}
+
+		const Char* data() const {
+			return p;
+		}
+
+		std::size_t size() const {
+			return s;
+		}
+
+		std::size_t length() const {
+			return size();
+		}
+
+		operator std::basic_string<Char, Traits>() const {
+			return std::basic_string<Char, Traits>(data(), size());
+		}
+
+		bool operator==(const basic_string_view& r) const {
+			return compare(p, s, r.data(), r.size()) == 0;
+		}
+
+		bool operator==(const Char* r) const {
+			return compare(r, Traits::length(r), p, s) == 0;
+		}
+
+		bool operator==(const std::basic_string<Char, Traits>& r) const {
+			return compare(r.data(), r.size(), p, s) == 0;
+		}
+
+		bool operator!=(const basic_string_view& r) const {
+			return !(*this == r);
+		}
+
+		bool operator!=(const char* r) const {
+			return !(*this == r);
+		}
+
+		bool operator!=(const std::basic_string<Char, Traits>& r) const {
+			return !(*this == r);
+		}
+	};
+
+	template <typename Ch, typename Tr = std::char_traits<Ch>>
+	struct basic_string_view_hash {
+		typedef basic_string_view<Ch, Tr> argument_type;
+		typedef std::size_t result_type;
+
+		template <typename Al>
+		result_type operator()(const std::basic_string<Ch, Tr, Al>& r) const {
+			return (*this)(argument_type(r.c_str(), r.size()));
+		}
+
+		result_type operator()(const argument_type& r) const {
+#if defined(SOL_USE_BOOST) && SOL_USE_BOOST
+			return boost::hash_range(r.begin(), r.end());
+#else
+			// Modified, from libstdc++
+			// An implementation attempt at Fowler No Voll, 1a.
+			// Supposedly, used in MSVC,
+			// GCC (libstdc++) uses MurmurHash of some sort for 64-bit though...?
+			// But, well. Can't win them all, right?
+			// This should normally only apply when NOT using boost,
+			// so this should almost never be tapped into...
+			std::size_t hash = 0;
+			const unsigned char* cptr = reinterpret_cast<const unsigned char*>(r.data());
+			for (std::size_t sz = r.size(); sz != 0; --sz) {
+				hash ^= static_cast<size_t>(*cptr++);
+				hash *= static_cast<size_t>(1099511628211ULL);
+			}
+			return hash;
+#endif
+		}
+	};
+} // namespace pugi
+
+namespace std {
+	template <typename Ch, typename Tr>
+	struct hash< ::pugi::basic_string_view<Ch, Tr> > : ::pugi::basic_string_view_hash<Ch, Tr> {};
+} // namespace std
+
+namespace pugi {
+	using string_view = basic_string_view<char>;
+	using wstring_view = basic_string_view<wchar_t>;
+	using u16string_view = basic_string_view<char16_t>;
+	using u32string_view = basic_string_view<char32_t>;
+	using string_view_hash = std::hash<string_view>;
+#endif
+} // namespace pugi
 
 // The PugiXML namespace
 namespace pugi
@@ -415,8 +566,8 @@ namespace pugi
 		bool as_bool(bool def = false) const;
 
 		// Set attribute name/value (returns false if attribute is empty or there is not enough memory)
-		bool set_name(const char_t* rhs);
-		bool set_value(const char_t* rhs);
+		bool set_name(string_view rhs);
+		bool set_value(string_view rhs);
 
 		// Set attribute value with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set_value(int rhs);
@@ -549,8 +700,8 @@ namespace pugi
 		const char_t* child_value(const char_t* name) const;
 
 		// Set node name/value (returns false if node is empty, there is not enough memory, or node can not have name/value)
-		bool set_name(const char_t* rhs);
-		bool set_value(const char_t* rhs);
+		bool set_name(string_view rhs);
+		bool set_value(string_view rhs);
 
 		// Add attribute with specified name. Returns added attribute, or empty attribute on errors.
 		xml_attribute append_attribute(const char_t* name);

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -291,6 +291,18 @@ namespace pugi {
 #endif
 } // namespace pugi
 
+// explicit boolean type
+namespace pugi {
+	struct boolean {
+		boolean() : value(false) {}
+		explicit boolean(bool bval) : value(bval) {}
+		bool value;
+		operator bool() const { return value; }
+	};
+	static const boolean true_value{ true };
+	static const boolean false_value{ false };
+}
+
 // The PugiXML namespace
 namespace pugi
 {
@@ -578,7 +590,7 @@ namespace pugi
 		bool set_value(double rhs, int precision);
 		bool set_value(float rhs);
 		bool set_value(float rhs, int precision);
-		bool set_value(bool rhs);
+		bool set_value(boolean rhs);
 
 	#ifdef PUGIXML_HAS_LONG_LONG
 		bool set_value(long long rhs);
@@ -586,14 +598,14 @@ namespace pugi
 	#endif
 
 		// Set attribute value (equivalent to set_value without error checking)
-		xml_attribute& operator=(const char_t* rhs);
+		xml_attribute& operator=(string_view rhs);
 		xml_attribute& operator=(int rhs);
 		xml_attribute& operator=(unsigned int rhs);
 		xml_attribute& operator=(long rhs);
 		xml_attribute& operator=(unsigned long rhs);
 		xml_attribute& operator=(double rhs);
 		xml_attribute& operator=(float rhs);
-		xml_attribute& operator=(bool rhs);
+		xml_attribute& operator=(boolean rhs);
 
 	#ifdef PUGIXML_HAS_LONG_LONG
 		xml_attribute& operator=(long long rhs);
@@ -926,7 +938,7 @@ namespace pugi
 		bool as_bool(bool def = false) const;
 
 		// Set text (returns false if object is empty or there is not enough memory)
-		bool set(const char_t* rhs);
+		bool set(string_view rhs);
 
 		// Set text with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set(int rhs);
@@ -937,7 +949,7 @@ namespace pugi
 		bool set(double rhs, int precision);
 		bool set(float rhs);
 		bool set(float rhs, int precision);
-		bool set(bool rhs);
+		bool set(boolean rhs);
 
 	#ifdef PUGIXML_HAS_LONG_LONG
 		bool set(long long rhs);
@@ -945,14 +957,14 @@ namespace pugi
 	#endif
 
 		// Set text (equivalent to set without error checking)
-		xml_text& operator=(const char_t* rhs);
+		xml_text& operator=(string_view rhs);
 		xml_text& operator=(int rhs);
 		xml_text& operator=(unsigned int rhs);
 		xml_text& operator=(long rhs);
 		xml_text& operator=(unsigned long rhs);
 		xml_text& operator=(double rhs);
 		xml_text& operator=(float rhs);
-		xml_text& operator=(bool rhs);
+		xml_text& operator=(boolean rhs);
 
 	#ifdef PUGIXML_HAS_LONG_LONG
 		xml_text& operator=(long long rhs);

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -284,8 +284,8 @@ namespace pugi {
 		bool value;
 		operator bool() const { return value; }
 	};
-	static const boolean true_value{ true };
-	static const boolean false_value{ false };
+	static const boolean true_value(true);
+	static const boolean false_value(false);
 } // namespace pugi
 
 namespace pugi

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -139,18 +139,8 @@
 #	define PUGIXML_CHAR char
 #endif
 
-namespace pugi
-{
-	// Character type used for all internal storage and operations; depends on PUGIXML_WCHAR_MODE
-	typedef PUGIXML_CHAR char_t;
 
-#ifndef PUGIXML_NO_STL
-	// String type used for operations that work with STL string; depends on PUGIXML_WCHAR_MODE
-	typedef std::basic_string<PUGIXML_CHAR, std::char_traits<PUGIXML_CHAR>, std::allocator<PUGIXML_CHAR> > string_t;
-#endif
-}
-
-// string_view
+// The string_view
 namespace pugi {
 #if defined(PUGI_CXX17_FEATURES) && PUGI_CXX17_FEATURES
 	template <typename C, typename T = std::char_traits<C>>
@@ -291,7 +281,8 @@ namespace pugi {
 #endif
 } // namespace pugi
 
-// explicit boolean type
+// The explicit boolean type to avoid compiler ambiguous match const char_t* as scalar type 'bool',
+// because we preferred compiler match const char_t* as string_view_t
 namespace pugi {
 	struct boolean {
 		boolean() : value(false) {}
@@ -301,6 +292,20 @@ namespace pugi {
 	};
 	static const boolean true_value{ true };
 	static const boolean false_value{ false };
+} // namespace pugi
+
+namespace pugi
+{
+	// Character type used for all internal storage and operations; depends on PUGIXML_WCHAR_MODE
+	typedef PUGIXML_CHAR char_t;
+
+#ifndef PUGIXML_NO_STL
+	// String type used for operations that work with STL string; depends on PUGIXML_WCHAR_MODE
+	typedef std::basic_string<PUGIXML_CHAR, std::char_traits<PUGIXML_CHAR>, std::allocator<PUGIXML_CHAR> > string_t;
+#endif
+
+	// string_view type used for operations that work with pugi::string_view, depends on PUGIXML_WCHAR_MODE
+	typedef pugi::basic_string_view<char_t, std::char_traits<char_t> > string_view_t;
 }
 
 // The PugiXML namespace
@@ -578,8 +583,8 @@ namespace pugi
 		bool as_bool(bool def = false) const;
 
 		// Set attribute name/value (returns false if attribute is empty or there is not enough memory)
-		bool set_name(string_view rhs);
-		bool set_value(string_view rhs);
+		bool set_name(string_view_t rhs);
+		bool set_value(string_view_t rhs);
 
 		// Set attribute value with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set_value(int rhs);
@@ -598,7 +603,7 @@ namespace pugi
 	#endif
 
 		// Set attribute value (equivalent to set_value without error checking)
-		xml_attribute& operator=(string_view rhs);
+		xml_attribute& operator=(string_view_t rhs);
 		xml_attribute& operator=(int rhs);
 		xml_attribute& operator=(unsigned int rhs);
 		xml_attribute& operator=(long rhs);
@@ -712,14 +717,14 @@ namespace pugi
 		const char_t* child_value(const char_t* name) const;
 
 		// Set node name/value (returns false if node is empty, there is not enough memory, or node can not have name/value)
-		bool set_name(string_view rhs);
-		bool set_value(string_view rhs);
+		bool set_name(string_view_t rhs);
+		bool set_value(string_view_t rhs);
 
 		// Add attribute with specified name. Returns added attribute, or empty attribute on errors.
-		xml_attribute append_attribute(string_view name);
-		xml_attribute prepend_attribute(string_view name);
-		xml_attribute insert_attribute_after(string_view name, const xml_attribute& attr);
-		xml_attribute insert_attribute_before(string_view name, const xml_attribute& attr);
+		xml_attribute append_attribute(string_view_t name);
+		xml_attribute prepend_attribute(string_view_t name);
+		xml_attribute insert_attribute_after(string_view_t name, const xml_attribute& attr);
+		xml_attribute insert_attribute_before(string_view_t name, const xml_attribute& attr);
 
 		// Add a copy of the specified attribute. Returns added attribute, or empty attribute on errors.
 		xml_attribute append_copy(const xml_attribute& proto);
@@ -734,10 +739,10 @@ namespace pugi
 		xml_node insert_child_before(xml_node_type type, const xml_node& node);
 
 		// Add child element with specified name. Returns added node, or empty node on errors.
-		xml_node append_child(string_view name);
-		xml_node prepend_child(string_view name);
-		xml_node insert_child_after(string_view name, const xml_node& node);
-		xml_node insert_child_before(string_view name, const xml_node& node);
+		xml_node append_child(string_view_t name);
+		xml_node prepend_child(string_view_t name);
+		xml_node insert_child_after(string_view_t name, const xml_node& node);
+		xml_node insert_child_before(string_view_t name, const xml_node& node);
 
 		// Add a copy of the specified node as a child. Returns added node, or empty node on errors.
 		xml_node append_copy(const xml_node& proto);
@@ -938,7 +943,7 @@ namespace pugi
 		bool as_bool(bool def = false) const;
 
 		// Set text (returns false if object is empty or there is not enough memory)
-		bool set(string_view rhs);
+		bool set(string_view_t rhs);
 
 		// Set text with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set(int rhs);
@@ -957,7 +962,7 @@ namespace pugi
 	#endif
 
 		// Set text (equivalent to set without error checking)
-		xml_text& operator=(string_view rhs);
+		xml_text& operator=(string_view_t rhs);
 		xml_text& operator=(int rhs);
 		xml_text& operator=(unsigned int rhs);
 		xml_text& operator=(long rhs);

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -150,17 +150,17 @@ namespace pugi {
 #else
 	template <typename Char, typename Traits = std::char_traits<Char> >
 	struct basic_string_view {
-		std::size_t s;
 		const Char* p;
-
+		std::size_t s;
+		
 		basic_string_view(const std::string& r)
-			: basic_string_view(r.data(), r.size()) {
+			: p(r.data()), s(r.size()) {
 		}
 		basic_string_view(const Char* ptr)
-			: basic_string_view(ptr, Traits::length(ptr)) {
+			: p(ptr), s(Traits::length(ptr)) {
 		}
 		basic_string_view(const Char* ptr, std::size_t sz)
-			: s(sz), p(ptr) {
+			: p(ptr), s(sz) {
 		}
 
 		static int compare(const Char* lhs_p, std::size_t lhs_sz, const Char* rhs_p, std::size_t rhs_sz) {
@@ -242,9 +242,6 @@ namespace pugi {
 		}
 
 		result_type operator()(const argument_type& r) const {
-#if defined(SOL_USE_BOOST) && SOL_USE_BOOST
-			return boost::hash_range(r.begin(), r.end());
-#else
 			// Modified, from libstdc++
 			// An implementation attempt at Fowler No Voll, 1a.
 			// Supposedly, used in MSVC,
@@ -259,7 +256,6 @@ namespace pugi {
 				hash *= static_cast<size_t>(1099511628211ULL);
 			}
 			return hash;
-#endif
 		}
 	};
 } // namespace pugi

--- a/tests/test_dom_modify.cpp
+++ b/tests/test_dom_modify.cpp
@@ -30,8 +30,8 @@ TEST_XML(dom_attr_assign, "<node/>")
 	node.append_attribute(STR("attr7")) = 0.25f;
 	xml_attribute() = 0.25f;
 
-	node.append_attribute(STR("attr8")) = true;
-	xml_attribute() = true;
+	node.append_attribute(STR("attr8")) = true_value;
+	xml_attribute() = true_value;
 
 	CHECK_NODE(node, STR("<node attr1=\"v1\" attr2=\"-2147483647\" attr3=\"-2147483648\" attr4=\"4294967295\" attr5=\"4294967294\" attr6=\"0.5\" attr7=\"0.25\" attr8=\"true\"/>"));
 }
@@ -67,8 +67,8 @@ TEST_XML(dom_attr_set_value, "<node/>")
 	CHECK(node.append_attribute(STR("attr7")).set_value(0.25f));
 	CHECK(!xml_attribute().set_value(0.25f));
 
-	CHECK(node.append_attribute(STR("attr8")).set_value(true));
-	CHECK(!xml_attribute().set_value(true));
+	CHECK(node.append_attribute(STR("attr8")).set_value(true_value));
+	CHECK(!xml_attribute().set_value(true_value));
 
 	CHECK_NODE(node, STR("<node attr1=\"v1\" attr2=\"-2147483647\" attr3=\"-2147483648\" attr4=\"4294967295\" attr5=\"4294967294\" attr6=\"0.5\" attr7=\"0.25\" attr8=\"true\"/>"));
 }

--- a/tests/test_dom_text.cpp
+++ b/tests/test_dom_text.cpp
@@ -270,7 +270,7 @@ TEST_XML(dom_text_assign, "<node/>")
 	node.append_child(STR("text7")).text() = 0.25f;
 	xml_text() = 0.25f;
 
-	node.append_child(STR("text8")).text() = true;
+	node.append_child(STR("text8")).text() = true_value;
 	xml_text() = true;
 
 	CHECK_NODE(node, STR("<node><text1>v1</text1><text2>-2147483647</text2><text3>-2147483648</text3><text4>4294967295</text4><text5>4294967294</text5><text6>0.5</text6><text7>0.25</text7><text8>true</text8></node>"));
@@ -297,8 +297,8 @@ TEST_XML(dom_text_set_value, "<node/>")
 	CHECK(node.append_child(STR("text7")).text().set(0.25f));
 	CHECK(!xml_text().set(0.25f));
 
-	CHECK(node.append_child(STR("text8")).text().set(true));
-	CHECK(!xml_text().set(true));
+	CHECK(node.append_child(STR("text8")).text().set(true_value));
+	CHECK(!xml_text().set(true_value));
 
 	CHECK_NODE(node, STR("<node><text1>v1</text1><text2>-2147483647</text2><text3>-2147483648</text3><text4>4294967295</text4><text5>4294967294</text5><text6>0.5</text6><text7>0.25</text7><text8>true</text8></node>"));
 }


### PR DESCRIPTION
## Don't needs merge, just a idea
- [x] All string setter function use string_view_t
- [x] API compatible with 1.11.x, but binary incompatible.
- [x] Add explicit boolean type for store bool value as string value `true`, `false` and avoid compiler ambiguous match const char_t* as scalar type 'bool'
- [ ] Add length field to support getter string as string_view_t, it's useful for avoid unnecessary strlen operations, could track this branch: https://github.com/halx99/pugixml/tree/dev