### PR TITLE
Update config=sanitize and fuzz targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifeq ($(config),coverage)
 endif
 
 ifeq ($(config),sanitize)
-	CXXFLAGS+=-fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,float-cast-overflow -fno-sanitize-recover=all
+	CXXFLAGS+=-fsanitize=address,undefined -fno-sanitize-recover=all
 	LDFLAGS+=-fsanitize=address,undefined
 endif
 
@@ -66,7 +66,7 @@ endif
 
 fuzz_%: $(BUILD)/fuzz_%
 	@mkdir -p build/$@
-	$< build/$@ tests/data_fuzz_$* -max_len=1024 -dict=tests/fuzz_$*.dict
+	$< build/$@ tests/data_fuzz_$* -max_len=1024 -dict=tests/fuzz_$*.dict -fork=16
 
 clean:
 	rm -rf $(BUILD)


### PR DESCRIPTION
We used to need to silence float-divide-by-zero and float-cast-overflow sanitizers since clang used a finite valid floating point value range. Fortunately, since clang-9 UBSAN properly handles various primitive operations per IEEE-754 so we no longer need this workaround.

Also use fork=16 mode for fuzz targets to make it easier to run fuzzing locally.