### PR TITLE
Fix exported symbols under clang-cl (Closes #503)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,10 @@ if (BUILD_SHARED_LIBS)
     ${PROJECT_SOURCE_DIR}/src/pugixml.cpp)
   add_library(pugixml::shared ALIAS pugixml-shared)
   list(APPEND libs pugixml-shared)
+  string(CONCAT pugixml.msvc $<OR:
+    $<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},MSVC>,
+    $<CXX_COMPILER_ID:MSVC>
+  >)
 
   set_property(TARGET pugixml-shared PROPERTY EXPORT_NAME shared)
   target_include_directories(pugixml-shared
@@ -111,8 +115,7 @@ if (BUILD_SHARED_LIBS)
       ${PUGIXML_BUILD_DEFINES}
       ${PUGIXML_PUBLIC_DEFINITIONS}
     PRIVATE
-      $<$<CXX_COMPILER_ID:MSVC>:PUGIXML_API=__declspec\(dllexport\)>
-      $<IF:$<CXX_COMPILER_ID:MSVC>,,PUGIXML_API=__attribute__\(\(visibility\("default"\)\)\)>
+      PUGIXML_API=$<IF:${pugixml.msvc},__declspec\(dllexport\),__attribute__\(\(visibility\("default"\)\)\)>
     )
   target_compile_options(pugixml-shared
     PRIVATE


### PR DESCRIPTION
This also turns the define for PUGIXML_API into an `$<IF:>`, instead of an
`$<IF:>` with an empty true condition. If this is inadequate, I will
undo it, and place them on separate lines as they were before, but will
most likely use an inverse `$<NOT:>` instead of an `$<IF:>`.
