### PR TITLE
{cmake} Fix deprecation warning by updating min version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 
 # Policy configuration; this *MUST* be specified before project is defined
 if(POLICY CMP0091)


### PR DESCRIPTION
With CMake 3.27, we get a deprecation warning:

> Compatibility with CMake &lt; 3.5 will be removed from a future version of CMake. Update the VERSION argument &lt;min&gt; value or use a ...&lt;max&gt; suffix to tell CMake that the project does not need compatibility with older versions.

Bump min version to 3.5 to remove warning.