### PR TITLE
Added cmake option to disable install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ cmake_dependent_option(PUGIXML_BUILD_SHARED_AND_STATIC_LIBS
 # Expose options from the pugiconfig.hpp
 option(PUGIXML_WCHAR_MODE "Enable wchar_t mode" OFF)
 option(PUGIXML_COMPACT "Enable compact mode" OFF)
+option(PUGIXML_INSTALL "Enable installation rules" ON)
 
 # Advanced options from pugiconfig.hpp
 option(PUGIXML_NO_XPATH "Disable XPath" OFF)
@@ -193,50 +194,53 @@ endif()
 
 configure_file(scripts/pugixml.pc.in pugixml.pc @ONLY)
 
-if (NOT DEFINED PUGIXML_RUNTIME_COMPONENT)
-  set(PUGIXML_RUNTIME_COMPONENT Runtime)
-endif()
-
-if (NOT DEFINED PUGIXML_LIBRARY_COMPONENT)
-  set(PUGIXML_LIBRARY_COMPONENT Library)
-endif()
-
-if (NOT DEFINED PUGIXML_DEVELOPMENT_COMPONENT)
-  set(PUGIXML_DEVELOPMENT_COMPONENT Development)
-endif()
-
-set(namelink-component)
-if (NOT CMAKE_VERSION VERSION_LESS 3.12)
-  set(namelink-component NAMELINK_COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
-endif()
-install(TARGETS ${install-targets}
-  EXPORT pugixml-targets
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${PUGIXML_RUNTIME_COMPONENT}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${PUGIXML_LIBRARY_COMPONENT} ${namelink-component}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT}
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}${versioned-dir})
-
-install(EXPORT pugixml-targets
+export(TARGETS ${install-targets}
   NAMESPACE pugixml::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+  FILE pugixml-targets.cmake)
 
-export(EXPORT pugixml-targets
-  NAMESPACE pugixml::)
+if(PUGIXML_INSTALL)
+  if (NOT DEFINED PUGIXML_RUNTIME_COMPONENT)
+    set(PUGIXML_RUNTIME_COMPONENT Runtime)
+  endif()
 
-install(FILES
-  "${PROJECT_BINARY_DIR}/pugixml-config-version.cmake"
-  "${PROJECT_BINARY_DIR}/pugixml-config.cmake"
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+  if (NOT DEFINED PUGIXML_LIBRARY_COMPONENT)
+    set(PUGIXML_LIBRARY_COMPONENT Library)
+  endif()
 
-install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+  if (NOT DEFINED PUGIXML_DEVELOPMENT_COMPONENT)
+    set(PUGIXML_DEVELOPMENT_COMPONENT Development)
+  endif()
 
-install(
-  FILES
-    "${PROJECT_SOURCE_DIR}/src/pugiconfig.hpp"
-    "${PROJECT_SOURCE_DIR}/src/pugixml.hpp"
-  DESTINATION
-    ${CMAKE_INSTALL_INCLUDEDIR}${versioned-dir} COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+  set(namelink-component)
+  if (NOT CMAKE_VERSION VERSION_LESS 3.12)
+    set(namelink-component NAMELINK_COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+  endif()
+  install(TARGETS ${install-targets}
+    EXPORT pugixml-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${PUGIXML_RUNTIME_COMPONENT}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${PUGIXML_LIBRARY_COMPONENT} ${namelink-component}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}${versioned-dir})
+
+  install(EXPORT pugixml-targets
+    NAMESPACE pugixml::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+
+  install(FILES
+    "${PROJECT_BINARY_DIR}/pugixml-config-version.cmake"
+    "${PROJECT_BINARY_DIR}/pugixml-config.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+
+  install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+
+  install(
+    FILES
+      "${PROJECT_SOURCE_DIR}/src/pugiconfig.hpp"
+      "${PROJECT_SOURCE_DIR}/src/pugixml.hpp"
+    DESTINATION
+      ${CMAKE_INSTALL_INCLUDEDIR}${versioned-dir} COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+endif()
 
 if (PUGIXML_BUILD_TESTS)
   include(CTest)


### PR DESCRIPTION
When pugixml is used as a submodule, installation rules are not required.

Additionally, it may cause issues when pugixml is installed / exported by parent project:
```
CMake Error: install(EXPORT "OpenVINODeveloperTargets" ...) includes target "inference_engine_s" which requires target "pugixml-static" that is not in this export set, but in multiple other export sets: runtime/cmake/OpenVINOTargets.cmake, lib/cmake/pugixml/pugixml-targets.cmake.
An exported target cannot depend upon another target which is exported multiple times. Consider consolidating the exports of the "pugixml-static" target to a single export.
CMake Error: install(EXPORT "OpenVINODeveloperTargets" ...) includes target "func_test_utils" which requires target "pugixml-static" that is not in this export set, but in multiple other export sets: runtime/cmake/OpenVINOTargets.cmake, lib/cmake/pugixml/pugixml-targets.cmake.
An exported target cannot depend upon another target which is exported multiple times. Consider consolidating the exports of the "pugixml-static" target to a single export.
CMake Error: install(EXPORT "OpenVINODeveloperTargets" ...) includes target "funcSharedTests" which requires target "pugixml-static" that is not in this export set, but in multiple other export sets: runtime/cmake/OpenVINOTargets.cmake, lib/cmake/pugixml/pugixml-targets.cmake.
An exported target cannot depend upon another target which is exported multiple times. Consider consolidating the exports of the "pugixml-static" target to a single export.
```
Parent projects now can set `set(PUGIXML_INSTALL OFF)` to disable installation rules. 

It's a good practice to provide such option. Example is https://github.com/nlohmann/json/blob/develop/CMakeLists.txt#L47