### PR TITLE
build: Fix CMake PUGIXML_STATIC_CRT behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 3.4)
+
+# Policy configuration; this *MUST* be specified before project is defined
+if(POLICY CMP0091)
+    cmake_policy(SET CMP0091 NEW) # Enables use of MSVC_RUNTIME_LIBRARY
+endif()
+
 project(pugixml VERSION 1.13 LANGUAGES CXX)
 
 include(CMakePackageConfigHelpers)
@@ -43,11 +49,6 @@ option(PUGIXML_NO_XPATH "Disable XPath" OFF)
 option(PUGIXML_NO_STL "Disable STL" OFF)
 option(PUGIXML_NO_EXCEPTIONS "Disable Exceptions" OFF)
 mark_as_advanced(PUGIXML_NO_XPATH PUGIXML_NO_STL PUGIXML_NO_EXCEPTIONS)
-
-# Policy configuration
-if(POLICY CMP0091)
-    cmake_policy(SET CMP0091 NEW) # Enables use of MSVC_RUNTIME_LIBRARY
-endif()
 
 set(PUGIXML_PUBLIC_DEFINITIONS
   $<$<BOOL:${PUGIXML_WCHAR_MODE}>:PUGIXML_WCHAR_MODE>


### PR DESCRIPTION
Implementation of PUGIXML_STATIC_CRT for newer CMake versions (3.15+) depend on MSVC_RUNTIME_LIBRARY, but this only works if the policy is defined *before* the project.

Fixes #544.