### PR TITLE
Replaced 0 with PUGIXML_NULL when a nullptr would have been needed.

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -293,7 +293,7 @@ PUGI_IMPL_NS_BEGIN
 		T* release()
 		{
 			T* result = data;
-			data = PUGIXML_NULL;
+			data = NULL;
 			return result;
 		}
 	};
@@ -476,9 +476,9 @@ PUGI_IMPL_NS_BEGIN
 		{
 			xml_memory_page* result = static_cast<xml_memory_page*>(memory);
 
-			result->allocator = PUGIXML_NULL;
-			result->prev = PUGIXML_NULL;
-			result->next = PUGIXML_NULL;
+			result->allocator = NULL;
+			result->prev = NULL;
+			result->next = NULL;
 			result->busy_size = 0;
 			result->freed_size = 0;
 
@@ -535,7 +535,7 @@ PUGI_IMPL_NS_BEGIN
 
 			// allocate block with some alignment, leaving memory for worst-case padding
 			void* memory = xml_memory::allocate(size);
-			if (!memory) return PUGIXML_NULL;
+			if (!memory) return NULL;
 
 			// prepare page structure
 			xml_memory_page* page = xml_memory_page::construct(memory);
@@ -618,7 +618,7 @@ PUGI_IMPL_NS_BEGIN
 
 			if (page->freed_size == page->busy_size)
 			{
-				if (page->next == PUGIXML_NULL)
+				if (page->next == NULL)
 				{
 					assert(_root == page);
 
@@ -665,7 +665,7 @@ PUGI_IMPL_NS_BEGIN
 			xml_memory_page* page;
 			xml_memory_string_header* header = static_cast<xml_memory_string_header*>(allocate_memory(full_size, page));
 
-			if (!header) return PUGIXML_NULL;
+			if (!header) return NULL;
 
 			// setup header
 			ptrdiff_t page_offset = reinterpret_cast<char*>(header) - reinterpret_cast<char*>(page) - sizeof(xml_memory_page);
@@ -727,7 +727,7 @@ PUGI_IMPL_NS_BEGIN
 		xml_memory_page* page = allocate_page(size <= large_allocation_threshold ? xml_memory_page_size : size);
 		out_page = page;
 
-		if (!page) return PUGIXML_NULL;
+		if (!page) return NULL;
 
 		if (size <= large_allocation_threshold)
 		{
@@ -1109,7 +1109,7 @@ namespace pugi
 {
 	struct xml_attribute_struct
 	{
-		xml_attribute_struct(impl::xml_memory_page* page): name(PUGIXML_NULL), value(PUGIXML_NULL), prev_attribute_c(PUGIXML_NULL), next_attribute(PUGIXML_NULL)
+		xml_attribute_struct(impl::xml_memory_page* page): name(NULL), value(NULL), prev_attribute_c(NULL), next_attribute(NULL)
 		{
 			header = PUGI_IMPL_GETHEADER_IMPL(this, page, 0);
 		}
@@ -1125,7 +1125,7 @@ namespace pugi
 
 	struct xml_node_struct
 	{
-		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): name(PUGIXML_NULL), value(PUGIXML_NULL), parent(PUGIXML_NULL), first_child(PUGIXML_NULL), prev_sibling_c(PUGIXML_NULL), next_sibling(PUGIXML_NULL), first_attribute(PUGIXML_NULL)
+		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): name(NULL), value(NULL), parent(NULL), first_child(NULL), prev_sibling_c(NULL), next_sibling(NULL), first_attribute(NULL)
 		{
 			header = PUGI_IMPL_GETHEADER_IMPL(this, page, type);
 		}
@@ -1156,7 +1156,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xml_document_struct: public xml_node_struct, public xml_allocator
 	{
-		xml_document_struct(xml_memory_page* page): xml_node_struct(page, node_document), xml_allocator(page), buffer(PUGIXML_NULL), extra_buffers(PUGIXML_NULL)
+		xml_document_struct(xml_memory_page* page): xml_node_struct(page, node_document), xml_allocator(page), buffer(NULL), extra_buffers(NULL)
 		{
 		}
 
@@ -1190,7 +1190,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		xml_memory_page* page;
 		void* memory = alloc.allocate_object(sizeof(xml_attribute_struct), page);
-		if (!memory) return PUGIXML_NULL;
+		if (!memory) return NULL;
 
 		return new (memory) xml_attribute_struct(page);
 	}
@@ -1199,7 +1199,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		xml_memory_page* page;
 		void* memory = alloc.allocate_object(sizeof(xml_node_struct), page);
-		if (!memory) return PUGIXML_NULL;
+		if (!memory) return NULL;
 
 		return new (memory) xml_node_struct(page, type);
 	}
@@ -1338,9 +1338,9 @@ PUGI_IMPL_NS_BEGIN
 		else
 			parent->first_child = next;
 
-		node->parent = PUGIXML_NULL;
-		node->prev_sibling_c = PUGIXML_NULL;
-		node->next_sibling = PUGIXML_NULL;
+		node->parent = NULL;
+		node->prev_sibling_c = NULL;
+		node->next_sibling = NULL;
 	}
 
 	inline void append_attribute(xml_attribute_struct* attr, xml_node_struct* node)
@@ -1421,16 +1421,16 @@ PUGI_IMPL_NS_BEGIN
 		else
 			node->first_attribute = next;
 
-		attr->prev_attribute_c = PUGIXML_NULL;
-		attr->next_attribute = PUGIXML_NULL;
+		attr->prev_attribute_c = NULL;
+		attr->next_attribute = NULL;
 	}
 
 	PUGI_IMPL_FN_NO_INLINE xml_node_struct* append_new_node(xml_node_struct* node, xml_allocator& alloc, xml_node_type type = node_element)
 	{
-		if (!alloc.reserve()) return PUGIXML_NULL;
+		if (!alloc.reserve()) return NULL;
 
 		xml_node_struct* child = allocate_node(alloc, type);
-		if (!child) return PUGIXML_NULL;
+		if (!child) return NULL;
 
 		append_node(child, node);
 
@@ -1439,10 +1439,10 @@ PUGI_IMPL_NS_BEGIN
 
 	PUGI_IMPL_FN_NO_INLINE xml_attribute_struct* append_new_attribute(xml_node_struct* node, xml_allocator& alloc)
 	{
-		if (!alloc.reserve()) return PUGIXML_NULL;
+		if (!alloc.reserve()) return NULL;
 
 		xml_attribute_struct* attr = allocate_attribute(alloc);
-		if (!attr) return PUGIXML_NULL;
+		if (!attr) return NULL;
 
 		append_attribute(attr, node);
 
@@ -2024,7 +2024,7 @@ PUGI_IMPL_NS_BEGIN
 		if (d0 == 0x3c && d1 == 0) return encoding_utf16_le;
 
 		// no known BOM detected; parse declaration
-		const uint8_t* enc = PUGIXML_NULL;
+		const uint8_t* enc = NULL;
 		size_t enc_length = 0;
 
 		if (d0 == 0x3c && d1 == 0x3f && d2 == 0x78 && d3 == 0x6d && parse_declaration_encoding(data, size, enc, enc_length))
@@ -2395,7 +2395,7 @@ PUGI_IMPL_NS_BEGIN
 			if (header & header_mask) alloc->deallocate_string(dest);
 
 			// mark the string as not allocated
-			dest = PUGIXML_NULL;
+			dest = NULL;
 			header &= ~header_mask;
 
 			return true;
@@ -2438,7 +2438,7 @@ PUGI_IMPL_NS_BEGIN
 		char_t* end;
 		size_t size;
 
-		gap(): end(PUGIXML_NULL), size(0)
+		gap(): end(NULL), size(0)
 		{
 		}
 
@@ -2625,7 +2625,7 @@ PUGI_IMPL_NS_BEGIN
 	#define PUGI_IMPL_SCANWHILE(X)          { while (X) ++s; }
 	#define PUGI_IMPL_SCANWHILE_UNROLL(X)   { for (;;) { char_t ss = s[0]; if (PUGI_IMPL_UNLIKELY(!(X))) { break; } ss = s[1]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 1; break; } ss = s[2]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 2; break; } ss = s[3]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 3; break; } s += 4; } }
 	#define PUGI_IMPL_ENDSEG()              { ch = *s; *s = 0; ++s; }
-	#define PUGI_IMPL_THROW_ERROR(err, m)   return error_offset = m, error_status = err, static_cast<char_t*>(PUGIXML_NULL)
+	#define PUGI_IMPL_THROW_ERROR(err, m)   return error_offset = m, error_status = err, static_cast<char_t*>(NULL)
 	#define PUGI_IMPL_CHECK_ERROR(err, m)   { if (*s == 0) PUGI_IMPL_THROW_ERROR(err, m); }
 
 	PUGI_IMPL_FN char_t* strconv_comment(char_t* s, char_t endch)
@@ -2650,7 +2650,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 			else if (*s == 0)
 			{
-				return PUGIXML_NULL;
+				return NULL;
 			}
 			else ++s;
 		}
@@ -2678,7 +2678,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 			else if (*s == 0)
 			{
-				return PUGIXML_NULL;
+				return NULL;
 			}
 			else ++s;
 		}
@@ -2751,7 +2751,7 @@ PUGI_IMPL_NS_BEGIN
 		case 5: return strconv_pcdata_impl<opt_true, opt_false, opt_true>::parse;
 		case 6: return strconv_pcdata_impl<opt_true, opt_true, opt_false>::parse;
 		case 7: return strconv_pcdata_impl<opt_true, opt_true, opt_true>::parse;
-		default: assert(false); return PUGIXML_NULL; // unreachable
+		default: assert(false); return NULL; // unreachable
 		}
 	}
 
@@ -2805,7 +2805,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return PUGIXML_NULL;
+					return NULL;
 				}
 				else ++s;
 			}
@@ -2841,7 +2841,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return PUGIXML_NULL;
+					return NULL;
 				}
 				else ++s;
 			}
@@ -2873,7 +2873,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return PUGIXML_NULL;
+					return NULL;
 				}
 				else ++s;
 			}
@@ -2899,7 +2899,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return PUGIXML_NULL;
+					return NULL;
 				}
 				else ++s;
 			}
@@ -2928,7 +2928,7 @@ PUGI_IMPL_NS_BEGIN
 		case 13: return strconv_attribute_impl<opt_true>::parse_wnorm;
 		case 14: return strconv_attribute_impl<opt_false>::parse_wnorm;
 		case 15: return strconv_attribute_impl<opt_true>::parse_wnorm;
-		default: assert(false); return PUGIXML_NULL; // unreachable
+		default: assert(false); return NULL; // unreachable
 		}
 	}
 
@@ -2947,7 +2947,7 @@ PUGI_IMPL_NS_BEGIN
 		char_t* error_offset;
 		xml_parse_status error_status;
 
-		xml_parser(xml_allocator* alloc_): alloc(alloc_), error_offset(PUGIXML_NULL), error_status(status_ok)
+		xml_parser(xml_allocator* alloc_): alloc(alloc_), error_offset(NULL), error_status(status_ok)
 		{
 		}
 
@@ -3559,7 +3559,7 @@ PUGI_IMPL_NS_BEGIN
 				return make_parse_result(PUGI_IMPL_OPTSET(parse_fragment) ? status_ok : status_no_document_element);
 
 			// get last child of the root before parsing
-			xml_node_struct* last_root_child = root->first_child ? root->first_child->prev_sibling_c + 0 : PUGIXML_NULL;
+			xml_node_struct* last_root_child = root->first_child ? root->first_child->prev_sibling_c + 0 : NULL;
 
 			// create parser on stack
 			xml_parser parser(static_cast<xml_allocator*>(xmldoc));
@@ -4476,7 +4476,7 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN void node_copy_tree(xml_node_struct* dn, xml_node_struct* sn)
 	{
 		xml_allocator& alloc = get_allocator(dn);
-		xml_allocator* shared_alloc = (&alloc == &get_allocator(sn)) ? &alloc : PUGIXML_NULL;
+		xml_allocator* shared_alloc = (&alloc == &get_allocator(sn)) ? &alloc : NULL;
 
 		node_copy_contents(dn, sn, shared_alloc);
 
@@ -4530,7 +4530,7 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN void node_copy_attribute(xml_attribute_struct* da, xml_attribute_struct* sa)
 	{
 		xml_allocator& alloc = get_allocator(da);
-		xml_allocator* shared_alloc = (&alloc == &get_allocator(sa)) ? &alloc : PUGIXML_NULL;
+		xml_allocator* shared_alloc = (&alloc == &get_allocator(sa)) ? &alloc : NULL;
 
 		node_copy_string(da->name, da->header, xml_memory_page_name_allocated_mask, sa->name, sa->header, shared_alloc);
 		node_copy_string(da->value, da->header, xml_memory_page_value_allocated_mask, sa->value, sa->header, shared_alloc);
@@ -4641,7 +4641,7 @@ PUGI_IMPL_NS_BEGIN
 	#ifdef PUGIXML_WCHAR_MODE
 		return wcstod(value, 0);
 	#else
-		return strtod(value, PUGIXML_NULL);
+		return strtod(value, NULL);
 	#endif
 	}
 
@@ -4650,7 +4650,7 @@ PUGI_IMPL_NS_BEGIN
 	#ifdef PUGIXML_WCHAR_MODE
 		return static_cast<float>(wcstod(value, 0));
 	#else
-		return static_cast<float>(strtod(value, PUGIXML_NULL));
+		return static_cast<float>(strtod(value, NULL));
 	#endif
 	}
 
@@ -4755,10 +4755,10 @@ PUGI_IMPL_NS_BEGIN
 		xml_encoding buffer_encoding = impl::get_buffer_encoding(encoding, contents, size);
 
 		// if convert_buffer below throws bad_alloc, we still need to deallocate contents if we own it
-		auto_deleter<void> contents_guard(own ? contents : PUGIXML_NULL, xml_memory::deallocate);
+		auto_deleter<void> contents_guard(own ? contents : NULL, xml_memory::deallocate);
 
 		// get private buffer
-		char_t* buffer = PUGIXML_NULL;
+		char_t* buffer = NULL;
 		size_t length = 0;
 
 		// coverity[var_deref_model]
@@ -4900,7 +4900,7 @@ PUGI_IMPL_NS_BEGIN
 		static xml_stream_chunk* create()
 		{
 			void* memory = xml_memory::allocate(sizeof(xml_stream_chunk));
-			if (!memory) return PUGIXML_NULL;
+			if (!memory) return NULL;
 
 			return new (memory) xml_stream_chunk();
 		}
@@ -4918,7 +4918,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 		}
 
-		xml_stream_chunk(): next(PUGIXML_NULL), size(0)
+		xml_stream_chunk(): next(NULL), size(0)
 		{
 		}
 
@@ -4930,11 +4930,11 @@ PUGI_IMPL_NS_BEGIN
 
 	template <typename T> PUGI_IMPL_FN xml_parse_status load_stream_data_noseek(std::basic_istream<T>& stream, void** out_buffer, size_t* out_size)
 	{
-		auto_deleter<xml_stream_chunk<T> > chunks(PUGIXML_NULL, xml_stream_chunk<T>::destroy);
+		auto_deleter<xml_stream_chunk<T> > chunks(NULL, xml_stream_chunk<T>::destroy);
 
 		// read file to a chunk list
 		size_t total = 0;
-		xml_stream_chunk<T>* last = PUGIXML_NULL;
+		xml_stream_chunk<T>* last = NULL;
 
 		while (!stream.eof())
 		{
@@ -5020,7 +5020,7 @@ PUGI_IMPL_NS_BEGIN
 
 	template <typename T> PUGI_IMPL_FN xml_parse_result load_stream_impl(xml_document_struct* doc, std::basic_istream<T>& stream, unsigned int options, xml_encoding encoding, char_t** out_buffer)
 	{
-		void* buffer = PUGIXML_NULL;
+		void* buffer = NULL;
 		size_t size = 0;
 		xml_parse_status status = status_ok;
 
@@ -5065,7 +5065,7 @@ PUGI_IMPL_NS_BEGIN
 
 		// allocate resulting string
 		char* result = static_cast<char*>(xml_memory::allocate(size + 1));
-		if (!result) return 0;
+		if (!result) return NULL;
 
 		// second pass: convert to utf8
 		as_utf8_end(result, size, str, length);
@@ -5080,7 +5080,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		// there is no standard function to open wide paths, so our best bet is to try utf8 path
 		char* path_utf8 = convert_path_heap(path);
-		if (!path_utf8) return 0;
+		if (!path_utf8) return NULL;
 
 		// convert mode to ASCII (we mirror _wfopen interface)
 		char mode_ascii[4] = {0};
@@ -5123,7 +5123,7 @@ PUGI_IMPL_NS_BEGIN
 
 		name_null_sentry(xml_node_struct* node_): node(node_), name(node_->name)
 		{
-			node->name = PUGIXML_NULL;
+			node->name = NULL;
 		}
 
 		~name_null_sentry()
@@ -5150,11 +5150,11 @@ namespace pugi
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<char, std::char_traits<char> >& stream): narrow_stream(&stream), wide_stream(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<char, std::char_traits<char> >& stream): narrow_stream(&stream), wide_stream(NULL)
 	{
 	}
 
-	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& stream): narrow_stream(PUGIXML_NULL), wide_stream(&stream)
+	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& stream): narrow_stream(NULL), wide_stream(&stream)
 	{
 	}
 
@@ -5198,7 +5198,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI_IMPL_FN xml_attribute::xml_attribute(): _attr(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_attribute::xml_attribute(): _attr(NULL)
 	{
 	}
 
@@ -5212,7 +5212,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_attribute::operator xml_attribute::unspecified_bool_type() const
 	{
-		return _attr ? unspecified_bool_xml_attribute : PUGIXML_NULL;
+		return _attr ? unspecified_bool_xml_attribute : NULL;
 	}
 
 	PUGI_IMPL_FN bool xml_attribute::operator!() const
@@ -5531,7 +5531,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI_IMPL_FN xml_node::xml_node(): _root(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_node::xml_node(): _root(NULL)
 	{
 	}
 
@@ -5545,7 +5545,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_node::operator xml_node::unspecified_bool_type() const
 	{
-		return _root ? unspecified_bool_xml_node : PUGIXML_NULL;
+		return _root ? unspecified_bool_xml_node : NULL;
 	}
 
 	PUGI_IMPL_FN bool xml_node::operator!() const
@@ -5555,22 +5555,22 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_node::iterator xml_node::begin() const
 	{
-		return iterator(_root ? _root->first_child + 0 : PUGIXML_NULL, _root);
+		return iterator(_root ? _root->first_child + 0 : NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::iterator xml_node::end() const
 	{
-		return iterator(PUGIXML_NULL, _root);
+		return iterator(NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::attribute_iterator xml_node::attributes_begin() const
 	{
-		return attribute_iterator(_root ? _root->first_attribute + 0 : PUGIXML_NULL, _root);
+		return attribute_iterator(_root ? _root->first_attribute + 0 : NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::attribute_iterator xml_node::attributes_end() const
 	{
-		return attribute_iterator(PUGIXML_NULL, _root);
+		return attribute_iterator(NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_object_range<xml_node_iterator> xml_node::children() const
@@ -5580,7 +5580,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_object_range<xml_named_node_iterator> xml_node::children(const char_t* name_) const
 	{
-		return xml_object_range<xml_named_node_iterator>(xml_named_node_iterator(child(name_)._root, _root, name_), xml_named_node_iterator(PUGIXML_NULL, _root, name_));
+		return xml_object_range<xml_named_node_iterator>(xml_named_node_iterator(child(name_)._root, _root, name_), xml_named_node_iterator(NULL, _root, name_));
 	}
 
 	PUGI_IMPL_FN xml_object_range<xml_attribute_iterator> xml_node::attributes() const
@@ -6272,7 +6272,7 @@ namespace pugi
 			attr = next;
 		}
 
-		_root->first_attribute = PUGIXML_NULL;
+		_root->first_attribute = NULL;
 
 		return true;
 	}
@@ -6311,7 +6311,7 @@ namespace pugi
 			cur = next;
 		}
 
-		_root->first_child = PUGIXML_NULL;
+		_root->first_child = NULL;
 
 		return true;
 	}
@@ -6331,7 +6331,7 @@ namespace pugi
 		doc->header |= impl::xml_memory_page_contents_shared_mask;
 
 		// get extra buffer element (we'll store the document fragment buffer there so that we can deallocate it later)
-		impl::xml_memory_page* page = PUGIXML_NULL;
+		impl::xml_memory_page* page = NULL;
 		impl::xml_extra_buffer* extra = static_cast<impl::xml_extra_buffer*>(doc->allocate_memory(sizeof(impl::xml_extra_buffer) + sizeof(void*), page));
 		(void)page;
 
@@ -6344,7 +6344,7 @@ namespace pugi
 	#endif
 
 		// add extra buffer to the list
-		extra->buffer = PUGIXML_NULL;
+		extra->buffer = NULL;
 		extra->next = doc->extra_buffers;
 		doc->extra_buffers = extra;
 
@@ -6484,7 +6484,7 @@ namespace pugi
 		xml_node arg_begin(_root);
 		if (!walker.begin(arg_begin)) return false;
 
-		xml_node_struct* cur = _root ? _root->first_child + 0 : PUGIXML_NULL;
+		xml_node_struct* cur = _root ? _root->first_child + 0 : NULL;
 
 		if (cur)
 		{
@@ -6620,7 +6620,7 @@ namespace pugi
 			if (impl::is_text_node(node))
 				return node;
 
-		return PUGIXML_NULL;
+		return NULL;
 	}
 
 	PUGI_IMPL_FN xml_node_struct* xml_text::_data_new()
@@ -6631,7 +6631,7 @@ namespace pugi
 		return xml_node(_root).append_child(node_pcdata).internal_object();
 	}
 
-	PUGI_IMPL_FN xml_text::xml_text(): _root(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_text::xml_text(): _root(NULL)
 	{
 	}
 
@@ -6641,7 +6641,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_text::operator xml_text::unspecified_bool_type() const
 	{
-		return _data() ? unspecified_bool_xml_text : PUGIXML_NULL;
+		return _data() ? unspecified_bool_xml_text : NULL;
 	}
 
 	PUGI_IMPL_FN bool xml_text::operator!() const
@@ -6651,7 +6651,7 @@ namespace pugi
 
 	PUGI_IMPL_FN bool xml_text::empty() const
 	{
-		return _data() == PUGIXML_NULL;
+		return _data() == NULL;
 	}
 
 	PUGI_IMPL_FN const char_t* xml_text::get() const
@@ -7022,7 +7022,7 @@ namespace pugi
 		return temp;
 	}
 
-	PUGI_IMPL_FN xml_named_node_iterator::xml_named_node_iterator(): _name(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_named_node_iterator::xml_named_node_iterator(): _name(NULL)
 	{
 	}
 
@@ -7132,7 +7132,7 @@ namespace pugi
 		}
 	}
 
-	PUGI_IMPL_FN xml_document::xml_document(): _buffer(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_document::xml_document(): _buffer(NULL)
 	{
 		_create();
 	}
@@ -7143,7 +7143,7 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI_IMPL_FN xml_document::xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT: _buffer(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_document::xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT: _buffer(NULL)
 	{
 		_create();
 		_move(rhs);
@@ -7225,7 +7225,7 @@ namespace pugi
 		if (_buffer)
 		{
 			impl::xml_memory::deallocate(_buffer);
-			_buffer = PUGIXML_NULL;
+			_buffer = NULL;
 		}
 
 		// destroy extra buffers (note: no need to destroy linked list nodes, they're allocated using document allocator)
@@ -7253,7 +7253,7 @@ namespace pugi
 		static_cast<impl::xml_document_struct*>(_root)->hash.clear();
 	#endif
 
-		_root = PUGIXML_NULL;
+		_root = NULL;
 	}
 
 #ifdef PUGIXML_HAS_MOVE
@@ -7326,7 +7326,7 @@ namespace pugi
 			page->prev = doc_page;
 
 			doc_page->next = page;
-			other_page->next = PUGIXML_NULL;
+			other_page->next = NULL;
 		}
 
 		// make sure pages point to the correct document state
@@ -7363,7 +7363,7 @@ namespace pugi
 
 		// reset other document
 		new (other) impl::xml_document_struct(PUGI_IMPL_GETPAGE(other));
-		rhs._buffer = PUGIXML_NULL;
+		rhs._buffer = NULL;
 	}
 #endif
 
@@ -7790,7 +7790,7 @@ PUGI_IMPL_NS_BEGIN
 
 		for (size_t probe = 0; probe <= hashmod; ++probe)
 		{
-			if (table[bucket] == PUGIXML_NULL)
+			if (table[bucket] == NULL)
 			{
 				table[bucket] = key;
 				return true;
@@ -7838,7 +7838,7 @@ PUGI_IMPL_NS_BEGIN
 		size_t _root_size;
 		bool* _error;
 
-		xpath_allocator(xpath_memory_block* root, bool* error = PUGIXML_NULL): _root(root), _root_size(0), _error(error)
+		xpath_allocator(xpath_memory_block* root, bool* error = NULL): _root(root), _root_size(0), _error(error)
 		{
 		}
 
@@ -7866,7 +7866,7 @@ PUGI_IMPL_NS_BEGIN
 				if (!block)
 				{
 					if (_error) *_error = true;
-					return PUGIXML_NULL;
+					return NULL;
 				}
 
 				block->next = _root;
@@ -7886,7 +7886,7 @@ PUGI_IMPL_NS_BEGIN
 			new_size = (new_size + xpath_memory_block_alignment - 1) & ~(xpath_memory_block_alignment - 1);
 
 			// we can only reallocate the last object
-			assert(ptr == PUGIXML_NULL || static_cast<char*>(ptr) + old_size == &_root->data[0] + _root_size);
+			assert(ptr == NULL || static_cast<char*>(ptr) + old_size == &_root->data[0] + _root_size);
 
 			// try to reallocate the object inplace
 			if (ptr && _root_size - old_size + new_size <= _root->capacity)
@@ -7897,7 +7897,7 @@ PUGI_IMPL_NS_BEGIN
 
 			// allocate a new block
 			void* result = allocate(new_size);
-			if (!result) return PUGIXML_NULL;
+			if (!result) return NULL;
 
 			// we have a new block
 			if (ptr)
@@ -7992,7 +7992,7 @@ PUGI_IMPL_NS_BEGIN
 
 		xpath_stack_data(): result(blocks + 0, &oom), temp(blocks + 1, &oom), oom(false)
 		{
-			blocks[0].next = blocks[1].next = PUGIXML_NULL;
+			blocks[0].next = blocks[1].next = NULL;
 			blocks[0].capacity = blocks[1].capacity = sizeof(blocks[0].data);
 
 			stack.result = &result;
@@ -8018,7 +8018,7 @@ PUGI_IMPL_NS_BEGIN
 		static char_t* duplicate_string(const char_t* string, size_t length, xpath_allocator* alloc)
 		{
 			char_t* result = static_cast<char_t*>(alloc->allocate((length + 1) * sizeof(char_t)));
-			if (!result) return PUGIXML_NULL;
+			if (!result) return NULL;
 
 			memcpy(result, string, length * sizeof(char_t));
 			result[length] = 0;
@@ -8078,7 +8078,7 @@ PUGI_IMPL_NS_BEGIN
 				size_t result_length = target_length + source_length;
 
 				// allocate new buffer
-				char_t* result = static_cast<char_t*>(alloc->reallocate(_uses_heap ? const_cast<char_t*>(_buffer) : PUGIXML_NULL, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
+				char_t* result = static_cast<char_t*>(alloc->reallocate(_uses_heap ? const_cast<char_t*>(_buffer) : NULL, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
 				if (!result) return;
 
 				// append first string to the new buffer in case there was no reallocation
@@ -8113,7 +8113,7 @@ PUGI_IMPL_NS_BEGIN
 				size_t length_ = strlength(_buffer);
 				const char_t* data_ = duplicate_string(_buffer, length_, alloc);
 
-				if (!data_) return PUGIXML_NULL;
+				if (!data_) return NULL;
 
 				_buffer = data_;
 				_uses_heap = true;
@@ -8322,7 +8322,7 @@ PUGI_IMPL_NS_BEGIN
 				if (node->value && (node->header & impl::xml_memory_page_value_allocated_or_shared_mask) == 0) return node->value;
 			}
 
-			return PUGIXML_NULL;
+			return NULL;
 		}
 
 		xml_attribute_struct* attr = xnode.attribute().internal_object();
@@ -8335,10 +8335,10 @@ PUGI_IMPL_NS_BEGIN
 				if ((attr->header & impl::xml_memory_page_value_allocated_or_shared_mask) == 0) return attr->value;
 			}
 
-			return PUGIXML_NULL;
+			return NULL;
 		}
 
-		return PUGIXML_NULL;
+		return NULL;
 	}
 
 	struct document_order_comparator
@@ -8451,7 +8451,7 @@ PUGI_IMPL_NS_BEGIN
 		if (v == 0) return PUGIXML_TEXT("0");
 		if (v != v) return PUGIXML_TEXT("NaN");
 		if (v * 2 == v) return value > 0 ? PUGIXML_TEXT("Infinity") : PUGIXML_TEXT("-Infinity");
-		return PUGIXML_NULL;
+		return NULL;
 	#endif
 	}
 
@@ -8618,7 +8618,7 @@ PUGI_IMPL_NS_BEGIN
 	#ifdef PUGIXML_WCHAR_MODE
 		return wcstod(string, 0);
 	#else
-		return strtod(string, PUGIXML_NULL);
+		return strtod(string, NULL);
 	#endif
 	}
 
@@ -8680,7 +8680,7 @@ PUGI_IMPL_NS_BEGIN
 		{
 			const char_t* pos = find_char(name, ':');
 
-			prefix = pos ? name : PUGIXML_NULL;
+			prefix = pos ? name : NULL;
 			prefix_length = pos ? static_cast<size_t>(pos - name) : 0;
 		}
 
@@ -8798,7 +8798,7 @@ PUGI_IMPL_NS_BEGIN
 			unsigned int tc = static_cast<unsigned int>(*to);
 
 			if (fc >= 128 || tc >= 128)
-				return PUGIXML_NULL;
+				return NULL;
 
 			// code=128 means "skip character"
 			if (!table[fc])
@@ -8813,7 +8813,7 @@ PUGI_IMPL_NS_BEGIN
 				table[i] = static_cast<unsigned char>(i);
 
 		void* result = alloc->allocate(sizeof(table));
-		if (!result) return PUGIXML_NULL;
+		if (!result) return NULL;
 
 		memcpy(result, table, sizeof(table));
 
@@ -8877,7 +8877,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_string: xpath_variable
 	{
-		xpath_variable_string(): xpath_variable(xpath_type_string), value(PUGIXML_NULL)
+		xpath_variable_string(): xpath_variable(xpath_type_string), value(NULL)
 		{
 		}
 
@@ -8924,11 +8924,11 @@ PUGI_IMPL_NS_BEGIN
 	template <typename T> PUGI_IMPL_FN T* new_xpath_variable(const char_t* name)
 	{
 		size_t length = strlength(name);
-		if (length == 0) return PUGIXML_NULL; // empty variable names are invalid
+		if (length == 0) return NULL; // empty variable names are invalid
 
 		// $$ we can't use offsetof(T, name) because T is non-POD, so we just allocate additional length characters
 		void* memory = xml_memory::allocate(sizeof(T) + length * sizeof(char_t));
-		if (!memory) return PUGIXML_NULL;
+		if (!memory) return NULL;
 
 		T* result = new (memory) T();
 
@@ -8954,7 +8954,7 @@ PUGI_IMPL_NS_BEGIN
 			return new_xpath_variable<xpath_variable_boolean>(name);
 
 		default:
-			return PUGIXML_NULL;
+			return NULL;
 		}
 	}
 
@@ -9107,7 +9107,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_node* _eos;
 
 	public:
-		xpath_node_set_raw(): _type(xpath_node_set::type_unsorted), _begin(PUGIXML_NULL), _end(PUGIXML_NULL), _eos(PUGIXML_NULL)
+		xpath_node_set_raw(): _type(xpath_node_set::type_unsorted), _begin(NULL), _end(NULL), _eos(NULL)
 		{
 		}
 
@@ -9299,7 +9299,7 @@ PUGI_IMPL_NS_BEGIN
 		const char_t* begin;
 		const char_t* end;
 
-		xpath_lexer_string(): begin(PUGIXML_NULL), end(PUGIXML_NULL)
+		xpath_lexer_string(): begin(NULL), end(NULL)
 		{
 		}
 
@@ -10487,40 +10487,40 @@ PUGI_IMPL_NS_BEGIN
 
 	public:
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, const char_t* value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(NULL), _right(NULL), _next(NULL)
 		{
 			assert(type == ast_string_constant);
 			_data.string = value;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, double value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(NULL), _right(NULL), _next(NULL)
 		{
 			assert(type == ast_number_constant);
 			_data.number = value;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_variable* value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(NULL), _right(NULL), _next(NULL)
 		{
 			assert(type == ast_variable);
 			_data.variable = value;
 		}
 
-		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_ast_node* left = PUGIXML_NULL, xpath_ast_node* right = PUGIXML_NULL):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(left), _right(right), _next(PUGIXML_NULL)
+		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_ast_node* left = NULL, xpath_ast_node* right = NULL):
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(left), _right(right), _next(NULL)
 		{
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_ast_node* left, axis_t axis, nodetest_t test, const char_t* contents):
-			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(static_cast<char>(axis)), _test(static_cast<char>(test)), _left(left), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
+			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(static_cast<char>(axis)), _test(static_cast<char>(test)), _left(left), _right(NULL), _next(NULL)
 		{
 			assert(type == ast_step);
 			_data.nodetest = contents;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_ast_node* left, xpath_ast_node* right, predicate_t test):
-			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(0), _test(static_cast<char>(test)), _left(left), _right(right), _next(PUGIXML_NULL)
+			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(0), _test(static_cast<char>(test)), _left(left), _right(right), _next(NULL)
 		{
 			assert(type == ast_filter || type == ast_predicate);
 		}
@@ -10580,7 +10580,7 @@ PUGI_IMPL_NS_BEGIN
 				xpath_string lr = _left->eval_string(c, stack);
 				xpath_string rr = _right->eval_string(c, stack);
 
-				return find_substring(lr.c_str(), rr.c_str()) != PUGIXML_NULL;
+				return find_substring(lr.c_str(), rr.c_str()) != NULL;
 			}
 
 			case ast_func_boolean:
@@ -11389,7 +11389,7 @@ PUGI_IMPL_NS_BEGIN
 			_result->error = message;
 			_result->offset = _lexer.current_pos() - _query;
 
-			return PUGIXML_NULL;
+			return NULL;
 		}
 
 		xpath_ast_node* error_oom()
@@ -11397,7 +11397,7 @@ PUGI_IMPL_NS_BEGIN
 			assert(_alloc->_error);
 			*_alloc->_error = true;
 
-			return PUGIXML_NULL;
+			return NULL;
 		}
 
 		xpath_ast_node* error_rec()
@@ -11413,37 +11413,37 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, const char_t* value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, double value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_variable* value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : NULL;
 		}
 
-		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_ast_node* left = PUGIXML_NULL, xpath_ast_node* right = PUGIXML_NULL)
+		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_ast_node* left = NULL, xpath_ast_node* right = NULL)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, left, right) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, left, right) : NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, axis_t axis, nodetest_t test, const char_t* contents)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, left, axis, test, contents) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, left, axis, test, contents) : NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, xpath_ast_node* right, predicate_t test)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, left, right, test) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, left, right, test) : NULL;
 		}
 
 		const char_t* alloc_string(const xpath_lexer_string& value)
@@ -11454,7 +11454,7 @@ PUGI_IMPL_NS_BEGIN
 			size_t length = static_cast<size_t>(value.end - value.begin);
 
 			char_t* c = static_cast<char_t*>(_alloc->allocate((length + 1) * sizeof(char_t)));
-			if (!c) return PUGIXML_NULL;
+			if (!c) return NULL;
 
 			memcpy(c, value.begin, length * sizeof(char_t));
 			c[length] = 0;
@@ -11697,7 +11697,7 @@ PUGI_IMPL_NS_BEGIN
 				if (!_variables)
 					return error("Unknown variable: variable set is not provided");
 
-				xpath_variable* var = PUGIXML_NULL;
+				xpath_variable* var = NULL;
 				if (!get_variable_scratch(_scratch, _variables, name.begin, name.end, &var))
 					return error_oom();
 
@@ -11714,7 +11714,7 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = parse_expression();
-				if (!n) return PUGIXML_NULL;
+				if (!n) return NULL;
 
 				if (_lexer.current() != lex_close_brace)
 					return error("Expected ')' to match an opening '('");
@@ -11727,7 +11727,7 @@ PUGI_IMPL_NS_BEGIN
 			case lex_quoted_string:
 			{
 				const char_t* value = alloc_string(_lexer.contents());
-				if (!value) return PUGIXML_NULL;
+				if (!value) return NULL;
 
 				_lexer.next();
 
@@ -11748,13 +11748,13 @@ PUGI_IMPL_NS_BEGIN
 
 			case lex_string:
 			{
-				xpath_ast_node* args[2] = {PUGIXML_NULL};
+				xpath_ast_node* args[2] = {NULL};
 				size_t argc = 0;
 
 				xpath_lexer_string function = _lexer.contents();
 				_lexer.next();
 
-				xpath_ast_node* last_arg = PUGIXML_NULL;
+				xpath_ast_node* last_arg = NULL;
 
 				if (_lexer.current() != lex_open_brace)
 					return error("Unrecognized function call");
@@ -11775,7 +11775,7 @@ PUGI_IMPL_NS_BEGIN
 						return error_rec();
 
 					xpath_ast_node* n = parse_expression();
-					if (!n) return PUGIXML_NULL;
+					if (!n) return NULL;
 
 					if (argc < 2) args[argc] = n;
 					else last_arg->set_next(n);
@@ -11802,7 +11802,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse_filter_expression()
 		{
 			xpath_ast_node* n = parse_primary_expression();
-			if (!n) return PUGIXML_NULL;
+			if (!n) return NULL;
 
 			size_t old_depth = _depth;
 
@@ -11817,10 +11817,10 @@ PUGI_IMPL_NS_BEGIN
 					return error("Predicate has to be applied to node set");
 
 				xpath_ast_node* expr = parse_expression();
-				if (!expr) return PUGIXML_NULL;
+				if (!expr) return NULL;
 
 				n = alloc_node(ast_filter, n, expr, predicate_default);
-				if (!n) return PUGIXML_NULL;
+				if (!n) return NULL;
 
 				if (_lexer.current() != lex_close_square_brace)
 					return error("Expected ']' to match an opening '['");
@@ -11860,7 +11860,7 @@ PUGI_IMPL_NS_BEGIN
 				if (_lexer.current() == lex_open_square_brace)
 					return error("Predicates are not allowed after an abbreviated step");
 
-				return alloc_node(ast_step, set, axis_self, nodetest_type_node, PUGIXML_NULL);
+				return alloc_node(ast_step, set, axis_self, nodetest_type_node, NULL);
 			}
 			else if (_lexer.current() == lex_double_dot)
 			{
@@ -11869,7 +11869,7 @@ PUGI_IMPL_NS_BEGIN
 				if (_lexer.current() == lex_open_square_brace)
 					return error("Predicates are not allowed after an abbreviated step");
 
-				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, PUGIXML_NULL);
+				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, NULL);
 			}
 
 			nodetest_t nt_type = nodetest_none;
@@ -11976,14 +11976,14 @@ PUGI_IMPL_NS_BEGIN
 			}
 
 			const char_t* nt_name_copy = alloc_string(nt_name);
-			if (!nt_name_copy) return PUGIXML_NULL;
+			if (!nt_name_copy) return NULL;
 
 			xpath_ast_node* n = alloc_node(ast_step, set, axis, nt_type, nt_name_copy);
-			if (!n) return PUGIXML_NULL;
+			if (!n) return NULL;
 
 			size_t old_depth = _depth;
 
-			xpath_ast_node* last = PUGIXML_NULL;
+			xpath_ast_node* last = NULL;
 
 			while (_lexer.current() == lex_open_square_brace)
 			{
@@ -11993,10 +11993,10 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				xpath_ast_node* expr = parse_expression();
-				if (!expr) return PUGIXML_NULL;
+				if (!expr) return NULL;
 
-				xpath_ast_node* pred = alloc_node(ast_predicate, PUGIXML_NULL, expr, predicate_default);
-				if (!pred) return PUGIXML_NULL;
+				xpath_ast_node* pred = alloc_node(ast_predicate, NULL, expr, predicate_default);
+				if (!pred) return NULL;
 
 				if (_lexer.current() != lex_close_square_brace)
 					return error("Expected ']' to match an opening '['");
@@ -12017,7 +12017,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse_relative_location_path(xpath_ast_node* set)
 		{
 			xpath_ast_node* n = parse_step(set);
-			if (!n) return PUGIXML_NULL;
+			if (!n) return NULL;
 
 			size_t old_depth = _depth;
 
@@ -12028,8 +12028,8 @@ PUGI_IMPL_NS_BEGIN
 
 				if (l == lex_double_slash)
 				{
-					n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
-					if (!n) return PUGIXML_NULL;
+					n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, NULL);
+					if (!n) return NULL;
 
 					++_depth;
 				}
@@ -12038,7 +12038,7 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				n = parse_step(n);
-				if (!n) return PUGIXML_NULL;
+				if (!n) return NULL;
 			}
 
 			_depth = old_depth;
@@ -12055,7 +12055,7 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
-				if (!n) return PUGIXML_NULL;
+				if (!n) return NULL;
 
 				// relative location path can start from axis_attribute, dot, double_dot, multiply and string lexemes; any other lexeme means standalone root path
 				lexeme_t l = _lexer.current();
@@ -12070,16 +12070,16 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
-				if (!n) return PUGIXML_NULL;
+				if (!n) return NULL;
 
-				n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
-				if (!n) return PUGIXML_NULL;
+				n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, NULL);
+				if (!n) return NULL;
 
 				return parse_relative_location_path(n);
 			}
 
 			// else clause moved outside of if because of bogus warning 'control may reach end of non-void function being inlined' in gcc 4.0.1
-			return parse_relative_location_path(PUGIXML_NULL);
+			return parse_relative_location_path(NULL);
 		}
 
 		// PathExpr ::= LocationPath
@@ -12116,7 +12116,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 
 				xpath_ast_node* n = parse_filter_expression();
-				if (!n) return PUGIXML_NULL;
+				if (!n) return NULL;
 
 				if (_lexer.current() == lex_slash || _lexer.current() == lex_double_slash)
 				{
@@ -12128,8 +12128,8 @@ PUGI_IMPL_NS_BEGIN
 						if (n->rettype() != xpath_type_node_set)
 							return error("Step has to be applied to node set");
 
-						n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
-						if (!n) return PUGIXML_NULL;
+						n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, NULL);
+						if (!n) return NULL;
 					}
 
 					// select from location path
@@ -12144,7 +12144,7 @@ PUGI_IMPL_NS_BEGIN
 
 				// precedence 7+ - only parses union expressions
 				xpath_ast_node* n = parse_expression(7);
-				if (!n) return PUGIXML_NULL;
+				if (!n) return NULL;
 
 				return alloc_node(ast_op_negate, xpath_type_number, n);
 			}
@@ -12232,14 +12232,14 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				xpath_ast_node* rhs = parse_path_or_unary_expression();
-				if (!rhs) return PUGIXML_NULL;
+				if (!rhs) return NULL;
 
 				binary_op_t nextop = binary_op_t::parse(_lexer);
 
 				while (nextop.asttype != ast_unknown && nextop.precedence > op.precedence)
 				{
 					rhs = parse_expression_rec(rhs, nextop.precedence);
-					if (!rhs) return PUGIXML_NULL;
+					if (!rhs) return NULL;
 
 					nextop = binary_op_t::parse(_lexer);
 				}
@@ -12248,7 +12248,7 @@ PUGI_IMPL_NS_BEGIN
 					return error("Union operator has to be applied to node sets");
 
 				lhs = alloc_node(op.asttype, op.rettype, lhs, rhs);
-				if (!lhs) return PUGIXML_NULL;
+				if (!lhs) return NULL;
 
 				op = binary_op_t::parse(_lexer);
 			}
@@ -12282,7 +12282,7 @@ PUGI_IMPL_NS_BEGIN
 				return error_rec();
 
 			xpath_ast_node* n = parse_path_or_unary_expression();
-			if (!n) return PUGIXML_NULL;
+			if (!n) return NULL;
 
 			n = parse_expression_rec(n, limit);
 
@@ -12298,7 +12298,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse()
 		{
 			xpath_ast_node* n = parse_expression();
-			if (!n) return PUGIXML_NULL;
+			if (!n) return NULL;
 
 			assert(_depth == 0);
 
@@ -12322,7 +12322,7 @@ PUGI_IMPL_NS_BEGIN
 		static xpath_query_impl* create()
 		{
 			void* memory = xml_memory::allocate(sizeof(xpath_query_impl));
-			if (!memory) return PUGIXML_NULL;
+			if (!memory) return NULL;
 
 			return new (memory) xpath_query_impl();
 		}
@@ -12336,9 +12336,9 @@ PUGI_IMPL_NS_BEGIN
 			xml_memory::deallocate(impl);
 		}
 
-		xpath_query_impl(): root(PUGIXML_NULL), alloc(&block, &oom), oom(false)
+		xpath_query_impl(): root(NULL), alloc(&block, &oom), oom(false)
 		{
-			block.next = PUGIXML_NULL;
+			block.next = NULL;
 			block.capacity = sizeof(block.data);
 		}
 
@@ -12350,7 +12350,7 @@ PUGI_IMPL_NS_BEGIN
 
 	PUGI_IMPL_FN impl::xpath_ast_node* evaluate_node_set_prepare(xpath_query_impl* impl)
 	{
-		if (!impl) return PUGIXML_NULL;
+		if (!impl) return NULL;
 
 		if (impl->root->rettype() != xpath_type_node_set)
 		{
@@ -12420,7 +12420,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_node::operator xpath_node::unspecified_bool_type() const
 	{
-		return (_node || _attribute) ? unspecified_bool_xpath_node : PUGIXML_NULL;
+		return (_node || _attribute) ? unspecified_bool_xpath_node : NULL;
 	}
 
 	PUGI_IMPL_FN bool xpath_node::operator!() const
@@ -12472,7 +12472,7 @@ namespace pugi
 		if (_begin != _storage)
 			impl::xml_memory::deallocate(_begin);
 
-		// size check is necessary because for begin_ = end_ = PUGIXML_NULL, memcpy is UB
+		// size check is necessary because for begin_ = end_ = nullptr, memcpy is UB
 		if (size_)
 			memcpy(storage, begin_, size_ * sizeof(xpath_node));
 
@@ -12590,7 +12590,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_parse_result::operator bool() const
 	{
-		return error == PUGIXML_NULL;
+		return error == NULL;
 	}
 
 	PUGI_IMPL_FN const char* xpath_parse_result::description() const
@@ -12598,7 +12598,7 @@ namespace pugi
 		return error ? error : "No error";
 	}
 
-	PUGI_IMPL_FN xpath_variable::xpath_variable(xpath_value_type type_): _type(type_), _next(PUGIXML_NULL)
+	PUGI_IMPL_FN xpath_variable::xpath_variable(xpath_value_type type_): _type(type_), _next(NULL)
 	{
 	}
 
@@ -12620,7 +12620,7 @@ namespace pugi
 
 		default:
 			assert(false && "Invalid variable type"); // unreachable
-			return PUGIXML_NULL;
+			return NULL;
 		}
 	}
 
@@ -12641,7 +12641,7 @@ namespace pugi
 
 	PUGI_IMPL_FN const char_t* xpath_variable::get_string() const
 	{
-		const char_t* value = (_type == xpath_type_string) ? static_cast<const impl::xpath_variable_string*>(this)->value : PUGIXML_NULL;
+		const char_t* value = (_type == xpath_type_string) ? static_cast<const impl::xpath_variable_string*>(this)->value : NULL;
 		return value ? value : PUGIXML_TEXT("");
 	}
 
@@ -12698,7 +12698,7 @@ namespace pugi
 	PUGI_IMPL_FN xpath_variable_set::xpath_variable_set()
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
-			_data[i] = PUGIXML_NULL;
+			_data[i] = NULL;
 	}
 
 	PUGI_IMPL_FN xpath_variable_set::~xpath_variable_set()
@@ -12710,7 +12710,7 @@ namespace pugi
 	PUGI_IMPL_FN xpath_variable_set::xpath_variable_set(const xpath_variable_set& rhs)
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
-			_data[i] = PUGIXML_NULL;
+			_data[i] = NULL;
 
 		_assign(rhs);
 	}
@@ -12730,7 +12730,7 @@ namespace pugi
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
 		{
 			_data[i] = rhs._data[i];
-			rhs._data[i] = PUGIXML_NULL;
+			rhs._data[i] = NULL;
 		}
 	}
 
@@ -12741,7 +12741,7 @@ namespace pugi
 			_destroy(_data[i]);
 
 			_data[i] = rhs._data[i];
-			rhs._data[i] = PUGIXML_NULL;
+			rhs._data[i] = NULL;
 		}
 
 		return *this;
@@ -12780,12 +12780,12 @@ namespace pugi
 			if (impl::strequal(var->name(), name))
 				return var;
 
-		return PUGIXML_NULL;
+		return NULL;
 	}
 
 	PUGI_IMPL_FN bool xpath_variable_set::_clone(xpath_variable* var, xpath_variable** out_result)
 	{
-		xpath_variable* last = PUGIXML_NULL;
+		xpath_variable* last = NULL;
 
 		while (var)
 		{
@@ -12830,7 +12830,7 @@ namespace pugi
 		// look for existing variable
 		for (xpath_variable* var = _data[hash]; var; var = var->_next)
 			if (impl::strequal(var->name(), name))
-				return var->type() == type ? var : PUGIXML_NULL;
+				return var->type() == type ? var : NULL;
 
 		// add new variable
 		xpath_variable* result = impl::new_xpath_variable(type, name);
@@ -12879,7 +12879,7 @@ namespace pugi
 		return _find(name);
 	}
 
-	PUGI_IMPL_FN xpath_query::xpath_query(const char_t* query, xpath_variable_set* variables): _impl(PUGIXML_NULL)
+	PUGI_IMPL_FN xpath_query::xpath_query(const char_t* query, xpath_variable_set* variables): _impl(NULL)
 	{
 		impl::xpath_query_impl* qimpl = impl::xpath_query_impl::create();
 
@@ -12903,7 +12903,7 @@ namespace pugi
 				qimpl->root->optimize(&qimpl->alloc);
 
 				_impl = impl.release();
-				_result.error = PUGIXML_NULL;
+				_result.error = NULL;
 			}
 			else
 			{
@@ -12917,7 +12917,7 @@ namespace pugi
 		}
 	}
 
-	PUGI_IMPL_FN xpath_query::xpath_query(): _impl(PUGIXML_NULL)
+	PUGI_IMPL_FN xpath_query::xpath_query(): _impl(NULL)
 	{
 	}
 
@@ -12932,7 +12932,7 @@ namespace pugi
 	{
 		_impl = rhs._impl;
 		_result = rhs._result;
-		rhs._impl = PUGIXML_NULL;
+		rhs._impl = NULL;
 		rhs._result = xpath_parse_result();
 	}
 
@@ -12945,7 +12945,7 @@ namespace pugi
 
 		_impl = rhs._impl;
 		_result = rhs._result;
-		rhs._impl = PUGIXML_NULL;
+		rhs._impl = NULL;
 		rhs._result = xpath_parse_result();
 
 		return *this;
@@ -13109,7 +13109,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_query::operator xpath_query::unspecified_bool_type() const
 	{
-		return _impl ? unspecified_bool_xpath_query : PUGIXML_NULL;
+		return _impl ? unspecified_bool_xpath_query : NULL;
 	}
 
 	PUGI_IMPL_FN bool xpath_query::operator!() const

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -22,6 +22,7 @@
 #include <assert.h>
 #include <limits.h>
 
+
 #ifdef PUGIXML_WCHAR_MODE
 #	include <wchar.h>
 #endif
@@ -293,7 +294,7 @@ PUGI_IMPL_NS_BEGIN
 		T* release()
 		{
 			T* result = data;
-			data = 0;
+			data = PUGIXML_NULL;
 			return result;
 		}
 	};
@@ -476,9 +477,9 @@ PUGI_IMPL_NS_BEGIN
 		{
 			xml_memory_page* result = static_cast<xml_memory_page*>(memory);
 
-			result->allocator = 0;
-			result->prev = 0;
-			result->next = 0;
+			result->allocator = PUGIXML_NULL;
+			result->prev = PUGIXML_NULL;
+			result->next = PUGIXML_NULL;
 			result->busy_size = 0;
 			result->freed_size = 0;
 
@@ -535,7 +536,7 @@ PUGI_IMPL_NS_BEGIN
 
 			// allocate block with some alignment, leaving memory for worst-case padding
 			void* memory = xml_memory::allocate(size);
-			if (!memory) return 0;
+			if (!memory) return PUGIXML_NULL;
 
 			// prepare page structure
 			xml_memory_page* page = xml_memory_page::construct(memory);
@@ -618,7 +619,7 @@ PUGI_IMPL_NS_BEGIN
 
 			if (page->freed_size == page->busy_size)
 			{
-				if (page->next == 0)
+				if (page->next == PUGIXML_NULL)
 				{
 					assert(_root == page);
 
@@ -665,7 +666,7 @@ PUGI_IMPL_NS_BEGIN
 			xml_memory_page* page;
 			xml_memory_string_header* header = static_cast<xml_memory_string_header*>(allocate_memory(full_size, page));
 
-			if (!header) return 0;
+			if (!header) return PUGIXML_NULL;
 
 			// setup header
 			ptrdiff_t page_offset = reinterpret_cast<char*>(header) - reinterpret_cast<char*>(page) - sizeof(xml_memory_page);
@@ -727,7 +728,7 @@ PUGI_IMPL_NS_BEGIN
 		xml_memory_page* page = allocate_page(size <= large_allocation_threshold ? xml_memory_page_size : size);
 		out_page = page;
 
-		if (!page) return 0;
+		if (!page) return PUGIXML_NULL;
 
 		if (size <= large_allocation_threshold)
 		{
@@ -1109,7 +1110,7 @@ namespace pugi
 {
 	struct xml_attribute_struct
 	{
-		xml_attribute_struct(impl::xml_memory_page* page): name(0), value(0), prev_attribute_c(0), next_attribute(0)
+		xml_attribute_struct(impl::xml_memory_page* page): name(PUGIXML_NULL), value(PUGIXML_NULL), prev_attribute_c(PUGIXML_NULL), next_attribute(PUGIXML_NULL)
 		{
 			header = PUGI_IMPL_GETHEADER_IMPL(this, page, 0);
 		}
@@ -1125,7 +1126,7 @@ namespace pugi
 
 	struct xml_node_struct
 	{
-		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): name(0), value(0), parent(0), first_child(0), prev_sibling_c(0), next_sibling(0), first_attribute(0)
+		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): name(PUGIXML_NULL), value(PUGIXML_NULL), parent(PUGIXML_NULL), first_child(PUGIXML_NULL), prev_sibling_c(PUGIXML_NULL), next_sibling(PUGIXML_NULL), first_attribute(PUGIXML_NULL)
 		{
 			header = PUGI_IMPL_GETHEADER_IMPL(this, page, type);
 		}
@@ -1156,7 +1157,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xml_document_struct: public xml_node_struct, public xml_allocator
 	{
-		xml_document_struct(xml_memory_page* page): xml_node_struct(page, node_document), xml_allocator(page), buffer(0), extra_buffers(0)
+		xml_document_struct(xml_memory_page* page): xml_node_struct(page, node_document), xml_allocator(page), buffer(PUGIXML_NULL), extra_buffers(PUGIXML_NULL)
 		{
 		}
 
@@ -1190,7 +1191,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		xml_memory_page* page;
 		void* memory = alloc.allocate_object(sizeof(xml_attribute_struct), page);
-		if (!memory) return 0;
+		if (!memory) return PUGIXML_NULL;
 
 		return new (memory) xml_attribute_struct(page);
 	}
@@ -1199,7 +1200,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		xml_memory_page* page;
 		void* memory = alloc.allocate_object(sizeof(xml_node_struct), page);
-		if (!memory) return 0;
+		if (!memory) return PUGIXML_NULL;
 
 		return new (memory) xml_node_struct(page, type);
 	}
@@ -1338,9 +1339,9 @@ PUGI_IMPL_NS_BEGIN
 		else
 			parent->first_child = next;
 
-		node->parent = 0;
-		node->prev_sibling_c = 0;
-		node->next_sibling = 0;
+		node->parent = PUGIXML_NULL;
+		node->prev_sibling_c = PUGIXML_NULL;
+		node->next_sibling = PUGIXML_NULL;
 	}
 
 	inline void append_attribute(xml_attribute_struct* attr, xml_node_struct* node)
@@ -1421,16 +1422,16 @@ PUGI_IMPL_NS_BEGIN
 		else
 			node->first_attribute = next;
 
-		attr->prev_attribute_c = 0;
-		attr->next_attribute = 0;
+		attr->prev_attribute_c = PUGIXML_NULL;
+		attr->next_attribute = PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN_NO_INLINE xml_node_struct* append_new_node(xml_node_struct* node, xml_allocator& alloc, xml_node_type type = node_element)
 	{
-		if (!alloc.reserve()) return 0;
+		if (!alloc.reserve()) return PUGIXML_NULL;
 
 		xml_node_struct* child = allocate_node(alloc, type);
-		if (!child) return 0;
+		if (!child) return PUGIXML_NULL;
 
 		append_node(child, node);
 
@@ -1439,10 +1440,10 @@ PUGI_IMPL_NS_BEGIN
 
 	PUGI_IMPL_FN_NO_INLINE xml_attribute_struct* append_new_attribute(xml_node_struct* node, xml_allocator& alloc)
 	{
-		if (!alloc.reserve()) return 0;
+		if (!alloc.reserve()) return PUGIXML_NULL;
 
 		xml_attribute_struct* attr = allocate_attribute(alloc);
-		if (!attr) return 0;
+		if (!attr) return PUGIXML_NULL;
 
 		append_attribute(attr, node);
 
@@ -2024,7 +2025,7 @@ PUGI_IMPL_NS_BEGIN
 		if (d0 == 0x3c && d1 == 0) return encoding_utf16_le;
 
 		// no known BOM detected; parse declaration
-		const uint8_t* enc = 0;
+		const uint8_t* enc = PUGIXML_NULL;
 		size_t enc_length = 0;
 
 		if (d0 == 0x3c && d1 == 0x3f && d2 == 0x78 && d3 == 0x6d && parse_declaration_encoding(data, size, enc, enc_length))
@@ -2395,7 +2396,7 @@ PUGI_IMPL_NS_BEGIN
 			if (header & header_mask) alloc->deallocate_string(dest);
 
 			// mark the string as not allocated
-			dest = 0;
+			dest = PUGIXML_NULL;
 			header &= ~header_mask;
 
 			return true;
@@ -2438,7 +2439,7 @@ PUGI_IMPL_NS_BEGIN
 		char_t* end;
 		size_t size;
 
-		gap(): end(0), size(0)
+		gap(): end(PUGIXML_NULL), size(0)
 		{
 		}
 
@@ -2650,7 +2651,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 			else if (*s == 0)
 			{
-				return 0;
+				return PUGIXML_NULL;
 			}
 			else ++s;
 		}
@@ -2678,7 +2679,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 			else if (*s == 0)
 			{
-				return 0;
+				return PUGIXML_NULL;
 			}
 			else ++s;
 		}
@@ -2751,7 +2752,7 @@ PUGI_IMPL_NS_BEGIN
 		case 5: return strconv_pcdata_impl<opt_true, opt_false, opt_true>::parse;
 		case 6: return strconv_pcdata_impl<opt_true, opt_true, opt_false>::parse;
 		case 7: return strconv_pcdata_impl<opt_true, opt_true, opt_true>::parse;
-		default: assert(false); return 0; // unreachable
+		default: assert(false); return PUGIXML_NULL; // unreachable
 		}
 	}
 
@@ -2805,7 +2806,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return 0;
+					return PUGIXML_NULL;
 				}
 				else ++s;
 			}
@@ -2841,7 +2842,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return 0;
+					return PUGIXML_NULL;
 				}
 				else ++s;
 			}
@@ -2873,7 +2874,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return 0;
+					return PUGIXML_NULL;
 				}
 				else ++s;
 			}
@@ -2899,7 +2900,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return 0;
+					return PUGIXML_NULL;
 				}
 				else ++s;
 			}
@@ -2928,7 +2929,7 @@ PUGI_IMPL_NS_BEGIN
 		case 13: return strconv_attribute_impl<opt_true>::parse_wnorm;
 		case 14: return strconv_attribute_impl<opt_false>::parse_wnorm;
 		case 15: return strconv_attribute_impl<opt_true>::parse_wnorm;
-		default: assert(false); return 0; // unreachable
+		default: assert(false); return PUGIXML_NULL; // unreachable
 		}
 	}
 
@@ -2947,7 +2948,7 @@ PUGI_IMPL_NS_BEGIN
 		char_t* error_offset;
 		xml_parse_status error_status;
 
-		xml_parser(xml_allocator* alloc_): alloc(alloc_), error_offset(0), error_status(status_ok)
+		xml_parser(xml_allocator* alloc_): alloc(alloc_), error_offset(PUGIXML_NULL), error_status(status_ok)
 		{
 		}
 
@@ -3559,7 +3560,7 @@ PUGI_IMPL_NS_BEGIN
 				return make_parse_result(PUGI_IMPL_OPTSET(parse_fragment) ? status_ok : status_no_document_element);
 
 			// get last child of the root before parsing
-			xml_node_struct* last_root_child = root->first_child ? root->first_child->prev_sibling_c + 0 : 0;
+			xml_node_struct* last_root_child = root->first_child ? root->first_child->prev_sibling_c + 0 : PUGIXML_NULL;
 
 			// create parser on stack
 			xml_parser parser(static_cast<xml_allocator*>(xmldoc));
@@ -4476,7 +4477,7 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN void node_copy_tree(xml_node_struct* dn, xml_node_struct* sn)
 	{
 		xml_allocator& alloc = get_allocator(dn);
-		xml_allocator* shared_alloc = (&alloc == &get_allocator(sn)) ? &alloc : 0;
+		xml_allocator* shared_alloc = (&alloc == &get_allocator(sn)) ? &alloc : PUGIXML_NULL;
 
 		node_copy_contents(dn, sn, shared_alloc);
 
@@ -4530,7 +4531,7 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN void node_copy_attribute(xml_attribute_struct* da, xml_attribute_struct* sa)
 	{
 		xml_allocator& alloc = get_allocator(da);
-		xml_allocator* shared_alloc = (&alloc == &get_allocator(sa)) ? &alloc : 0;
+		xml_allocator* shared_alloc = (&alloc == &get_allocator(sa)) ? &alloc : PUGIXML_NULL;
 
 		node_copy_string(da->name, da->header, xml_memory_page_name_allocated_mask, sa->name, sa->header, shared_alloc);
 		node_copy_string(da->value, da->header, xml_memory_page_value_allocated_mask, sa->value, sa->header, shared_alloc);
@@ -4641,7 +4642,7 @@ PUGI_IMPL_NS_BEGIN
 	#ifdef PUGIXML_WCHAR_MODE
 		return wcstod(value, 0);
 	#else
-		return strtod(value, 0);
+		return strtod(value, PUGIXML_NULL);
 	#endif
 	}
 
@@ -4650,7 +4651,7 @@ PUGI_IMPL_NS_BEGIN
 	#ifdef PUGIXML_WCHAR_MODE
 		return static_cast<float>(wcstod(value, 0));
 	#else
-		return static_cast<float>(strtod(value, 0));
+		return static_cast<float>(strtod(value, PUGIXML_NULL));
 	#endif
 	}
 
@@ -4755,10 +4756,10 @@ PUGI_IMPL_NS_BEGIN
 		xml_encoding buffer_encoding = impl::get_buffer_encoding(encoding, contents, size);
 
 		// if convert_buffer below throws bad_alloc, we still need to deallocate contents if we own it
-		auto_deleter<void> contents_guard(own ? contents : 0, xml_memory::deallocate);
+		auto_deleter<void> contents_guard(own ? contents : PUGIXML_NULL, xml_memory::deallocate);
 
 		// get private buffer
-		char_t* buffer = 0;
+		char_t* buffer = PUGIXML_NULL;
 		size_t length = 0;
 
 		// coverity[var_deref_model]
@@ -4900,7 +4901,7 @@ PUGI_IMPL_NS_BEGIN
 		static xml_stream_chunk* create()
 		{
 			void* memory = xml_memory::allocate(sizeof(xml_stream_chunk));
-			if (!memory) return 0;
+			if (!memory) return PUGIXML_NULL;
 
 			return new (memory) xml_stream_chunk();
 		}
@@ -4918,7 +4919,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 		}
 
-		xml_stream_chunk(): next(0), size(0)
+		xml_stream_chunk(): next(PUGIXML_NULL), size(0)
 		{
 		}
 
@@ -4930,11 +4931,11 @@ PUGI_IMPL_NS_BEGIN
 
 	template <typename T> PUGI_IMPL_FN xml_parse_status load_stream_data_noseek(std::basic_istream<T>& stream, void** out_buffer, size_t* out_size)
 	{
-		auto_deleter<xml_stream_chunk<T> > chunks(0, xml_stream_chunk<T>::destroy);
+		auto_deleter<xml_stream_chunk<T> > chunks(PUGIXML_NULL, xml_stream_chunk<T>::destroy);
 
 		// read file to a chunk list
 		size_t total = 0;
-		xml_stream_chunk<T>* last = 0;
+		xml_stream_chunk<T>* last = PUGIXML_NULL;
 
 		while (!stream.eof())
 		{
@@ -5020,7 +5021,7 @@ PUGI_IMPL_NS_BEGIN
 
 	template <typename T> PUGI_IMPL_FN xml_parse_result load_stream_impl(xml_document_struct* doc, std::basic_istream<T>& stream, unsigned int options, xml_encoding encoding, char_t** out_buffer)
 	{
-		void* buffer = 0;
+		void* buffer = PUGIXML_NULL;
 		size_t size = 0;
 		xml_parse_status status = status_ok;
 
@@ -5123,7 +5124,7 @@ PUGI_IMPL_NS_BEGIN
 
 		name_null_sentry(xml_node_struct* node_): node(node_), name(node_->name)
 		{
-			node->name = 0;
+			node->name = PUGIXML_NULL;
 		}
 
 		~name_null_sentry()
@@ -5150,11 +5151,11 @@ namespace pugi
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<char, std::char_traits<char> >& stream): narrow_stream(&stream), wide_stream(0)
+	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<char, std::char_traits<char> >& stream): narrow_stream(&stream), wide_stream(PUGIXML_NULL)
 	{
 	}
 
-	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& stream): narrow_stream(0), wide_stream(&stream)
+	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& stream): narrow_stream(PUGIXML_NULL), wide_stream(&stream)
 	{
 	}
 
@@ -5198,7 +5199,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI_IMPL_FN xml_attribute::xml_attribute(): _attr(0)
+	PUGI_IMPL_FN xml_attribute::xml_attribute(): _attr(PUGIXML_NULL)
 	{
 	}
 
@@ -5212,7 +5213,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_attribute::operator xml_attribute::unspecified_bool_type() const
 	{
-		return _attr ? unspecified_bool_xml_attribute : 0;
+		return _attr ? unspecified_bool_xml_attribute : PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xml_attribute::operator!() const
@@ -5531,7 +5532,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI_IMPL_FN xml_node::xml_node(): _root(0)
+	PUGI_IMPL_FN xml_node::xml_node(): _root(PUGIXML_NULL)
 	{
 	}
 
@@ -5545,7 +5546,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_node::operator xml_node::unspecified_bool_type() const
 	{
-		return _root ? unspecified_bool_xml_node : 0;
+		return _root ? unspecified_bool_xml_node : PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xml_node::operator!() const
@@ -5555,22 +5556,22 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_node::iterator xml_node::begin() const
 	{
-		return iterator(_root ? _root->first_child + 0 : 0, _root);
+		return iterator(_root ? _root->first_child + 0 : PUGIXML_NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::iterator xml_node::end() const
 	{
-		return iterator(0, _root);
+		return iterator(PUGIXML_NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::attribute_iterator xml_node::attributes_begin() const
 	{
-		return attribute_iterator(_root ? _root->first_attribute + 0 : 0, _root);
+		return attribute_iterator(_root ? _root->first_attribute + 0 : PUGIXML_NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::attribute_iterator xml_node::attributes_end() const
 	{
-		return attribute_iterator(0, _root);
+		return attribute_iterator(PUGIXML_NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_object_range<xml_node_iterator> xml_node::children() const
@@ -5580,7 +5581,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_object_range<xml_named_node_iterator> xml_node::children(const char_t* name_) const
 	{
-		return xml_object_range<xml_named_node_iterator>(xml_named_node_iterator(child(name_)._root, _root, name_), xml_named_node_iterator(0, _root, name_));
+		return xml_object_range<xml_named_node_iterator>(xml_named_node_iterator(child(name_)._root, _root, name_), xml_named_node_iterator(PUGIXML_NULL, _root, name_));
 	}
 
 	PUGI_IMPL_FN xml_object_range<xml_attribute_iterator> xml_node::attributes() const
@@ -6272,7 +6273,7 @@ namespace pugi
 			attr = next;
 		}
 
-		_root->first_attribute = 0;
+		_root->first_attribute = PUGIXML_NULL;
 
 		return true;
 	}
@@ -6311,7 +6312,7 @@ namespace pugi
 			cur = next;
 		}
 
-		_root->first_child = 0;
+		_root->first_child = PUGIXML_NULL;
 
 		return true;
 	}
@@ -6331,7 +6332,7 @@ namespace pugi
 		doc->header |= impl::xml_memory_page_contents_shared_mask;
 
 		// get extra buffer element (we'll store the document fragment buffer there so that we can deallocate it later)
-		impl::xml_memory_page* page = 0;
+		impl::xml_memory_page* page = PUGIXML_NULL;
 		impl::xml_extra_buffer* extra = static_cast<impl::xml_extra_buffer*>(doc->allocate_memory(sizeof(impl::xml_extra_buffer) + sizeof(void*), page));
 		(void)page;
 
@@ -6344,7 +6345,7 @@ namespace pugi
 	#endif
 
 		// add extra buffer to the list
-		extra->buffer = 0;
+		extra->buffer = PUGIXML_NULL;
 		extra->next = doc->extra_buffers;
 		doc->extra_buffers = extra;
 
@@ -6484,7 +6485,7 @@ namespace pugi
 		xml_node arg_begin(_root);
 		if (!walker.begin(arg_begin)) return false;
 
-		xml_node_struct* cur = _root ? _root->first_child + 0 : 0;
+		xml_node_struct* cur = _root ? _root->first_child + 0 : PUGIXML_NULL;
 
 		if (cur)
 		{
@@ -6620,7 +6621,7 @@ namespace pugi
 			if (impl::is_text_node(node))
 				return node;
 
-		return 0;
+		return PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN xml_node_struct* xml_text::_data_new()
@@ -6631,7 +6632,7 @@ namespace pugi
 		return xml_node(_root).append_child(node_pcdata).internal_object();
 	}
 
-	PUGI_IMPL_FN xml_text::xml_text(): _root(0)
+	PUGI_IMPL_FN xml_text::xml_text(): _root(PUGIXML_NULL)
 	{
 	}
 
@@ -6641,7 +6642,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_text::operator xml_text::unspecified_bool_type() const
 	{
-		return _data() ? unspecified_bool_xml_text : 0;
+		return _data() ? unspecified_bool_xml_text : PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xml_text::operator!() const
@@ -6651,7 +6652,7 @@ namespace pugi
 
 	PUGI_IMPL_FN bool xml_text::empty() const
 	{
-		return _data() == 0;
+		return _data() == PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN const char_t* xml_text::get() const
@@ -7022,7 +7023,7 @@ namespace pugi
 		return temp;
 	}
 
-	PUGI_IMPL_FN xml_named_node_iterator::xml_named_node_iterator(): _name(0)
+	PUGI_IMPL_FN xml_named_node_iterator::xml_named_node_iterator(): _name(PUGIXML_NULL)
 	{
 	}
 
@@ -7132,7 +7133,7 @@ namespace pugi
 		}
 	}
 
-	PUGI_IMPL_FN xml_document::xml_document(): _buffer(0)
+	PUGI_IMPL_FN xml_document::xml_document(): _buffer(PUGIXML_NULL)
 	{
 		_create();
 	}
@@ -7143,7 +7144,7 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI_IMPL_FN xml_document::xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT: _buffer(0)
+	PUGI_IMPL_FN xml_document::xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT: _buffer(PUGIXML_NULL)
 	{
 		_create();
 		_move(rhs);
@@ -7225,7 +7226,7 @@ namespace pugi
 		if (_buffer)
 		{
 			impl::xml_memory::deallocate(_buffer);
-			_buffer = 0;
+			_buffer = PUGIXML_NULL;
 		}
 
 		// destroy extra buffers (note: no need to destroy linked list nodes, they're allocated using document allocator)
@@ -7253,7 +7254,7 @@ namespace pugi
 		static_cast<impl::xml_document_struct*>(_root)->hash.clear();
 	#endif
 
-		_root = 0;
+		_root = PUGIXML_NULL;
 	}
 
 #ifdef PUGIXML_HAS_MOVE
@@ -7326,7 +7327,7 @@ namespace pugi
 			page->prev = doc_page;
 
 			doc_page->next = page;
-			other_page->next = 0;
+			other_page->next = PUGIXML_NULL;
 		}
 
 		// make sure pages point to the correct document state
@@ -7363,7 +7364,7 @@ namespace pugi
 
 		// reset other document
 		new (other) impl::xml_document_struct(PUGI_IMPL_GETPAGE(other));
-		rhs._buffer = 0;
+		rhs._buffer = PUGIXML_NULL;
 	}
 #endif
 
@@ -7790,7 +7791,7 @@ PUGI_IMPL_NS_BEGIN
 
 		for (size_t probe = 0; probe <= hashmod; ++probe)
 		{
-			if (table[bucket] == 0)
+			if (table[bucket] == PUGIXML_NULL)
 			{
 				table[bucket] = key;
 				return true;
@@ -7838,7 +7839,7 @@ PUGI_IMPL_NS_BEGIN
 		size_t _root_size;
 		bool* _error;
 
-		xpath_allocator(xpath_memory_block* root, bool* error = 0): _root(root), _root_size(0), _error(error)
+		xpath_allocator(xpath_memory_block* root, bool* error = PUGIXML_NULL): _root(root), _root_size(0), _error(error)
 		{
 		}
 
@@ -7866,7 +7867,7 @@ PUGI_IMPL_NS_BEGIN
 				if (!block)
 				{
 					if (_error) *_error = true;
-					return 0;
+					return PUGIXML_NULL;
 				}
 
 				block->next = _root;
@@ -7886,7 +7887,7 @@ PUGI_IMPL_NS_BEGIN
 			new_size = (new_size + xpath_memory_block_alignment - 1) & ~(xpath_memory_block_alignment - 1);
 
 			// we can only reallocate the last object
-			assert(ptr == 0 || static_cast<char*>(ptr) + old_size == &_root->data[0] + _root_size);
+			assert(ptr == PUGIXML_NULL || static_cast<char*>(ptr) + old_size == &_root->data[0] + _root_size);
 
 			// try to reallocate the object inplace
 			if (ptr && _root_size - old_size + new_size <= _root->capacity)
@@ -7897,7 +7898,7 @@ PUGI_IMPL_NS_BEGIN
 
 			// allocate a new block
 			void* result = allocate(new_size);
-			if (!result) return 0;
+			if (!result) return PUGIXML_NULL;
 
 			// we have a new block
 			if (ptr)
@@ -7992,7 +7993,7 @@ PUGI_IMPL_NS_BEGIN
 
 		xpath_stack_data(): result(blocks + 0, &oom), temp(blocks + 1, &oom), oom(false)
 		{
-			blocks[0].next = blocks[1].next = 0;
+			blocks[0].next = blocks[1].next = PUGIXML_NULL;
 			blocks[0].capacity = blocks[1].capacity = sizeof(blocks[0].data);
 
 			stack.result = &result;
@@ -8018,7 +8019,7 @@ PUGI_IMPL_NS_BEGIN
 		static char_t* duplicate_string(const char_t* string, size_t length, xpath_allocator* alloc)
 		{
 			char_t* result = static_cast<char_t*>(alloc->allocate((length + 1) * sizeof(char_t)));
-			if (!result) return 0;
+			if (!result) return PUGIXML_NULL;
 
 			memcpy(result, string, length * sizeof(char_t));
 			result[length] = 0;
@@ -8078,7 +8079,7 @@ PUGI_IMPL_NS_BEGIN
 				size_t result_length = target_length + source_length;
 
 				// allocate new buffer
-				char_t* result = static_cast<char_t*>(alloc->reallocate(_uses_heap ? const_cast<char_t*>(_buffer) : 0, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
+				char_t* result = static_cast<char_t*>(alloc->reallocate(_uses_heap ? const_cast<char_t*>(_buffer) : PUGIXML_NULL, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
 				if (!result) return;
 
 				// append first string to the new buffer in case there was no reallocation
@@ -8095,12 +8096,12 @@ PUGI_IMPL_NS_BEGIN
 			}
 		}
 
-		const char_t* c_str() const
+		 const char_t* c_str() const
 		{
 			return _buffer;
 		}
 
-		size_t length() const
+		 size_t length() const
 		{
 			return _uses_heap ? _length_heap : strlength(_buffer);
 		}
@@ -8113,7 +8114,7 @@ PUGI_IMPL_NS_BEGIN
 				size_t length_ = strlength(_buffer);
 				const char_t* data_ = duplicate_string(_buffer, length_, alloc);
 
-				if (!data_) return 0;
+				if (!data_) return PUGIXML_NULL;
 
 				_buffer = data_;
 				_uses_heap = true;
@@ -8123,7 +8124,7 @@ PUGI_IMPL_NS_BEGIN
 			return const_cast<char_t*>(_buffer);
 		}
 
-		bool empty() const
+		 bool empty() const
 		{
 			return *_buffer == 0;
 		}
@@ -8322,7 +8323,7 @@ PUGI_IMPL_NS_BEGIN
 				if (node->value && (node->header & impl::xml_memory_page_value_allocated_or_shared_mask) == 0) return node->value;
 			}
 
-			return 0;
+			return PUGIXML_NULL;
 		}
 
 		xml_attribute_struct* attr = xnode.attribute().internal_object();
@@ -8335,10 +8336,10 @@ PUGI_IMPL_NS_BEGIN
 				if ((attr->header & impl::xml_memory_page_value_allocated_or_shared_mask) == 0) return attr->value;
 			}
 
-			return 0;
+			return PUGIXML_NULL;
 		}
 
-		return 0;
+		return PUGIXML_NULL;
 	}
 
 	struct document_order_comparator
@@ -8451,7 +8452,7 @@ PUGI_IMPL_NS_BEGIN
 		if (v == 0) return PUGIXML_TEXT("0");
 		if (v != v) return PUGIXML_TEXT("NaN");
 		if (v * 2 == v) return value > 0 ? PUGIXML_TEXT("Infinity") : PUGIXML_TEXT("-Infinity");
-		return 0;
+		return PUGIXML_NULL;
 	#endif
 	}
 
@@ -8618,7 +8619,7 @@ PUGI_IMPL_NS_BEGIN
 	#ifdef PUGIXML_WCHAR_MODE
 		return wcstod(string, 0);
 	#else
-		return strtod(string, 0);
+		return strtod(string, PUGIXML_NULL);
 	#endif
 	}
 
@@ -8680,7 +8681,7 @@ PUGI_IMPL_NS_BEGIN
 		{
 			const char_t* pos = find_char(name, ':');
 
-			prefix = pos ? name : 0;
+			prefix = pos ? name : PUGIXML_NULL;
 			prefix_length = pos ? static_cast<size_t>(pos - name) : 0;
 		}
 
@@ -8798,7 +8799,7 @@ PUGI_IMPL_NS_BEGIN
 			unsigned int tc = static_cast<unsigned int>(*to);
 
 			if (fc >= 128 || tc >= 128)
-				return 0;
+				return PUGIXML_NULL;
 
 			// code=128 means "skip character"
 			if (!table[fc])
@@ -8813,7 +8814,7 @@ PUGI_IMPL_NS_BEGIN
 				table[i] = static_cast<unsigned char>(i);
 
 		void* result = alloc->allocate(sizeof(table));
-		if (!result) return 0;
+		if (!result) return PUGIXML_NULL;
 
 		memcpy(result, table, sizeof(table));
 
@@ -8877,7 +8878,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_string: xpath_variable
 	{
-		xpath_variable_string(): xpath_variable(xpath_type_string), value(0)
+		xpath_variable_string(): xpath_variable(xpath_type_string), value(PUGIXML_NULL)
 		{
 		}
 
@@ -8924,11 +8925,11 @@ PUGI_IMPL_NS_BEGIN
 	template <typename T> PUGI_IMPL_FN T* new_xpath_variable(const char_t* name)
 	{
 		size_t length = strlength(name);
-		if (length == 0) return 0; // empty variable names are invalid
+		if (length == 0) return PUGIXML_NULL; // empty variable names are invalid
 
 		// $$ we can't use offsetof(T, name) because T is non-POD, so we just allocate additional length characters
 		void* memory = xml_memory::allocate(sizeof(T) + length * sizeof(char_t));
-		if (!memory) return 0;
+		if (!memory) return PUGIXML_NULL;
 
 		T* result = new (memory) T();
 
@@ -8954,7 +8955,7 @@ PUGI_IMPL_NS_BEGIN
 			return new_xpath_variable<xpath_variable_boolean>(name);
 
 		default:
-			return 0;
+			return PUGIXML_NULL;
 		}
 	}
 
@@ -9107,7 +9108,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_node* _eos;
 
 	public:
-		xpath_node_set_raw(): _type(xpath_node_set::type_unsorted), _begin(0), _end(0), _eos(0)
+		xpath_node_set_raw(): _type(xpath_node_set::type_unsorted), _begin(PUGIXML_NULL), _end(PUGIXML_NULL), _eos(PUGIXML_NULL)
 		{
 		}
 
@@ -9299,7 +9300,7 @@ PUGI_IMPL_NS_BEGIN
 		const char_t* begin;
 		const char_t* end;
 
-		xpath_lexer_string(): begin(0), end(0)
+		xpath_lexer_string(): begin(PUGIXML_NULL), end(PUGIXML_NULL)
 		{
 		}
 
@@ -10487,40 +10488,40 @@ PUGI_IMPL_NS_BEGIN
 
 	public:
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, const char_t* value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(0), _right(0), _next(0)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
 		{
 			assert(type == ast_string_constant);
 			_data.string = value;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, double value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(0), _right(0), _next(0)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
 		{
 			assert(type == ast_number_constant);
 			_data.number = value;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_variable* value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(0), _right(0), _next(0)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
 		{
 			assert(type == ast_variable);
 			_data.variable = value;
 		}
 
-		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_ast_node* left = 0, xpath_ast_node* right = 0):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(left), _right(right), _next(0)
+		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_ast_node* left = PUGIXML_NULL, xpath_ast_node* right = PUGIXML_NULL):
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(left), _right(right), _next(PUGIXML_NULL)
 		{
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_ast_node* left, axis_t axis, nodetest_t test, const char_t* contents):
-			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(static_cast<char>(axis)), _test(static_cast<char>(test)), _left(left), _right(0), _next(0)
+			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(static_cast<char>(axis)), _test(static_cast<char>(test)), _left(left), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
 		{
 			assert(type == ast_step);
 			_data.nodetest = contents;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_ast_node* left, xpath_ast_node* right, predicate_t test):
-			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(0), _test(static_cast<char>(test)), _left(left), _right(right), _next(0)
+			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(0), _test(static_cast<char>(test)), _left(left), _right(right), _next(PUGIXML_NULL)
 		{
 			assert(type == ast_filter || type == ast_predicate);
 		}
@@ -10580,7 +10581,7 @@ PUGI_IMPL_NS_BEGIN
 				xpath_string lr = _left->eval_string(c, stack);
 				xpath_string rr = _right->eval_string(c, stack);
 
-				return find_substring(lr.c_str(), rr.c_str()) != 0;
+				return find_substring(lr.c_str(), rr.c_str()) != PUGIXML_NULL;
 			}
 
 			case ast_func_boolean:
@@ -11389,7 +11390,7 @@ PUGI_IMPL_NS_BEGIN
 			_result->error = message;
 			_result->offset = _lexer.current_pos() - _query;
 
-			return 0;
+			return PUGIXML_NULL;
 		}
 
 		xpath_ast_node* error_oom()
@@ -11397,7 +11398,7 @@ PUGI_IMPL_NS_BEGIN
 			assert(_alloc->_error);
 			*_alloc->_error = true;
 
-			return 0;
+			return PUGIXML_NULL;
 		}
 
 		xpath_ast_node* error_rec()
@@ -11413,37 +11414,37 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, const char_t* value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : 0;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, double value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : 0;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_variable* value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : 0;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
 		}
 
-		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_ast_node* left = 0, xpath_ast_node* right = 0)
+		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_ast_node* left = PUGIXML_NULL, xpath_ast_node* right = PUGIXML_NULL)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, left, right) : 0;
+			return memory ? new (memory) xpath_ast_node(type, rettype, left, right) : PUGIXML_NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, axis_t axis, nodetest_t test, const char_t* contents)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, left, axis, test, contents) : 0;
+			return memory ? new (memory) xpath_ast_node(type, left, axis, test, contents) : PUGIXML_NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, xpath_ast_node* right, predicate_t test)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, left, right, test) : 0;
+			return memory ? new (memory) xpath_ast_node(type, left, right, test) : PUGIXML_NULL;
 		}
 
 		const char_t* alloc_string(const xpath_lexer_string& value)
@@ -11454,7 +11455,7 @@ PUGI_IMPL_NS_BEGIN
 			size_t length = static_cast<size_t>(value.end - value.begin);
 
 			char_t* c = static_cast<char_t*>(_alloc->allocate((length + 1) * sizeof(char_t)));
-			if (!c) return 0;
+			if (!c) return PUGIXML_NULL;
 
 			memcpy(c, value.begin, length * sizeof(char_t));
 			c[length] = 0;
@@ -11697,7 +11698,7 @@ PUGI_IMPL_NS_BEGIN
 				if (!_variables)
 					return error("Unknown variable: variable set is not provided");
 
-				xpath_variable* var = 0;
+				xpath_variable* var = PUGIXML_NULL;
 				if (!get_variable_scratch(_scratch, _variables, name.begin, name.end, &var))
 					return error_oom();
 
@@ -11714,7 +11715,7 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = parse_expression();
-				if (!n) return 0;
+				if (!n) return PUGIXML_NULL;
 
 				if (_lexer.current() != lex_close_brace)
 					return error("Expected ')' to match an opening '('");
@@ -11727,7 +11728,7 @@ PUGI_IMPL_NS_BEGIN
 			case lex_quoted_string:
 			{
 				const char_t* value = alloc_string(_lexer.contents());
-				if (!value) return 0;
+				if (!value) return PUGIXML_NULL;
 
 				_lexer.next();
 
@@ -11748,13 +11749,13 @@ PUGI_IMPL_NS_BEGIN
 
 			case lex_string:
 			{
-				xpath_ast_node* args[2] = {0};
+				xpath_ast_node* args[2] = {PUGIXML_NULL};
 				size_t argc = 0;
 
 				xpath_lexer_string function = _lexer.contents();
 				_lexer.next();
 
-				xpath_ast_node* last_arg = 0;
+				xpath_ast_node* last_arg = PUGIXML_NULL;
 
 				if (_lexer.current() != lex_open_brace)
 					return error("Unrecognized function call");
@@ -11775,7 +11776,7 @@ PUGI_IMPL_NS_BEGIN
 						return error_rec();
 
 					xpath_ast_node* n = parse_expression();
-					if (!n) return 0;
+					if (!n) return PUGIXML_NULL;
 
 					if (argc < 2) args[argc] = n;
 					else last_arg->set_next(n);
@@ -11802,7 +11803,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse_filter_expression()
 		{
 			xpath_ast_node* n = parse_primary_expression();
-			if (!n) return 0;
+			if (!n) return PUGIXML_NULL;
 
 			size_t old_depth = _depth;
 
@@ -11817,10 +11818,10 @@ PUGI_IMPL_NS_BEGIN
 					return error("Predicate has to be applied to node set");
 
 				xpath_ast_node* expr = parse_expression();
-				if (!expr) return 0;
+				if (!expr) return PUGIXML_NULL;
 
 				n = alloc_node(ast_filter, n, expr, predicate_default);
-				if (!n) return 0;
+				if (!n) return PUGIXML_NULL;
 
 				if (_lexer.current() != lex_close_square_brace)
 					return error("Expected ']' to match an opening '['");
@@ -11860,7 +11861,7 @@ PUGI_IMPL_NS_BEGIN
 				if (_lexer.current() == lex_open_square_brace)
 					return error("Predicates are not allowed after an abbreviated step");
 
-				return alloc_node(ast_step, set, axis_self, nodetest_type_node, 0);
+				return alloc_node(ast_step, set, axis_self, nodetest_type_node, PUGIXML_NULL);
 			}
 			else if (_lexer.current() == lex_double_dot)
 			{
@@ -11869,7 +11870,7 @@ PUGI_IMPL_NS_BEGIN
 				if (_lexer.current() == lex_open_square_brace)
 					return error("Predicates are not allowed after an abbreviated step");
 
-				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, 0);
+				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, PUGIXML_NULL);
 			}
 
 			nodetest_t nt_type = nodetest_none;
@@ -11976,14 +11977,14 @@ PUGI_IMPL_NS_BEGIN
 			}
 
 			const char_t* nt_name_copy = alloc_string(nt_name);
-			if (!nt_name_copy) return 0;
+			if (!nt_name_copy) return PUGIXML_NULL;
 
 			xpath_ast_node* n = alloc_node(ast_step, set, axis, nt_type, nt_name_copy);
-			if (!n) return 0;
+			if (!n) return PUGIXML_NULL;
 
 			size_t old_depth = _depth;
 
-			xpath_ast_node* last = 0;
+			xpath_ast_node* last = PUGIXML_NULL;
 
 			while (_lexer.current() == lex_open_square_brace)
 			{
@@ -11993,10 +11994,10 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				xpath_ast_node* expr = parse_expression();
-				if (!expr) return 0;
+				if (!expr) return PUGIXML_NULL;
 
-				xpath_ast_node* pred = alloc_node(ast_predicate, 0, expr, predicate_default);
-				if (!pred) return 0;
+				xpath_ast_node* pred = alloc_node(ast_predicate, PUGIXML_NULL, expr, predicate_default);
+				if (!pred) return PUGIXML_NULL;
 
 				if (_lexer.current() != lex_close_square_brace)
 					return error("Expected ']' to match an opening '['");
@@ -12017,7 +12018,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse_relative_location_path(xpath_ast_node* set)
 		{
 			xpath_ast_node* n = parse_step(set);
-			if (!n) return 0;
+			if (!n) return PUGIXML_NULL;
 
 			size_t old_depth = _depth;
 
@@ -12028,8 +12029,8 @@ PUGI_IMPL_NS_BEGIN
 
 				if (l == lex_double_slash)
 				{
-					n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
-					if (!n) return 0;
+					n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
+					if (!n) return PUGIXML_NULL;
 
 					++_depth;
 				}
@@ -12038,7 +12039,7 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				n = parse_step(n);
-				if (!n) return 0;
+				if (!n) return PUGIXML_NULL;
 			}
 
 			_depth = old_depth;
@@ -12055,7 +12056,7 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
-				if (!n) return 0;
+				if (!n) return PUGIXML_NULL;
 
 				// relative location path can start from axis_attribute, dot, double_dot, multiply and string lexemes; any other lexeme means standalone root path
 				lexeme_t l = _lexer.current();
@@ -12070,16 +12071,16 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
-				if (!n) return 0;
+				if (!n) return PUGIXML_NULL;
 
-				n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
-				if (!n) return 0;
+				n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
+				if (!n) return PUGIXML_NULL;
 
 				return parse_relative_location_path(n);
 			}
 
 			// else clause moved outside of if because of bogus warning 'control may reach end of non-void function being inlined' in gcc 4.0.1
-			return parse_relative_location_path(0);
+			return parse_relative_location_path(PUGIXML_NULL);
 		}
 
 		// PathExpr ::= LocationPath
@@ -12116,7 +12117,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 
 				xpath_ast_node* n = parse_filter_expression();
-				if (!n) return 0;
+				if (!n) return PUGIXML_NULL;
 
 				if (_lexer.current() == lex_slash || _lexer.current() == lex_double_slash)
 				{
@@ -12128,8 +12129,8 @@ PUGI_IMPL_NS_BEGIN
 						if (n->rettype() != xpath_type_node_set)
 							return error("Step has to be applied to node set");
 
-						n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
-						if (!n) return 0;
+						n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
+						if (!n) return PUGIXML_NULL;
 					}
 
 					// select from location path
@@ -12144,7 +12145,7 @@ PUGI_IMPL_NS_BEGIN
 
 				// precedence 7+ - only parses union expressions
 				xpath_ast_node* n = parse_expression(7);
-				if (!n) return 0;
+				if (!n) return PUGIXML_NULL;
 
 				return alloc_node(ast_op_negate, xpath_type_number, n);
 			}
@@ -12232,14 +12233,14 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				xpath_ast_node* rhs = parse_path_or_unary_expression();
-				if (!rhs) return 0;
+				if (!rhs) return PUGIXML_NULL;
 
 				binary_op_t nextop = binary_op_t::parse(_lexer);
 
 				while (nextop.asttype != ast_unknown && nextop.precedence > op.precedence)
 				{
 					rhs = parse_expression_rec(rhs, nextop.precedence);
-					if (!rhs) return 0;
+					if (!rhs) return PUGIXML_NULL;
 
 					nextop = binary_op_t::parse(_lexer);
 				}
@@ -12248,7 +12249,7 @@ PUGI_IMPL_NS_BEGIN
 					return error("Union operator has to be applied to node sets");
 
 				lhs = alloc_node(op.asttype, op.rettype, lhs, rhs);
-				if (!lhs) return 0;
+				if (!lhs) return PUGIXML_NULL;
 
 				op = binary_op_t::parse(_lexer);
 			}
@@ -12282,7 +12283,7 @@ PUGI_IMPL_NS_BEGIN
 				return error_rec();
 
 			xpath_ast_node* n = parse_path_or_unary_expression();
-			if (!n) return 0;
+			if (!n) return PUGIXML_NULL;
 
 			n = parse_expression_rec(n, limit);
 
@@ -12298,7 +12299,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse()
 		{
 			xpath_ast_node* n = parse_expression();
-			if (!n) return 0;
+			if (!n) return PUGIXML_NULL;
 
 			assert(_depth == 0);
 
@@ -12322,7 +12323,7 @@ PUGI_IMPL_NS_BEGIN
 		static xpath_query_impl* create()
 		{
 			void* memory = xml_memory::allocate(sizeof(xpath_query_impl));
-			if (!memory) return 0;
+			if (!memory) return PUGIXML_NULL;
 
 			return new (memory) xpath_query_impl();
 		}
@@ -12336,9 +12337,9 @@ PUGI_IMPL_NS_BEGIN
 			xml_memory::deallocate(impl);
 		}
 
-		xpath_query_impl(): root(0), alloc(&block, &oom), oom(false)
+		xpath_query_impl(): root(PUGIXML_NULL), alloc(&block, &oom), oom(false)
 		{
-			block.next = 0;
+			block.next = PUGIXML_NULL;
 			block.capacity = sizeof(block.data);
 		}
 
@@ -12350,7 +12351,7 @@ PUGI_IMPL_NS_BEGIN
 
 	PUGI_IMPL_FN impl::xpath_ast_node* evaluate_node_set_prepare(xpath_query_impl* impl)
 	{
-		if (!impl) return 0;
+		if (!impl) return PUGIXML_NULL;
 
 		if (impl->root->rettype() != xpath_type_node_set)
 		{
@@ -12420,7 +12421,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_node::operator xpath_node::unspecified_bool_type() const
 	{
-		return (_node || _attribute) ? unspecified_bool_xpath_node : 0;
+		return (_node || _attribute) ? unspecified_bool_xpath_node : PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xpath_node::operator!() const
@@ -12472,7 +12473,7 @@ namespace pugi
 		if (_begin != _storage)
 			impl::xml_memory::deallocate(_begin);
 
-		// size check is necessary because for begin_ = end_ = nullptr, memcpy is UB
+		// size check is necessary because for begin_ = end_ = PUGIXML_NULL, memcpy is UB
 		if (size_)
 			memcpy(storage, begin_, size_ * sizeof(xpath_node));
 
@@ -12590,7 +12591,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_parse_result::operator bool() const
 	{
-		return error == 0;
+		return error == PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN const char* xpath_parse_result::description() const
@@ -12598,7 +12599,7 @@ namespace pugi
 		return error ? error : "No error";
 	}
 
-	PUGI_IMPL_FN xpath_variable::xpath_variable(xpath_value_type type_): _type(type_), _next(0)
+	PUGI_IMPL_FN xpath_variable::xpath_variable(xpath_value_type type_): _type(type_), _next(PUGIXML_NULL)
 	{
 	}
 
@@ -12620,7 +12621,7 @@ namespace pugi
 
 		default:
 			assert(false && "Invalid variable type"); // unreachable
-			return 0;
+			return PUGIXML_NULL;
 		}
 	}
 
@@ -12641,7 +12642,7 @@ namespace pugi
 
 	PUGI_IMPL_FN const char_t* xpath_variable::get_string() const
 	{
-		const char_t* value = (_type == xpath_type_string) ? static_cast<const impl::xpath_variable_string*>(this)->value : 0;
+		const char_t* value = (_type == xpath_type_string) ? static_cast<const impl::xpath_variable_string*>(this)->value : PUGIXML_NULL;
 		return value ? value : PUGIXML_TEXT("");
 	}
 
@@ -12698,7 +12699,7 @@ namespace pugi
 	PUGI_IMPL_FN xpath_variable_set::xpath_variable_set()
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
-			_data[i] = 0;
+			_data[i] = PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN xpath_variable_set::~xpath_variable_set()
@@ -12710,7 +12711,7 @@ namespace pugi
 	PUGI_IMPL_FN xpath_variable_set::xpath_variable_set(const xpath_variable_set& rhs)
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
-			_data[i] = 0;
+			_data[i] = PUGIXML_NULL;
 
 		_assign(rhs);
 	}
@@ -12730,7 +12731,7 @@ namespace pugi
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
 		{
 			_data[i] = rhs._data[i];
-			rhs._data[i] = 0;
+			rhs._data[i] = PUGIXML_NULL;
 		}
 	}
 
@@ -12741,7 +12742,7 @@ namespace pugi
 			_destroy(_data[i]);
 
 			_data[i] = rhs._data[i];
-			rhs._data[i] = 0;
+			rhs._data[i] = PUGIXML_NULL;
 		}
 
 		return *this;
@@ -12780,12 +12781,12 @@ namespace pugi
 			if (impl::strequal(var->name(), name))
 				return var;
 
-		return 0;
+		return PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xpath_variable_set::_clone(xpath_variable* var, xpath_variable** out_result)
 	{
-		xpath_variable* last = 0;
+		xpath_variable* last = PUGIXML_NULL;
 
 		while (var)
 		{
@@ -12830,7 +12831,7 @@ namespace pugi
 		// look for existing variable
 		for (xpath_variable* var = _data[hash]; var; var = var->_next)
 			if (impl::strequal(var->name(), name))
-				return var->type() == type ? var : 0;
+				return var->type() == type ? var : PUGIXML_NULL;
 
 		// add new variable
 		xpath_variable* result = impl::new_xpath_variable(type, name);
@@ -12879,7 +12880,7 @@ namespace pugi
 		return _find(name);
 	}
 
-	PUGI_IMPL_FN xpath_query::xpath_query(const char_t* query, xpath_variable_set* variables): _impl(0)
+	PUGI_IMPL_FN xpath_query::xpath_query(const char_t* query, xpath_variable_set* variables): _impl(PUGIXML_NULL)
 	{
 		impl::xpath_query_impl* qimpl = impl::xpath_query_impl::create();
 
@@ -12903,7 +12904,7 @@ namespace pugi
 				qimpl->root->optimize(&qimpl->alloc);
 
 				_impl = impl.release();
-				_result.error = 0;
+				_result.error = PUGIXML_NULL;
 			}
 			else
 			{
@@ -12917,7 +12918,7 @@ namespace pugi
 		}
 	}
 
-	PUGI_IMPL_FN xpath_query::xpath_query(): _impl(0)
+	PUGI_IMPL_FN xpath_query::xpath_query(): _impl(PUGIXML_NULL)
 	{
 	}
 
@@ -12932,7 +12933,7 @@ namespace pugi
 	{
 		_impl = rhs._impl;
 		_result = rhs._result;
-		rhs._impl = 0;
+		rhs._impl = PUGIXML_NULL;
 		rhs._result = xpath_parse_result();
 	}
 
@@ -12945,7 +12946,7 @@ namespace pugi
 
 		_impl = rhs._impl;
 		_result = rhs._result;
-		rhs._impl = 0;
+		rhs._impl = PUGIXML_NULL;
 		rhs._result = xpath_parse_result();
 
 		return *this;
@@ -13109,7 +13110,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_query::operator xpath_query::unspecified_bool_type() const
 	{
-		return _impl ? unspecified_bool_xpath_query : 0;
+		return _impl ? unspecified_bool_xpath_query : PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xpath_query::operator!() const

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -8100,12 +8100,12 @@ PUGI_IMPL_NS_BEGIN
 			}
 		}
 
-        const char_t* c_str() const
+		const char_t* c_str() const
 		{
 			return _buffer;
 		}
 
-        size_t length() const
+		size_t length() const
 		{
 			return _uses_heap ? _length_heap : strlength(_buffer);
 		}
@@ -8128,7 +8128,7 @@ PUGI_IMPL_NS_BEGIN
 			return const_cast<char_t*>(_buffer);
 		}
 
-        bool empty() const
+		bool empty() const
 		{
 			return *_buffer == 0;
 		}

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -304,7 +304,7 @@ PUGI_IMPL_NS_BEGIN
 	class compact_hash_table
 	{
 	public:
-		compact_hash_table(): _items(0), _capacity(0), _count(0)
+		compact_hash_table(): _items(NULL), _capacity(0), _count(0)
 		{
 		}
 
@@ -313,7 +313,7 @@ PUGI_IMPL_NS_BEGIN
 			if (_items)
 			{
 				xml_memory::deallocate(_items);
-				_items = 0;
+				_items = NULL;
 				_capacity = 0;
 				_count = 0;
 			}
@@ -321,11 +321,11 @@ PUGI_IMPL_NS_BEGIN
 
 		void* find(const void* key)
 		{
-			if (_capacity == 0) return 0;
+			if (_capacity == 0) return NULL;
 
 			item_t* item = get_item(key);
 			assert(item);
-			assert(item->key == key || (item->key == 0 && item->value == 0));
+			assert(item->key == key || (item->key == NULL && item->value == NULL));
 
 			return item->value;
 		}
@@ -337,7 +337,7 @@ PUGI_IMPL_NS_BEGIN
 			item_t* item = get_item(key);
 			assert(item);
 
-			if (item->key == 0)
+			if (item->key == NULL)
 			{
 				_count++;
 				item->key = key;
@@ -380,7 +380,7 @@ PUGI_IMPL_NS_BEGIN
 			{
 				item_t& probe_item = _items[bucket];
 
-				if (probe_item.key == key || probe_item.key == 0)
+				if (probe_item.key == key || probe_item.key == NULL)
 					return &probe_item;
 
 				// hash collision, quadratic probing
@@ -388,7 +388,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 
 			assert(false && "Hash table is full"); // unreachable
-			return 0;
+			return NULL;
 		}
 
 		static PUGI_IMPL_UNSIGNED_OVERFLOW unsigned int hash(const void* key)
@@ -483,9 +483,9 @@ PUGI_IMPL_NS_BEGIN
 			result->freed_size = 0;
 
 		#ifdef PUGIXML_COMPACT
-			result->compact_string_base = 0;
-			result->compact_shared_parent = 0;
-			result->compact_page_marker = 0;
+			result->compact_string_base = NULL;
+			result->compact_shared_parent = NULL;
+			result->compact_page_marker = NULL;
 		#endif
 
 			return result;
@@ -525,7 +525,7 @@ PUGI_IMPL_NS_BEGIN
 		xml_allocator(xml_memory_page* root): _root(root), _busy_size(root->busy_size)
 		{
 		#ifdef PUGIXML_COMPACT
-			_hash = 0;
+			_hash = NULL;
 		#endif
 		}
 
@@ -572,7 +572,7 @@ PUGI_IMPL_NS_BEGIN
 		void* allocate_object(size_t size, xml_memory_page*& out_page)
 		{
 			void* result = allocate_memory(size + sizeof(uint32_t), out_page);
-			if (!result) return 0;
+			if (!result) return NULL;
 
 			// adjust for marker
 			ptrdiff_t offset = static_cast<char*>(result) - reinterpret_cast<char*>(out_page->compact_page_marker);
@@ -628,9 +628,9 @@ PUGI_IMPL_NS_BEGIN
 
 				#ifdef PUGIXML_COMPACT
 					// reset compact state to maximize efficiency
-					page->compact_string_base = 0;
-					page->compact_shared_parent = 0;
-					page->compact_page_marker = 0;
+					page->compact_string_base = NULL;
+					page->compact_shared_parent = NULL;
+					page->compact_page_marker = NULL;
 				#endif
 
 					_busy_size = 0;
@@ -874,7 +874,7 @@ PUGI_IMPL_NS_BEGIN
 					return compact_get_value<header_offset, T>(this);
 			}
 			else
-				return 0;
+				return NULL;
 		}
 
 		T* operator->() const
@@ -917,7 +917,7 @@ PUGI_IMPL_NS_BEGIN
 				{
 					xml_memory_page* page = compact_get_page(this, header_offset);
 
-					if (PUGI_IMPL_UNLIKELY(page->compact_shared_parent == 0))
+					if (PUGI_IMPL_UNLIKELY(page->compact_shared_parent == NULL))
 						page->compact_shared_parent = value;
 
 					if (page->compact_shared_parent == value)
@@ -954,7 +954,7 @@ PUGI_IMPL_NS_BEGIN
 					return compact_get_value<header_offset, T>(this);
 			}
 			else
-				return 0;
+				return NULL;
 		}
 
 		T* operator->() const
@@ -984,7 +984,7 @@ PUGI_IMPL_NS_BEGIN
 			{
 				xml_memory_page* page = compact_get_page(this, header_offset);
 
-				if (PUGI_IMPL_UNLIKELY(page->compact_string_base == 0))
+				if (PUGI_IMPL_UNLIKELY(page->compact_string_base == NULL))
 					page->compact_string_base = value;
 
 				ptrdiff_t offset = value - page->compact_string_base;
@@ -1050,7 +1050,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 			}
 			else
-				return 0;
+				return NULL;
 		}
 
 	private:
@@ -4639,7 +4639,7 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN double get_value_double(const char_t* value)
 	{
 	#ifdef PUGIXML_WCHAR_MODE
-		return wcstod(value, 0);
+		return wcstod(value, NULL);
 	#else
 		return strtod(value, NULL);
 	#endif
@@ -4648,7 +4648,7 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN float get_value_float(const char_t* value)
 	{
 	#ifdef PUGIXML_WCHAR_MODE
-		return static_cast<float>(wcstod(value, 0));
+		return static_cast<float>(wcstod(value, NULL));
 	#else
 		return static_cast<float>(strtod(value, NULL));
 	#endif
@@ -7308,7 +7308,7 @@ namespace pugi
 		doc->_hash = &doc->hash;
 
 		// make sure we don't access other hash up until the end when we reinitialize other document
-		other->_hash = 0;
+		other->_hash = NULL;
 	#endif
 
 		// move page structure
@@ -8616,7 +8616,7 @@ PUGI_IMPL_NS_BEGIN
 
 		// parse string
 	#ifdef PUGIXML_WCHAR_MODE
-		return wcstod(string, 0);
+		return wcstod(string, NULL);
 	#else
 		return strtod(string, NULL);
 	#endif

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -53,6 +53,11 @@
 #	pragma warning(disable: 4996) // this function or variable may be unsafe
 #endif
 
+#if defined(__clang__)
+#	pragma clang diagnostic push
+#	pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant" // NULL as null pointer constant
+#endif
+
 #if defined(_MSC_VER) && defined(__c2__)
 #	pragma clang diagnostic push
 #	pragma clang diagnostic ignored "-Wdeprecated" // this function or variable may be unsafe
@@ -13157,14 +13162,18 @@ namespace pugi
 #	pragma option pop
 #endif
 
+#if defined(_MSC_VER) && defined(__c2__)
+#	pragma clang diagnostic pop
+#endif
+
+#if defined(__clang__)
+#	pragma clang diagnostic pop
+#endif
+
 // Intel C++ does not properly keep warning state for function templates,
 // so popping warning state at the end of translation unit leads to warnings in the middle.
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 #	pragma warning(pop)
-#endif
-
-#if defined(_MSC_VER) && defined(__c2__)
-#	pragma clang diagnostic pop
 #endif
 
 // Undefine all local macros (makes sure we're not leaking macros in header-only mode)

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -22,7 +22,6 @@
 #include <assert.h>
 #include <limits.h>
 
-
 #ifdef PUGIXML_WCHAR_MODE
 #	include <wchar.h>
 #endif
@@ -2626,7 +2625,7 @@ PUGI_IMPL_NS_BEGIN
 	#define PUGI_IMPL_SCANWHILE(X)          { while (X) ++s; }
 	#define PUGI_IMPL_SCANWHILE_UNROLL(X)   { for (;;) { char_t ss = s[0]; if (PUGI_IMPL_UNLIKELY(!(X))) { break; } ss = s[1]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 1; break; } ss = s[2]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 2; break; } ss = s[3]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 3; break; } s += 4; } }
 	#define PUGI_IMPL_ENDSEG()              { ch = *s; *s = 0; ++s; }
-	#define PUGI_IMPL_THROW_ERROR(err, m)   return error_offset = m, error_status = err, static_cast<char_t*>(0)
+	#define PUGI_IMPL_THROW_ERROR(err, m)   return error_offset = m, error_status = err, static_cast<char_t*>(PUGIXML_NULL)
 	#define PUGI_IMPL_CHECK_ERROR(err, m)   { if (*s == 0) PUGI_IMPL_THROW_ERROR(err, m); }
 
 	PUGI_IMPL_FN char_t* strconv_comment(char_t* s, char_t endch)
@@ -8096,12 +8095,12 @@ PUGI_IMPL_NS_BEGIN
 			}
 		}
 
-		 const char_t* c_str() const
+        const char_t* c_str() const
 		{
 			return _buffer;
 		}
 
-		 size_t length() const
+        size_t length() const
 		{
 			return _uses_heap ? _length_heap : strlength(_buffer);
 		}
@@ -8124,7 +8123,7 @@ PUGI_IMPL_NS_BEGIN
 			return const_cast<char_t*>(_buffer);
 		}
 
-		 bool empty() const
+        bool empty() const
 		{
 			return *_buffer == 0;
 		}

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5048,8 +5048,8 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN FILE* open_file_wide(const wchar_t* path, const wchar_t* mode)
 	{
 #if defined(PUGI_IMPL_MSVC_CRT_VERSION) && PUGI_IMPL_MSVC_CRT_VERSION >= 1400
-		FILE* file = 0;
-		return _wfopen_s(&file, path, mode) == 0 ? file : 0;
+		FILE* file = NULL;
+		return _wfopen_s(&file, path, mode) == 0 ? file : NULL;
 #else
 		return _wfopen(path, mode);
 #endif
@@ -5099,8 +5099,8 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN FILE* open_file(const char* path, const char* mode)
 	{
 #if defined(PUGI_IMPL_MSVC_CRT_VERSION) && PUGI_IMPL_MSVC_CRT_VERSION >= 1400
-		FILE* file = 0;
-		return fopen_s(&file, path, mode) == 0 ? file : 0;
+		FILE* file = NULL;
+		return fopen_s(&file, path, mode) == 0 ? file : NULL;
 #else
 		return fopen(path, mode);
 #endif


### PR DESCRIPTION
Fixed a GCC warning about using a const literal zero in place of nullptr (-Wzero-as-null-pointer-constant) by using the already defined PUGIXML_NULL macro when the C++ version supports nullptr.