### PR TITLE
Work around 'unreferenced function' warnings in NO_STL builds

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5054,6 +5054,14 @@ PUGI_IMPL_NS_BEGIN
 #if defined(PUGI_IMPL_MSVC_CRT_VERSION) || defined(__BORLANDC__) || (defined(__MINGW32__) && (!defined(__STRICT_ANSI__) || defined(__MINGW64_VERSION_MAJOR)))
 	PUGI_IMPL_FN FILE* open_file_wide(const wchar_t* path, const wchar_t* mode)
 	{
+#ifdef PUGIXML_NO_STL
+		// ensure these symbols are consistently referenced to avoid 'unreferenced function' warnings
+		// note that generally these functions are used in STL builds, but PUGIXML_NO_STL leaves the only usage in convert_path_heap
+		(void)&as_utf8_begin;
+		(void)&as_utf8_end;
+		(void)&strlength_wide;
+#endif
+
 #if defined(PUGI_IMPL_MSVC_CRT_VERSION) && PUGI_IMPL_MSVC_CRT_VERSION >= 1400
 		FILE* file = NULL;
 		return _wfopen_s(&file, path, mode) == 0 ? file : NULL;


### PR DESCRIPTION
Normally, as_utf8_begin et al are used in STL functions but when STL is disabled, these are only used if the target platform lacks first class support for wchar_t FILE* APIs. With some warning levels we consequently can get warnings about these functions not being referenced; this affects MSVC (when using aggressive /Wall warning setup) and MinGW (when using -Wall which should work on gcc without warnings, hence the fix).

Not defining these in the first place is difficult because of the complexity of the selection logic for open_file_wide so for now just mark these as unused. The strange (void)& syntax is needed for MSVC to not trigger another warning...

The workaround is narrowly scoped to avoid unforeseen compatibility issues.

Fixes #619.