### PR TITLE
Add overloads with size_t type argument

### DIFF
--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -1275,6 +1275,7 @@ As discussed before, nodes can have name and value, both of which are strings. D
 [source]
 ----
 bool xml_node::set_name(const char_t* rhs);
+bool xml_node::set_name(const char_t* rhs, size_t sz)
 bool xml_node::set_value(const char_t* rhs);
 bool xml_node::set_value(const char_t* rhs, size_t size);
 ----
@@ -1297,6 +1298,7 @@ All attributes have name and value, both of which are strings (value may be empt
 [source]
 ----
 bool xml_attribute::set_name(const char_t* rhs);
+bool xml_attribute::set_name(const char_t* rhs, size_t sz)
 bool xml_attribute::set_value(const char_t* rhs);
 bool xml_attribute::set_value(const char_t* rhs, size_t size);
 ----

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5401,6 +5401,13 @@ namespace pugi
 		return impl::strcpy_insitu(_attr->name, _attr->header, impl::xml_memory_page_name_allocated_mask, rhs, impl::strlength(rhs));
 	}
 
+	PUGI_IMPL_FN bool xml_attribute::set_name(const char_t* rhs, size_t sz)
+	{
+		if (!_attr) return false;
+
+		return impl::strcpy_insitu(_attr->name, _attr->header, impl::xml_memory_page_name_allocated_mask, rhs, sz);
+	}
+
 	PUGI_IMPL_FN bool xml_attribute::set_value(const char_t* rhs, size_t sz)
 	{
 		if (!_attr) return false;
@@ -5796,6 +5803,16 @@ namespace pugi
 			return false;
 
 		return impl::strcpy_insitu(_root->name, _root->header, impl::xml_memory_page_name_allocated_mask, rhs, impl::strlength(rhs));
+	}
+
+	PUGI_IMPL_FN bool xml_node::set_name(const char_t* rhs, size_t sz)
+	{
+		xml_node_type type_ = _root ? PUGI_IMPL_NODETYPE(_root) : node_null;
+
+		if (type_ != node_element && type_ != node_pi && type_ != node_declaration)
+			return false;
+
+		return impl::strcpy_insitu(_root->name, _root->header, impl::xml_memory_page_name_allocated_mask, rhs, sz);
 	}
 
 	PUGI_IMPL_FN bool xml_node::set_value(const char_t* rhs, size_t sz)

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -418,6 +418,7 @@ namespace pugi
 
 		// Set attribute name/value (returns false if attribute is empty or there is not enough memory)
 		bool set_name(const char_t* rhs);
+		bool set_name(const char_t* rhs, size_t sz);
 		bool set_value(const char_t* rhs, size_t sz);
 		bool set_value(const char_t* rhs);
 
@@ -553,6 +554,7 @@ namespace pugi
 
 		// Set node name/value (returns false if node is empty, there is not enough memory, or node can not have name/value)
 		bool set_name(const char_t* rhs);
+		bool set_name(const char_t* rhs, size_t sz);
 		bool set_value(const char_t* rhs, size_t sz);
 		bool set_value(const char_t* rhs);
 

--- a/tests/test_dom_modify.cpp
+++ b/tests/test_dom_modify.cpp
@@ -46,6 +46,16 @@ TEST_XML(dom_attr_set_name, "<node attr='value' />")
 	CHECK_NODE(doc, STR("<node n=\"value\"/>"));
 }
 
+TEST_XML(dom_attr_set_name_with_size, "<node attr='value' />")
+{
+	xml_attribute attr = doc.child(STR("node")).attribute(STR("attr"));
+
+	CHECK(attr.set_name(STR("n1234"), 1));
+	CHECK(!xml_attribute().set_name(STR("nfail"), 1));
+
+	CHECK_NODE(doc, STR("<node n=\"value\"/>"));
+}
+
 TEST_XML(dom_attr_set_value, "<node/>")
 {
 	xml_node node = doc.child(STR("node"));
@@ -202,6 +212,15 @@ TEST_XML(dom_node_set_name, "<node>text</node>")
 	CHECK(doc.child(STR("node")).set_name(STR("n")));
 	CHECK(!doc.child(STR("node")).first_child().set_name(STR("n")));
 	CHECK(!xml_node().set_name(STR("n")));
+
+	CHECK_NODE(doc, STR("<n>text</n>"));
+}
+
+TEST_XML(dom_node_set_name_with_size, "<node>text</node>")
+{
+	CHECK(doc.child(STR("node")).set_name(STR("nlongname"), 1));
+	CHECK(!doc.child(STR("node")).first_child().set_name(STR("n42"), 1));
+	CHECK(!xml_node().set_name(STR("nanothername"), 1));
 
 	CHECK_NODE(doc, STR("<n>text</n>"));
 }


### PR DESCRIPTION
* bool xml_attribute::set_name(const char_t* rhs, size_t sz)
* xml_attribute xml_node::append_attribute(const char_t* name_, size_t sz)
* xml_node xml_node::append_child(const char_t* name_, size_t sz)
* xml_attribute xml_node::attribute(const char_t* name_, size_t sz) const
* xml_node xml_node::child(const char_t* name_, size_t sz) const
* bool xml_node::set_name(const char_t* rhs, size_t sz)