### PR TITLE
Add string view support (only impl, no tests)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
     - name: make test
       run: |
         export CXX=${{matrix.compiler}}
+        make test cxxstd=c++17 defines=${{matrix.defines}} config=release pugiflags=-DPUGIXML_STRING_VIEW -j2
         make test cxxstd=c++11 defines=${{matrix.defines}} config=release -j2
         make test cxxstd=c++98 defines=${{matrix.defines}} config=debug -j2
         make test defines=${{matrix.defines}} config=sanitize -j2
@@ -42,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: cmake configure
-      run: cmake . -DPUGIXML_BUILD_TESTS=ON -D${{matrix.defines}}=ON -A ${{matrix.arch}}
+      run: cmake . -DPUGIXML_BUILD_TESTS=ON -D${{matrix.defines}}=ON -DPUGIXML_STRING_VIEW=ON -A ${{matrix.arch}}
     - name: cmake test
       shell: bash # necessary for fail-fast
       run: |

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ MAKEFLAGS+=-r
 config=debug
 defines=standard
 cxxstd=c++11
+pugiflags=
 # set cxxstd=any to disable use of -std=...
 
 BUILD=build/make-$(firstword $(CXX))-$(config)-$(defines)-$(cxxstd)
@@ -38,6 +39,10 @@ endif
 ifneq ($(defines),standard)
 	COMMA=,
 	CXXFLAGS+=-D $(subst $(COMMA), -D ,$(defines))
+endif
+
+ifneq ($(pugiflags),)
+	CXXFLAGS+=$(pugiflags)
 endif
 
 ifneq ($(findstring PUGIXML_NO_EXCEPTIONS,$(defines)),)

--- a/src/pugiconfig.hpp
+++ b/src/pugiconfig.hpp
@@ -26,6 +26,11 @@
 // Uncomment this to disable STL
 // #define PUGIXML_NO_STL
 
+// Uncomment this to enable support for std::string_view (requires C++17, PUGIXML_NO_STL will override this)
+// Note: In a future version of pugixml this macro will become obsolete.
+//       Support will then be enabled automatically if the used C++ standard supports it.
+// #define PUGIXML_STRING_VIEW
+
 // Uncomment this to disable exceptions
 // #define PUGIXML_NO_EXCEPTIONS
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5442,7 +5442,7 @@ namespace pugi
 	}
 
 #ifdef PUGI_HAS_STRING_VIEW
-	PUGI_IMPL_FN bool xml_attribute::set_name(const string_view_t rhs)
+	PUGI_IMPL_FN bool xml_attribute::set_name(string_view_t rhs)
 	{
 		return set_name(rhs.data(), rhs.size());
 	}
@@ -5463,7 +5463,7 @@ namespace pugi
 	}
 
 #ifdef PUGI_HAS_STRING_VIEW
-	PUGI_IMPL_FN bool xml_attribute::set_value(const string_view_t rhs)
+	PUGI_IMPL_FN bool xml_attribute::set_value(string_view_t rhs)
 	{
 		return set_value(rhs.data(), rhs.size());
 	}
@@ -5863,7 +5863,7 @@ namespace pugi
 	}
 
 #ifdef PUGI_HAS_STRING_VIEW
-	PUGI_IMPL_FN bool xml_node::set_name(const string_view_t rhs)
+	PUGI_IMPL_FN bool xml_node::set_name(string_view_t rhs)
 	{
 		return set_name(rhs.data(), rhd.size());
 	}
@@ -5890,7 +5890,7 @@ namespace pugi
 	}
 
 #ifdef PUGI_HAS_STRING_VIEW
-	PUGI_IMPL_FN bool xml_node::set_value(const string_view_t rhs)
+	PUGI_IMPL_FN bool xml_node::set_value(string_view_t rhs)
 	{
 		return set_value(rhs.data(), rhs.value());
 	}
@@ -6786,7 +6786,7 @@ namespace pugi
 	}
 
 #ifdef PUGI_HAS_STRING_VIEW
-	PUGI_IMPL_FN bool xml_text::set(const string_view_t rhs)
+	PUGI_IMPL_FN bool xml_text::set(string_view_t rhs)
 	{
 		return set(rhs.data(), rhs.size());
 	}

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -5441,6 +5441,13 @@ namespace pugi
 		return impl::strcpy_insitu(_attr->name, _attr->header, impl::xml_memory_page_name_allocated_mask, rhs, size);
 	}
 
+#ifdef PUGI_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_attribute::set_name(const string_view_t rhs)
+	{
+		return set_name(rhs.data(), rhs.size());
+	}
+#endif
+
 	PUGI_IMPL_FN bool xml_attribute::set_value(const char_t* rhs)
 	{
 		if (!_attr) return false;
@@ -5454,6 +5461,13 @@ namespace pugi
 
 		return impl::strcpy_insitu(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, size);
 	}
+
+#ifdef PUGI_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_attribute::set_value(const string_view_t rhs)
+	{
+		return set_value(rhs.data(), rhs.size());
+	}
+#endif
 
 	PUGI_IMPL_FN bool xml_attribute::set_value(int rhs)
 	{
@@ -5848,6 +5862,13 @@ namespace pugi
 		return impl::strcpy_insitu(_root->name, _root->header, impl::xml_memory_page_name_allocated_mask, rhs, size);
 	}
 
+#ifdef PUGI_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_node::set_name(const string_view_t rhs)
+	{
+		return set_name(rhs.data(), rhd.size());
+	}
+#endif
+
 	PUGI_IMPL_FN bool xml_node::set_value(const char_t* rhs)
 	{
 		xml_node_type type_ = _root ? PUGI_IMPL_NODETYPE(_root) : node_null;
@@ -5867,6 +5888,13 @@ namespace pugi
 
 		return impl::strcpy_insitu(_root->value, _root->header, impl::xml_memory_page_value_allocated_mask, rhs, size);
 	}
+
+#ifdef PUGI_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_node::set_value(const string_view_t rhs)
+	{
+		return set_value(rhs.data(), rhs.value());
+	}
+#endif
 
 	PUGI_IMPL_FN xml_attribute xml_node::append_attribute(const char_t* name_)
 	{
@@ -6756,6 +6784,13 @@ namespace pugi
 
 		return dn ? impl::strcpy_insitu(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, size) : false;
 	}
+
+#ifdef PUGI_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_text::set(const string_view_t rhs)
+	{
+		return set(rhs.data(), rhs.size());
+	}
+#endif
 
 	PUGI_IMPL_FN bool xml_text::set(int rhs)
 	{

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -159,7 +159,7 @@ namespace pugi
 
 #ifdef PUGI_HAS_STRING_VIEW
 	// String view type used for overloads of functions that accept strings; depends on PUGIXML_WCHAR_MODE
-	using string_view_t = std::basic_string_view<char_t>;
+	typedef std::basic_string_view<char_t> string_view_t;
 #endif
 }
 

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -162,6 +162,7 @@ namespace pugi
 #endif
 
 #ifdef PUGI_HAS_STRING_VIEW
+	// String view type used for overloads of functions that accept strings; depends on PUGIXML_WCHAR_MODE
 	using string_view_t = std::basic_string_view<char_t>;
 #endif
 }
@@ -447,8 +448,14 @@ namespace pugi
 		// Set attribute name/value (returns false if attribute is empty or there is not enough memory)
 		bool set_name(const char_t* rhs);
 		bool set_name(const char_t* rhs, size_t size);
+#ifdef PUGI_HAS_STRING_VIEW
+		bool set_name(string_view_t rhs);
+#endif
 		bool set_value(const char_t* rhs);
 		bool set_value(const char_t* rhs, size_t size);
+#ifdef PUGI_HAS_STRING_VIEW
+		bool set_value(string_view_t rhs);
+#endif
 
 		// Set attribute value with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set_value(int rhs);
@@ -583,8 +590,14 @@ namespace pugi
 		// Set node name/value (returns false if node is empty, there is not enough memory, or node can not have name/value)
 		bool set_name(const char_t* rhs);
 		bool set_name(const char_t* rhs, size_t size);
+#ifdef PUGI_HAS_STRING_VIEW
+		bool set_name(string_view_t rhs);
+#endif
 		bool set_value(const char_t* rhs);
 		bool set_value(const char_t* rhs, size_t size);
+#ifdef PUGI_HAS_STRING_VIEW
+		bool set_value(string_view_t rhs);
+#endif
 
 		// Add attribute with specified name. Returns added attribute, or empty attribute on errors.
 		xml_attribute append_attribute(const char_t* name);
@@ -814,6 +827,9 @@ namespace pugi
 		// Set text (returns false if object is empty or there is not enough memory)
 		bool set(const char_t* rhs);
 		bool set(const char_t* rhs, size_t size);
+#ifdef PUGI_HAS_STRING_VIEW
+		bool set(string_view_t rhs);
+#endif
 
 		// Set text with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set(int rhs);

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -122,6 +122,26 @@
 #	endif
 #endif
 
+// Detect if C++ standard supports 'string_view' (2017 or higher)
+#ifndef PUGI_STRING_VIEW_SUPPORTED
+#	if defined(__cpp_lib_string_view) || __cplusplus >= 201703L || defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
+#		define PUGI_STRING_VIEW_SUPPORTED 1
+#	endif
+#endif
+// Enable 'string_view' support if requested and supported
+#ifndef PUGI_HAS_STRING_VIEW
+#	if defined(PUGI_ENABLE_STRING_VIEW) && !defined(PUGIXML_NO_STL)
+#		ifdef PUGI_STRING_VIEW_SUPPORTED
+#			define PUGI_HAS_STRING_VIEW
+#		else
+#			warning "Support for std::string_view was requested but is not supported by your C++ standard"
+#		endif
+#	endif
+#endif
+#ifdef PUGI_HAS_STRING_VIEW
+#	include <string_view>
+#endif
+
 // Character interface macros
 #ifdef PUGIXML_WCHAR_MODE
 #	define PUGIXML_TEXT(t) L ## t

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -124,7 +124,7 @@
 
 // Enable 'string_view' support if requested and supported (at least C++17)
 #ifndef PUGI_HAS_STRING_VIEW
-#	if (defined(__cpp_lib_string_view) || __cplusplus >= 201703L || defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) \
+#	if (__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)) \
 		&& defined(PUGIXML_STRING_VIEW) && !defined(PUGIXML_NO_STL)
 #		define PUGI_HAS_STRING_VIEW
 #	endif

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -160,6 +160,10 @@ namespace pugi
 	// String type used for operations that work with STL string; depends on PUGIXML_WCHAR_MODE
 	typedef std::basic_string<PUGIXML_CHAR> string_t;
 #endif
+
+#ifdef PUGI_HAS_STRING_VIEW
+	using string_view_t = std::basic_string_view<char_t>;
+#endif
 }
 
 // The PugiXML namespace

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -125,17 +125,13 @@
 // Detect if C++ standard supports 'string_view' (2017 or higher)
 #ifndef PUGI_STRING_VIEW_SUPPORTED
 #	if defined(__cpp_lib_string_view) || __cplusplus >= 201703L || defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
-#		define PUGI_STRING_VIEW_SUPPORTED 1
+#		define PUGI_STRING_VIEW_SUPPORTED
 #	endif
 #endif
 // Enable 'string_view' support if requested and supported
 #ifndef PUGI_HAS_STRING_VIEW
-#	if defined(PUGI_ENABLE_STRING_VIEW) && !defined(PUGIXML_NO_STL)
-#		ifdef PUGI_STRING_VIEW_SUPPORTED
-#			define PUGI_HAS_STRING_VIEW
-#		else
-#			warning "Support for std::string_view was requested but is not supported by your C++ standard"
-#		endif
+#	if defined(PUGI_STRING_VIEW_SUPPORTED) && defined(PUGI_ENABLE_STRING_VIEW) && !defined(PUGIXML_NO_STL)
+#		define PUGI_HAS_STRING_VIEW
 #	endif
 #endif
 #ifdef PUGI_HAS_STRING_VIEW

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -122,15 +122,10 @@
 #	endif
 #endif
 
-// Detect if C++ standard supports 'string_view' (2017 or higher)
-#ifndef PUGI_STRING_VIEW_SUPPORTED
-#	if defined(__cpp_lib_string_view) || __cplusplus >= 201703L || defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
-#		define PUGI_STRING_VIEW_SUPPORTED
-#	endif
-#endif
-// Enable 'string_view' support if requested and supported
+// Enable 'string_view' support if requested and supported (at least C++17)
 #ifndef PUGI_HAS_STRING_VIEW
-#	if defined(PUGI_STRING_VIEW_SUPPORTED) && defined(PUGI_ENABLE_STRING_VIEW) && !defined(PUGIXML_NO_STL)
+#	if (defined(__cpp_lib_string_view) || __cplusplus >= 201703L || defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) \
+		&& defined(PUGIXML_STRING_VIEW) && !defined(PUGIXML_NO_STL)
 #		define PUGI_HAS_STRING_VIEW
 #	endif
 #endif
@@ -1524,6 +1519,10 @@ namespace std
 #if defined(PUGIXML_HEADER_ONLY) && !defined(PUGIXML_SOURCE)
 #	define PUGIXML_SOURCE "pugixml.cpp"
 #	include PUGIXML_SOURCE
+#endif
+
+#ifdef PUGI_HAS_STRING_VIEW
+#	undef PUGI_HAS_STRING_VIEW
 #endif
 
 /**


### PR DESCRIPTION
Productive implementation should be complete (restricted to the functions you mentioned for a first PR) but there are no tests yet. 
So this is intentionally only a draft to get quick review on the implementation. Despite the limited scope there are still many choices and you might want those differently. Examples are:
* Issue a warning if string_view is requested or not?
* Delegate to existing overload or copy the implementation?
* Define `string_view_t` via a type alias since we already know this is supported or use `typedef` to stay consistent with `char_t` etc.?

I will add tests soon and then publish the PR.