### PR TITLE
AppVeyor build optimizations

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,8 @@ test_script:
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2017") { .\tests\autotest-appveyor.ps1 15 }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2019") { .\tests\autotest-appveyor.ps1 19 }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2022") { .\tests\autotest-appveyor.ps1 22 }
-  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { & C:\cygwin\bin\bash.exe -c "PATH=/usr/bin:/usr/local/bin:$PATH; make config=coverage test && bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov 2>&1" }
-  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { & C:\cygwin\bin\bash.exe -c "PATH=/usr/bin:/usr/local/bin:$PATH; make config=coverage defines=PUGIXML_WCHAR_MODE test && bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov 2>&1" }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { & C:\cygwin\bin\bash.exe -c "PATH=/usr/bin:/usr/local/bin:$PATH; make -j2 config=coverage test && bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov 2>&1" }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { & C:\cygwin\bin\bash.exe -c "PATH=/usr/bin:/usr/local/bin:$PATH; make -j2 config=coverage defines=PUGIXML_WCHAR_MODE test && bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov 2>&1" }
 
 artifacts:
   - path: .\scripts\*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 image:
   - Visual Studio 2022
   - Visual Studio 2019

--- a/tests/autotest-appveyor.ps1
+++ b/tests/autotest-appveyor.ps1
@@ -45,7 +45,7 @@ foreach ($vs in $args)
 			Add-AppveyorTest $target -Outcome Running
 
 			Write-Output "# Building $target.exe"
-			& cmd /c "cl.exe /Fe$target.exe /EHsc /W4 /WX $deflist $sources 2>&1" | Tee-Object -Variable buildOutput
+			& cmd /c "cl.exe /MP /Fe$target.exe /EHsc /W4 /WX $deflist $sources 2>&1" | Tee-Object -Variable buildOutput
 
 			if ($?)
 			{


### PR DESCRIPTION
- Use /MP for cl.exe builds to try to take advantage of 2 cores
- Use -j2 for MinGW builds to do the same
- Don't build AppVeyor on non-master branches to avoid double builds for PRs from this repository

MP and j2 aren't as impactful as I'd like them to be but they do result in ~25% build time reduction. The branch restriction should additionally cut the time for internal PRs 2x.