### PR TITLE
Fix -Wshorten-64-to-32 warning on Android NDK when targeting x86

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4801,7 +4801,8 @@ PUGI_IMPL_NS_BEGIN
 		// anything that's not a regular file doesn't have a coherent length
 		if (!S_ISREG(st.st_mode)) return status_io_error;
 
-		typedef off_t length_type;
+		// normally st_size is off_t, but Android NDK defines off_t as long (which is 32-bit when targeting x86 on Android) and st_size as long long
+		typedef long long length_type;
 		length_type length = st.st_size;
 	#elif defined(PUGI_IMPL_MSVC_CRT_VERSION) && PUGI_IMPL_MSVC_CRT_VERSION >= 1400
 		// there are 64-bit versions of fseek/ftell, let's use them


### PR DESCRIPTION
stat.h defines struct stat to use long long on Android NDK when targeting x86; off_t however is defined as long, which is 32-bit (unlike other Unix-like platforms). This results in a narrowing conversion which produces a warning, and can also result in silently reading a prefix of a huge file instead of a clean "out of memory" error. To avoid this, we need to deduce the type of stat::st_size which requires moving the length conversion logic to a templated function since we can't use `auto`/`decltype` before C++11.

Fixes #603.