### PR TITLE
Fix compilation errors on old GCC (2.95.3, 3.3.5)

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -129,6 +129,12 @@ using std::memmove;
 using std::memset;
 #endif
 
+// Old versions of GCC do not define ::malloc and ::free depending on header include order
+#if defined(__GNUC__) && (__GNUC__ < 3 || (__GNUC__ == 3 && __GNUC_MINOR__ < 4))
+using std::malloc;
+using std::free;
+#endif
+
 // Some MinGW/GCC versions have headers that erroneously omit LLONG_MIN/LLONG_MAX/ULLONG_MAX definitions from limits.h in some configurations
 #if defined(PUGIXML_HAS_LONG_LONG) && defined(__GNUC__) && !defined(LLONG_MAX) && !defined(LLONG_MIN) && !defined(ULLONG_MAX)
 #	define LLONG_MIN (-LLONG_MAX - 1LL)
@@ -9950,7 +9956,8 @@ PUGI_IMPL_NS_BEGIN
 
 			xpath_node* last = ns.begin() + first;
 
-			xpath_context c(xpath_node(), 1, size);
+			xpath_node cn;
+			xpath_context c(cn, 1, size);
 
 			double er = expr->eval_number(c, stack);
 


### PR DESCRIPTION
Hi, cannot compile pugixml for old GCC (versions 2.95.3 and 3.3.5). It happened when I try to cross-compile my project for QNX 6.3.2. There is a bug with header files. It can be fixed by reordering (put `<stdlib.h>` above all other headers) or by checking the compiler version. Errors:

```cpp
libs/pugixml/src/pugixml.cpp: In
   function `void* pugi::impl::<unnamed>::default_allocate(unsigned int)':
libs/pugixml/src/pugixml.cpp:195: error: `
   malloc' undeclared (first use this function)
libs/pugixml/src/pugixml.cpp:195: error: (Each
   undeclared identifier is reported only once for each function it appears 
   in.)
libs/pugixml/src/pugixml.cpp: In
   function `void pugi::impl::<unnamed>::default_deallocate(void*)':
libs/pugixml/src/pugixml.cpp:200: error: `
   free' undeclared (first use this function)
```

When the issue with headers is fixed occur others errors:

```cpp
libs/pugixml/src/pugixml.cpp: In
   static member function `static void 
   pugi::impl::<unnamed>::xpath_ast_node::apply_predicate_number_const(pugi::impl::<unnamed>::xpath_node_set_raw&,
   unsigned int, pugi::impl::<unnamed>::xpath_ast_node*, const 
   pugi::impl::<unnamed>::xpath_stack&)':
libs/pugixml/src/pugixml.cpp:9967: error: type
   specifier omitted for parameter
libs/pugixml/src/pugixml.cpp:9967: error: parse
   error before `;' token
libs/pugixml/src/pugixml.cpp:9969: error: no
   matching function for call to `pugi::impl::<unnamed>::xpath_ast_node::
   eval_number(pugi::impl::<unnamed>::xpath_context (&)(...), const 
   pugi::impl::<unnamed>::xpath_stack&)'
libs/pugixml/src/pugixml.cpp:10648: error: candidates
   are: double pugi::impl::<unnamed>::xpath_ast_node::eval_number(const 
   pugi::impl::<unnamed>::xpath_context&, const 
   pugi::impl::<unnamed>::xpath_stack&)
```