### PR TITLE
fuzzer: excersizes query code on xml doc

### DIFF
--- a/tests/fuzz_xpath.cpp
+++ b/tests/fuzz_xpath.cpp
@@ -1,26 +1,40 @@
 #include "../src/pugixml.hpp"
+#include "fuzzer/FuzzedDataProvider.h"
 
 #include <stdint.h>
 #include <string.h>
+#include <string>
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
-{
-	char* text = new char[Size + 1];
-	memcpy(text, Data, Size);
-	text[Size] = 0;
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  FuzzedDataProvider fdp(Data, Size);
+  std::string text = fdp.ConsumeRandomLengthString(1024);
 
-#ifdef PUGIXML_NO_EXCEPTIONS
-	pugi::xpath_query q(text);
-#else
-	try
-	{
-		pugi::xpath_query q(text);
-	}
-	catch (pugi::xpath_exception&)
-	{
-	}
-#endif
+  try {
+    pugi::xpath_variable_set vars;
+    size_t var_count = fdp.ConsumeIntegralInRange<size_t>(0, 50);
+    std::vector<std::string> var_name_storage = {};
+    for (size_t i = 0; i < var_count; i++) {
+      var_name_storage.push_back(fdp.ConsumeRandomLengthString(128));
 
-	delete[] text;
-	return 0;
+      pugi::xpath_value_type value_type =
+          static_cast<pugi::xpath_value_type>(fdp.ConsumeIntegralInRange(0, 5));
+      vars.add(var_name_storage.back().c_str(), value_type);
+    }
+    pugi::xpath_query q(text.c_str(), &vars);
+
+    std::vector<uint8_t> xml_buffer =
+        fdp.ConsumeBytes<uint8_t>(fdp.ConsumeIntegralInRange(0, 1024));
+    pugi::xml_document doc;
+    doc.load_buffer(xml_buffer.data(), xml_buffer.size(), pugi::parse_full);
+
+    bool boolean = q.evaluate_boolean(doc);
+    double num = q.evaluate_number(doc);
+    pugi::string_t s = q.evaluate_string(doc);
+    pugi::xpath_node n = q.evaluate_node(doc);
+    pugi::xpath_node_set set = q.evaluate_node_set(doc);
+
+  } catch (pugi::xpath_exception &) {
+  }
+
+  return 0;
 }

--- a/tests/fuzz_xpath.cpp
+++ b/tests/fuzz_xpath.cpp
@@ -5,36 +5,42 @@
 #include <string.h>
 #include <string>
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
-  FuzzedDataProvider fdp(Data, Size);
-  std::string text = fdp.ConsumeRandomLengthString(1024);
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+	FuzzedDataProvider fdp(Data, Size);
+	std::string text = fdp.ConsumeRandomLengthString(1024);
 
-  try {
-    pugi::xpath_variable_set vars;
-    size_t var_count = fdp.ConsumeIntegralInRange<size_t>(0, 50);
-    std::vector<std::string> var_name_storage = {};
-    for (size_t i = 0; i < var_count; i++) {
-      var_name_storage.push_back(fdp.ConsumeRandomLengthString(128));
+#ifndef PUGIXML_NO_EXCEPTIONS
+	try
+#endif
+	{
+		pugi::xpath_variable_set vars;
+		size_t var_count = fdp.ConsumeIntegralInRange<size_t>(0, 50);
+		std::vector<std::string> var_name_storage;
+		for (size_t i = 0; i < var_count; ++i)
+		{
+			var_name_storage.push_back(fdp.ConsumeRandomLengthString(128));
 
-      pugi::xpath_value_type value_type =
-          static_cast<pugi::xpath_value_type>(fdp.ConsumeIntegralInRange(0, 5));
-      vars.add(var_name_storage.back().c_str(), value_type);
-    }
-    pugi::xpath_query q(text.c_str(), &vars);
+			const int xpath_value_type_count = pugi::xpath_type_boolean + 1;
+			pugi::xpath_value_type value_type = static_cast<pugi::xpath_value_type>(fdp.ConsumeIntegralInRange(0, xpath_value_type_count));
+			vars.add(var_name_storage.back().c_str(), value_type);
+		}
+		pugi::xpath_query q(text.c_str(), &vars);
 
-    std::vector<uint8_t> xml_buffer =
-        fdp.ConsumeBytes<uint8_t>(fdp.ConsumeIntegralInRange(0, 1024));
-    pugi::xml_document doc;
-    doc.load_buffer(xml_buffer.data(), xml_buffer.size(), pugi::parse_full);
+		std::vector<uint8_t> xml_buffer = fdp.ConsumeBytes<uint8_t>(fdp.ConsumeIntegralInRange(0, 1024));
+		pugi::xml_document doc;
+		doc.load_buffer(xml_buffer.data(), xml_buffer.size(), pugi::parse_full);
 
-    bool boolean = q.evaluate_boolean(doc);
-    double num = q.evaluate_number(doc);
-    pugi::string_t s = q.evaluate_string(doc);
-    pugi::xpath_node n = q.evaluate_node(doc);
-    pugi::xpath_node_set set = q.evaluate_node_set(doc);
-
-  } catch (pugi::xpath_exception &) {
-  }
-
-  return 0;
+		bool boolean = q.evaluate_boolean(doc);
+		double num = q.evaluate_number(doc);
+		pugi::string_t s = q.evaluate_string(doc);
+		pugi::xpath_node n = q.evaluate_node(doc);
+		pugi::xpath_node_set set = q.evaluate_node_set(doc);
+	}
+#ifndef PUGIXML_NO_EXCEPTIONS
+	catch (pugi::xpath_exception&)
+	{
+	}
+#endif
+	return 0;
 }

--- a/tests/fuzz_xpath.cpp
+++ b/tests/fuzz_xpath.cpp
@@ -31,11 +31,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
 		pugi::xml_document doc;
 		doc.load_buffer(xml_buffer.data(), xml_buffer.size(), pugi::parse_full);
 
-		bool boolean = q.evaluate_boolean(doc);
-		double num = q.evaluate_number(doc);
-		pugi::string_t s = q.evaluate_string(doc);
-		pugi::xpath_node n = q.evaluate_node(doc);
-		pugi::xpath_node_set set = q.evaluate_node_set(doc);
+		q.evaluate_boolean(doc);
+		q.evaluate_number(doc);
+		q.evaluate_string(doc);
+		q.evaluate_node(doc);
+		q.evaluate_node_set(doc);
 	}
 #ifndef PUGIXML_NO_EXCEPTIONS
 	catch (pugi::xpath_exception&)


### PR DESCRIPTION
This change increases code coverage significantly during fuzzing as it excersizes the query code against an arbitrary file.  I've also updated the fuzzer to use LLVM's FuzzedDataProvider which makes the fuzzer a little easier to understand/reason about.