### PR TITLE
Fix Xcode 14 sprintf deprecation warning

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -143,6 +143,8 @@ using std::memset;
 #	define PUGI__SNPRINTF(buf, ...) snprintf(buf, sizeof(buf), __VA_ARGS__)
 #elif defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400
 #	define PUGI__SNPRINTF(buf, ...) _snprintf_s(buf, _countof(buf), _TRUNCATE, __VA_ARGS__)
+#elif defined(__APPLE__) && __clang_major__ >= 14 && !defined(__STRICT_ANSI__) // Xcode 14 marks snprintf as deprecated while still using C++98 by default
+#	define PUGI__SNPRINTF(buf, ...) snprintf(buf, sizeof(buf), __VA_ARGS__)
 #else
 #	define PUGI__SNPRINTF sprintf
 #endif

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -143,8 +143,8 @@ using std::memset;
 #	define PUGI__SNPRINTF(buf, ...) snprintf(buf, sizeof(buf), __VA_ARGS__)
 #elif defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400
 #	define PUGI__SNPRINTF(buf, ...) _snprintf_s(buf, _countof(buf), _TRUNCATE, __VA_ARGS__)
-#elif defined(__APPLE__) && __clang_major__ >= 14 && !defined(__STRICT_ANSI__) // Xcode 14 marks snprintf as deprecated while still using C++98 by default
-#	define PUGI__SNPRINTF(buf, ...) snprintf(buf, sizeof(buf), __VA_ARGS__)
+#elif defined(__APPLE__) && __clang_major__ >= 14 // Xcode 14 marks snprintf as deprecated while still using C++98 by default
+#	define PUGI__SNPRINTF(buf, fmt, arg1, arg2) snprintf(buf, sizeof(buf), fmt, arg1, arg2)
 #else
 #	define PUGI__SNPRINTF sprintf
 #endif

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -143,7 +143,7 @@ using std::memset;
 #	define PUGI__SNPRINTF(buf, ...) snprintf(buf, sizeof(buf), __VA_ARGS__)
 #elif defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400
 #	define PUGI__SNPRINTF(buf, ...) _snprintf_s(buf, _countof(buf), _TRUNCATE, __VA_ARGS__)
-#elif defined(__APPLE__) && __clang_major__ >= 14 // Xcode 14 marks snprintf as deprecated while still using C++98 by default
+#elif defined(__APPLE__) && __clang_major__ >= 14 // Xcode 14 marks sprintf as deprecated while still using C++98 by default
 #	define PUGI__SNPRINTF(buf, fmt, arg1, arg2) snprintf(buf, sizeof(buf), fmt, arg1, arg2)
 #else
 #	define PUGI__SNPRINTF sprintf

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -737,7 +737,7 @@ struct temp_file
 	{
 		static int index = 0;
 
-	#if __cplusplus >= 201103
+	#if __cplusplus >= 201103 || defined(__APPLE__) // Xcode 14 warns about use of sprintf in C++98 builds
 		snprintf(path, sizeof(path), "%stempfile%d", test_runner::_temp_path, index++);
 	#else
 		sprintf(path, "%stempfile%d", test_runner::_temp_path, index++);

--- a/tests/test_dom_traverse.cpp
+++ b/tests/test_dom_traverse.cpp
@@ -796,7 +796,7 @@ struct test_walker: xml_tree_walker
 	{
 		char buf[32];
 
-	#if __cplusplus >= 201103
+	#if __cplusplus >= 201103 || defined(__APPLE__) // Xcode 14 warns about use of sprintf in C++98 builds
 		snprintf(buf, sizeof(buf), "%d", depth());
 	#else
 		sprintf(buf, "%d", depth());


### PR DESCRIPTION
We use snprintf when stdc is set to C++11, however in C++98 mode we can't use variadic macros, and Xcode 14 complains about the use of sprintf.

It should be safe however to use variadic macros on any remotely recent version of clang on Apple, unless -pedantic is defined which warns against the use of variadic macros in C++98 mode...

This change fixes the problem for the builds that don't specify -pedantic, which is a problem for another day.