### PR TITLE
xmldocument::save: use encoding interpreted by get_write_encoding in buffered_writer constructor

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -7460,7 +7460,7 @@ namespace pugi
 	{
 		impl::xml_buffered_writer buffered_writer(writer, encoding);
 
-		if ((flags & format_write_bom) && encoding != encoding_latin1)
+		if ((flags & format_write_bom) && buffered_writer.encoding != encoding_latin1)
 		{
 			// BOM always represents the codepoint U+FEFF, so just write it in native encoding
 		#ifdef PUGIXML_WCHAR_MODE
@@ -7474,7 +7474,7 @@ namespace pugi
 		if (!(flags & format_no_declaration) && !impl::has_declaration(_root))
 		{
 			buffered_writer.write_string(PUGIXML_TEXT("<?xml version=\"1.0\""));
-			if (encoding == encoding_latin1) buffered_writer.write_string(PUGIXML_TEXT(" encoding=\"ISO-8859-1\""));
+			if (buffered_writer.encoding == encoding_latin1) buffered_writer.write_string(PUGIXML_TEXT(" encoding=\"ISO-8859-1\""));
 			buffered_writer.write('?', '>');
 			if (!(flags & format_raw)) buffered_writer.write('\n');
 		}


### PR DESCRIPTION
This is a preemptive patch, for something that is currently not a bug, but could become one in the future.

`xml_document::save` currently constructs `buffered_writer` with parameter `encoding`:
https://github.com/zeux/pugixml/blob/master/src/pugixml.cpp#L7459

The `xml_buffered_writer` constructor then invokes `get_write_encoding` to interpret that `user_encoding`:
https://github.com/zeux/pugixml/blob/master/src/pugixml.cpp#L3753

`get_write_encoding` can modify the value of `encoding` (that is subsequently used to initialize `buffered_writer.encoding`)
https://github.com/zeux/pugixml/blob/master/src/pugixml.cpp#L3618

`xml_document::save` proceeds to perform two checks on the unmodified local function parameter `encoding`:
https://github.com/zeux/pugixml/blob/master/src/pugixml.cpp#L7463 (`encoding != encoding_latin1`)
and
https://github.com/zeux/pugixml/blob/master/src/pugixml.cpp#L7477 (`encoding == encoding_latin1`)

This implementation could cause a bug in the future, if either of the following becomes true:

1. `encoding_latin1` is modified to a different encoding in `get_write_encoding`
2. any other encoding is modified to `encoding_latin1`
3. a similar check is added in `xml_document::save` on any other encoding that is translated either to a different value or from a different value in `get_write_encoding`, meaning that the check would then act on the non-interpreted function parameter, possibly triggering an action for the wrong encoding

This patch implements the two checks on the interpreted `buffered_writer.encoding` member variable instead of the unmodified function parameter `encoding`.