### PR TITLE
build: only include CTest when building the pugixml tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ project(pugixml VERSION 1.14 LANGUAGES CXX)
 include(CMakePackageConfigHelpers)
 include(CMakeDependentOption)
 include(GNUInstallDirs)
-include(CTest)
 
 cmake_dependent_option(PUGIXML_USE_VERSIONED_LIBDIR
   "Use a private subdirectory to install the headers and libraries" OFF
@@ -240,6 +239,7 @@ install(
     ${CMAKE_INSTALL_INCLUDEDIR}${versioned-dir} COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
 
 if (PUGIXML_BUILD_TESTS)
+  include(CTest)
   set(fuzz-pattern "tests/fuzz_*.cpp")
   set(test-pattern "tests/*.cpp")
   if (CMAKE_VERSION VERSION_GREATER 3.11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ cmake_dependent_option(PUGIXML_STATIC_CRT
 
 cmake_dependent_option(PUGIXML_BUILD_TESTS
   "Build pugixml tests" OFF
-  "BUILD_TESTING;CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
 # Custom build defines
 set(PUGIXML_BUILD_DEFINES CACHE STRING "Build defines for custom options")


### PR DESCRIPTION
Currently, the CMakeLists.txt unconditionally includes CTest. As a consequence, BUILD_TESTING is defined by CTest, which has unintended consequences for any project that uses pugixml: a project that has a certain configuration in which the tests are disabled suddenly finds that testing is enabled after including pugixml.

By making include(CTest) conditional on PUGIXML_BUILD_TESTS, BUILD_TESTING is not set anymore in other projects.