### PR TITLE
Fix weak vtable warning regarding xml_writer

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5111,6 +5111,10 @@ PUGI_IMPL_NS_END
 
 namespace pugi
 {
+	PUGI_IMPL_FN xml_writer::~xml_writer()
+	{
+	}
+
 	PUGI_IMPL_FN xml_writer_file::xml_writer_file(void* file_): file(file_)
 	{
 	}

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -324,7 +324,7 @@ namespace pugi
 	class PUGIXML_CLASS xml_writer
 	{
 	public:
-		virtual ~xml_writer() {}
+		virtual ~xml_writer();
 
 		// Write memory chunk into stream/file/whatever
 		virtual void write(const void* data, size_t size) = 0;


### PR DESCRIPTION
Using Apple clang (clang-1400.0.29.202) with `-Wweak-vtables` would produce the following warning:

> 'xml_writer' has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Wweak-vtables]

Using the "defaulted default constructor" prevents this.