### PR TITLE
Enable usage of nullptr for MSVC 16 and newer (MSVS 2010)

### DIFF
--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -115,6 +115,8 @@
 #ifndef PUGIXML_NULL
 #	if __cplusplus >= 201103
 #		define PUGIXML_NULL nullptr
+#	elif defined(_MSC_VER) && _MSC_VER >= 1600
+#		define PUGIXML_NULL nullptr
 #	else
 #		define PUGIXML_NULL 0
 #	endif


### PR DESCRIPTION
Support for `nullptr` was added with MS Visual Studio 2010 which has `_MSC_VER == 1600`.

[This Microsoft document](https://docs.microsoft.com/en-us/cpp/porting/visual-cpp-what-s-new-2003-through-2015?view=msvc-170#whats-new-for-c-in-visual-studio-2010) states that `nullptr` support was in fact introduced with 2010, the mapping to `_MSC_VER` was taken from [here](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170).