### PR TITLE
throw() -> noexcept

### DIFF
--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -2115,7 +2115,7 @@ By default, XPath functions throw `xpath_exception` object in case of errors; ad
 
 [source]
 ----
-virtual const char* xpath_exception::what() const throw();
+virtual const char* xpath_exception::what() const noexcept;
 const xpath_parse_result& xpath_exception::result() const;
 ----
 
@@ -3140,7 +3140,7 @@ const unsigned int +++<a href="#parse_wnorm_attribute">parse_wnorm_attribute</a>
     operator +++<a href="#xpath_query::unspecified_bool_type">unspecified_bool_type</a>+++() const;
 
 +++<span class="tok-k">class</span> <a href="#xpath_exception">xpath_exception</a>+++: public std::exception
-    virtual const char* +++<a href="#xpath_exception::what">what</a>+++() const throw();
+    virtual const char* +++<a href="#xpath_exception::what">what</a>+++() const noexcept;
 
     const xpath_parse_result& +++<a href="#xpath_exception::result">result</a>+++() const;
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -12391,7 +12391,7 @@ namespace pugi
 		assert(_result.error);
 	}
 
-	PUGI_IMPL_FN const char* xpath_exception::what() const throw()
+	PUGI_IMPL_FN const char* xpath_exception::what() const PUGIXML_NOEXCEPT
 	{
 		return _result.error;
 	}

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -82,14 +82,14 @@
 #	endif
 #endif
 
-// If C++ is 2011 or higher, add 'noexcept' specifiers
+// If C++ is 2011 or higher, use 'noexcept' specifiers
 #ifndef PUGIXML_NOEXCEPT
 #	if __cplusplus >= 201103
 #		define PUGIXML_NOEXCEPT noexcept
 #	elif defined(_MSC_VER) && _MSC_VER >= 1900
 #		define PUGIXML_NOEXCEPT noexcept
 #	else
-#		define PUGIXML_NOEXCEPT
+#		define PUGIXML_NOEXCEPT throw()
 #	endif
 #endif
 

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -1314,7 +1314,7 @@ namespace pugi
 		explicit xpath_exception(const xpath_parse_result& result);
 
 		// Get error message
-		virtual const char* what() const throw() PUGIXML_OVERRIDE;
+		virtual const char* what() const PUGIXML_NOEXCEPT PUGIXML_OVERRIDE;
 
 		// Get parse result
 		const xpath_parse_result& result() const;


### PR DESCRIPTION
`throw()` was deprecated in C++11 and removed in C++17. `noexcept` is the appropriate fix.