### PR TITLE
#556 fix makefile err in some env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ defines=standard
 cxxstd=c++11
 # set cxxstd=any to disable use of -std=...
 
-BUILD=build/make-$(CXX)-$(config)-$(defines)-$(cxxstd)
+BUILD=build/make-$(firstword $(CXX))-$(config)-$(defines)-$(cxxstd)
 
 SOURCES=src/pugixml.cpp $(filter-out tests/fuzz_%,$(wildcard tests/*.cpp))
 EXECUTABLE=$(BUILD)/test


### PR DESCRIPTION
Fix the make error by adding `firstword()` wrap for environments with pre-settled switches in `$(CXX)`. 

Fixes #556.