### PR TITLE
resolved all microsoft native recommened warnings

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4721,7 +4721,7 @@ PUGI_IMPL_NS_BEGIN
 	template <typename U, typename String, typename Header>
 	PUGI_IMPL_FN bool set_value_integer(String& dest, Header& header, uintptr_t header_mask, U value, bool negative)
 	{
-		char_t buf[64] = "";
+		char_t buf[64]{};
 		char_t* end = buf + sizeof(buf) / sizeof(buf[0]);
 		char_t* begin = integer_to_string(buf, end, value, negative);
 
@@ -8410,7 +8410,7 @@ PUGI_IMPL_NS_BEGIN
 		UI i = 0x7fc00000;
 		float f = 0.0f;
 		// using memcpy to avoid undefined behavior of union type punning.
-		std::memcpy(&f, &i, sizeof(UI));
+		memcpy(&f, &i, sizeof(UI));
 		return static_cast<double>(f);
 	#else
 		// fallback
@@ -8528,7 +8528,7 @@ PUGI_IMPL_NS_BEGIN
 		if (special) return xpath_string::from_const(special);
 
 		// get mantissa + exponent form
-		char mantissa_buffer[32];
+		char mantissa_buffer[32]= "";
 
 		char* mantissa;
 		int exponent;
@@ -8869,7 +8869,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_boolean: xpath_variable
 	{
-		xpath_variable_boolean(): xpath_variable(xpath_type_boolean), value(false), name("")
+		xpath_variable_boolean(): xpath_variable(xpath_type_boolean), value(false), name()
 		{
 		}
 
@@ -8879,7 +8879,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_number: xpath_variable
 	{
-		xpath_variable_number(): xpath_variable(xpath_type_number), value(0), name("")
+		xpath_variable_number(): xpath_variable(xpath_type_number), value(0), name()
 		{
 		}
 
@@ -8889,7 +8889,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_string: xpath_variable
 	{
-		xpath_variable_string(): xpath_variable(xpath_type_string), value(NULL), name("")
+		xpath_variable_string(): xpath_variable(xpath_type_string), value(NULL), name()
 		{
 		}
 
@@ -8904,7 +8904,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_node_set: xpath_variable
 	{
-		xpath_variable_node_set(): xpath_variable(xpath_type_node_set), name("")
+		xpath_variable_node_set(): xpath_variable(xpath_type_node_set), name()
 		{
 		}
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -275,6 +275,14 @@ PUGI_IMPL_NS_BEGIN
 		return static_cast<size_t>(end - s);
 	#endif
 	}
+
+	#ifdef PUGIXML_WCHAR_MODE
+		#define PUGIXML_EMPTY_STRING L""
+	#else 
+		#define PUGIXML_EMPTY_STRING ""
+	#endif
+
+
 PUGI_IMPL_NS_END
 
 // auto_ptr-like object for exception recovery
@@ -3750,7 +3758,7 @@ PUGI_IMPL_NS_BEGIN
 		xml_buffered_writer& operator=(const xml_buffered_writer&);
 
 	public:
-		xml_buffered_writer(xml_writer& writer_, xml_encoding user_encoding): buffer(), scratch(), writer(writer_), bufsize(0), encoding(get_write_encoding(user_encoding))
+		xml_buffered_writer(xml_writer& writer_, xml_encoding user_encoding): buffer(PUGIXML_EMPTY_STRING), scratch(), writer(writer_), bufsize(0), encoding(get_write_encoding(user_encoding))
 		{
 			PUGI_IMPL_STATIC_ASSERT(bufcapacity >= 8);
 		}
@@ -4721,11 +4729,8 @@ PUGI_IMPL_NS_BEGIN
 	template <typename U, typename String, typename Header>
 	PUGI_IMPL_FN bool set_value_integer(String& dest, Header& header, uintptr_t header_mask, U value, bool negative)
 	{
-	#ifdef PUGIXML_WCHAR_MODE
-		char_t buf[64] = L"";
-	#else 
-		char_t buf[64] = "";
-	#endif
+		char_t buf[64] = PUGIXML_EMPTY_STRING;
+
 		char_t* end = buf + sizeof(buf) / sizeof(buf[0]);
 		char_t* begin = integer_to_string(buf, end, value, negative);
 
@@ -4928,7 +4933,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 		}
 
-		xml_stream_chunk(): next(NULL), size(0), data()
+		xml_stream_chunk(): next(NULL), size(0)
 		{
 		}
 
@@ -8873,7 +8878,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_boolean: xpath_variable
 	{
-		xpath_variable_boolean(): xpath_variable(xpath_type_boolean), value(false), name()
+		xpath_variable_boolean(): xpath_variable(xpath_type_boolean), value(false), name(PUGIXML_EMPTY_STRING)
 		{
 		}
 
@@ -8883,7 +8888,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_number: xpath_variable
 	{
-		xpath_variable_number(): xpath_variable(xpath_type_number), value(0), name()
+		xpath_variable_number(): xpath_variable(xpath_type_number), value(0), name(PUGIXML_EMPTY_STRING)
 		{
 		}
 
@@ -8893,7 +8898,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_string: xpath_variable
 	{
-		xpath_variable_string(): xpath_variable(xpath_type_string), value(NULL), name()
+		xpath_variable_string(): xpath_variable(xpath_type_string), value(NULL), name(PUGIXML_EMPTY_STRING)
 		{
 		}
 
@@ -8908,7 +8913,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_node_set: xpath_variable
 	{
-		xpath_variable_node_set(): xpath_variable(xpath_type_node_set), name()
+		xpath_variable_node_set(): xpath_variable(xpath_type_node_set), name(PUGIXML_EMPTY_STRING)
 		{
 		}
 
@@ -12308,7 +12313,7 @@ PUGI_IMPL_NS_BEGIN
 		}
 
 		xpath_parser(const char_t* query, xpath_variable_set* variables, xpath_allocator* alloc, xpath_parse_result* result): 
-			_alloc(alloc), _lexer(query), _query(query), _variables(variables), _result(result), _scratch(), _depth(0)
+			_alloc(alloc), _lexer(query), _query(query), _variables(variables), _result(result), _scratch(PUGIXML_EMPTY_STRING), _depth(0)
 		{
 		}
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4721,7 +4721,11 @@ PUGI_IMPL_NS_BEGIN
 	template <typename U, typename String, typename Header>
 	PUGI_IMPL_FN bool set_value_integer(String& dest, Header& header, uintptr_t header_mask, U value, bool negative)
 	{
-		char_t buf[64]{};
+	#ifdef PUGIXML_WCHAR_MODE
+		char_t buf[64] = L"";
+	#else 
+		char_t buf[64] = "";
+	#endif
 		char_t* end = buf + sizeof(buf) / sizeof(buf[0]);
 		char_t* begin = integer_to_string(buf, end, value, negative);
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -3758,9 +3758,10 @@ PUGI_IMPL_NS_BEGIN
 		xml_buffered_writer& operator=(const xml_buffered_writer&);
 
 	public:
-		xml_buffered_writer(xml_writer& writer_, xml_encoding user_encoding): buffer(PUGIXML_EMPTY_STRING), scratch(), writer(writer_), bufsize(0), encoding(get_write_encoding(user_encoding))
+		xml_buffered_writer(xml_writer& writer_, xml_encoding user_encoding): scratch(), writer(writer_), bufsize(0), encoding(get_write_encoding(user_encoding))
 		{
 			PUGI_IMPL_STATIC_ASSERT(bufcapacity >= 8);
+			strcpy(buffer, PUGIXML_EMPTY_STRING);
 		}
 
 		size_t flush()
@@ -8878,8 +8879,9 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_boolean: xpath_variable
 	{
-		xpath_variable_boolean(): xpath_variable(xpath_type_boolean), value(false), name(PUGIXML_EMPTY_STRING)
+		xpath_variable_boolean(): xpath_variable(xpath_type_boolean), value(false)
 		{
+			strcpy(name, PUGIXML_EMPTY_STRING);
 		}
 
 		bool value;
@@ -8888,8 +8890,9 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_number: xpath_variable
 	{
-		xpath_variable_number(): xpath_variable(xpath_type_number), value(0), name(PUGIXML_EMPTY_STRING)
+		xpath_variable_number(): xpath_variable(xpath_type_number), value(0)
 		{
+			strcpy(name, PUGIXML_EMPTY_STRING);
 		}
 
 		double value;
@@ -8898,8 +8901,9 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_string: xpath_variable
 	{
-		xpath_variable_string(): xpath_variable(xpath_type_string), value(NULL), name(PUGIXML_EMPTY_STRING)
+		xpath_variable_string(): xpath_variable(xpath_type_string), value(NULL)
 		{
+			strcpy(name, PUGIXML_EMPTY_STRING);
 		}
 
 		~xpath_variable_string()
@@ -8913,8 +8917,9 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_node_set: xpath_variable
 	{
-		xpath_variable_node_set(): xpath_variable(xpath_type_node_set), name(PUGIXML_EMPTY_STRING)
+		xpath_variable_node_set(): xpath_variable(xpath_type_node_set)
 		{
+			strcpy(name, PUGIXML_EMPTY_STRING);
 		}
 
 		xpath_node_set value;
@@ -12313,8 +12318,9 @@ PUGI_IMPL_NS_BEGIN
 		}
 
 		xpath_parser(const char_t* query, xpath_variable_set* variables, xpath_allocator* alloc, xpath_parse_result* result): 
-			_alloc(alloc), _lexer(query), _query(query), _variables(variables), _result(result), _scratch(PUGIXML_EMPTY_STRING), _depth(0)
+			_alloc(alloc), _lexer(query), _query(query), _variables(variables), _result(result), _depth(0)
 		{
+			strcpy(_scratch, PUGIXML_EMPTY_STRING);
 		}
 
 		xpath_ast_node* parse()


### PR DESCRIPTION
Resolved all the Microsoft Native Recommended warnings.
Compiled using C++14 on MSVC, but should be backwards compatible further than that. Wasn't sure what version to target.

- default initialized uninitialized variables.
- replaced bitwise & which was used to combine bools with logical &&. Better represents intent and allows short-circuiting, which bitwise & does not.
- added a null check
- replaced union type punning with memcpy to avoid undefined behavior.
- Ensure null termination of mantissa_buffer for safe use of strlen
- Some explicit casting to avoid risk of arithmetic overflow.