### PR TITLE
Add Bazel support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "pugixml",
+    srcs = [
+        "src/pugiconfig.hpp",
+        "src/pugixml.cpp",
+    ],
+    hdrs = ["src/pugixml.hpp"],
+    includes = ["src/"],
+    strip_include_prefix = "src",
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "pugixml",
+    version = "1.14",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.9")


### PR DESCRIPTION
This PR helps users of the Bazel build system to integrate pugixml in their builds.

Supporting the Bazel build systems is of course more effort to maintain but helps to spread pugixml.
In the worst case the Bazel build path does simply not work - in the best case, someone who uses Bazel can benefit from it.

Also, other projects support Bazel side by side to other build systems (e.g. Catch2, gtest, etc.).

I will maintain the pugixml Bazel build at least for a half year.