### PR TITLE
Add remaining std::string_view overloads

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -252,6 +252,25 @@ PUGI_IMPL_NS_BEGIN
 	#endif
 	}
 
+#ifdef PUGIXML_HAS_STRING_VIEW
+	// Check if dst contains all of the characters in src followed by a null terminator,
+	// requiring that dst is a null terminated string.
+	PUGI_IMPL_FN bool stringview_equal(string_view_t srcview, const char_t* dst)
+	{
+		// std::basic_string_view::compare(char*) has the right behavior, but it performs an up-front
+		// traversal of dst to compute its length.
+		assert(dst);
+		size_t srclen = srcview.size();
+		const char_t* src = srcview.data();
+
+		while (*dst && srclen && *src == *dst)
+		{
+			++src; --srclen; ++dst;
+		}
+		return srclen == 0 && *dst == 0;
+	}
+#endif
+
 	// Compare lhs with [rhs_begin, rhs_end)
 	PUGI_IMPL_FN bool strequalrange(const char_t* lhs, const char_t* rhs, size_t count)
 	{
@@ -5413,6 +5432,14 @@ namespace pugi
 		return *this;
 	}
 
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(string_view_t rhs)
+	{
+		set_value(rhs);
+		return *this;
+	}
+#endif
+
 #ifdef PUGIXML_HAS_LONG_LONG
 	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(long long rhs)
 	{
@@ -5736,6 +5763,64 @@ namespace pugi
 		return xml_node();
 	}
 
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_node xml_node::child(string_view_t name_) const
+	{
+		if (!_root) return xml_node();
+
+		for (xml_node_struct* i = _root->first_child; i; i = i->next_sibling)
+		{
+			const char_t* iname = i->name;
+			if (iname && impl::stringview_equal(name_, iname))
+				return xml_node(i);
+		}
+
+		return xml_node();
+	}
+
+	PUGI_IMPL_FN xml_attribute xml_node::attribute(string_view_t name_) const
+	{
+		if (!_root) return xml_attribute();
+
+		for (xml_attribute_struct* i = _root->first_attribute; i; i = i->next_attribute)
+		{
+			const char_t* iname = i->name;
+			if (iname && impl::stringview_equal(name_, iname))
+				return xml_attribute(i);
+		}
+
+		return xml_attribute();
+	}
+
+	PUGI_IMPL_FN xml_node xml_node::next_sibling(string_view_t name_) const
+	{
+		if (!_root) return xml_node();
+
+		for (xml_node_struct* i = _root->next_sibling; i; i = i->next_sibling)
+		{
+			const char_t* iname = i->name;
+			if (iname && impl::stringview_equal(name_, iname))
+				return xml_node(i);
+		}
+
+		return xml_node();
+	}
+
+	PUGI_IMPL_FN xml_node xml_node::previous_sibling(string_view_t name_) const
+	{
+		if (!_root) return xml_node();
+
+		for (xml_node_struct* i = _root->prev_sibling_c; i->next_sibling; i = i->prev_sibling_c)
+		{
+			const char_t* iname = i->name;
+			if (iname && impl::stringview_equal(name_, iname))
+				return xml_node(i);
+		}
+
+		return xml_node();
+	}
+#endif
+
 	PUGI_IMPL_FN xml_attribute xml_node::attribute(const char_t* name_, xml_attribute& hint_) const
 	{
 		xml_attribute_struct* hint = hint_._attr;
@@ -5774,6 +5859,47 @@ namespace pugi
 
 		return xml_attribute();
 	}
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_attribute xml_node::attribute(string_view_t name_, xml_attribute& hint_) const
+	{
+		xml_attribute_struct* hint = hint_._attr;
+
+		// if hint is not an attribute of node, behavior is not defined
+		assert(!hint || (_root && impl::is_attribute_of(hint, _root)));
+
+		if (!_root) return xml_attribute();
+
+		// optimistically search from hint up until the end
+		for (xml_attribute_struct* i = hint; i; i = i->next_attribute)
+		{
+			const char_t* iname = i->name;
+			if (iname && impl::stringview_equal(name_, iname))
+			{
+				// update hint to maximize efficiency of searching for consecutive attributes
+				hint_._attr = i->next_attribute;
+
+				return xml_attribute(i);
+			}
+		}
+
+		// wrap around and search from the first attribute until the hint
+		// 'j' null pointer check is technically redundant, but it prevents a crash in case the assertion above fails
+		for (xml_attribute_struct* j = _root->first_attribute; j && j != hint; j = j->next_attribute)
+		{
+			const char_t* jname = j->name;
+			if (jname && impl::stringview_equal(name_, jname))
+			{
+				// update hint to maximize efficiency of searching for consecutive attributes
+				hint_._attr = j->next_attribute;
+
+				return xml_attribute(j);
+			}
+		}
+
+		return xml_attribute();
+	}
+#endif
 
 	PUGI_IMPL_FN xml_node xml_node::previous_sibling() const
 	{
@@ -5980,6 +6106,78 @@ namespace pugi
 		return a;
 	}
 
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_attribute xml_node::append_attribute(string_view_t name_)
+	{
+		if (!impl::allow_insert_attribute(type())) return xml_attribute();
+
+		impl::xml_allocator& alloc = impl::get_allocator(_root);
+		if (!alloc.reserve()) return xml_attribute();
+
+		xml_attribute a(impl::allocate_attribute(alloc));
+		if (!a) return xml_attribute();
+
+		impl::append_attribute(a._attr, _root);
+
+		a.set_name(name_);
+
+		return a;
+	}
+
+	PUGI_IMPL_FN xml_attribute xml_node::prepend_attribute(string_view_t name_)
+	{
+		if (!impl::allow_insert_attribute(type())) return xml_attribute();
+
+		impl::xml_allocator& alloc = impl::get_allocator(_root);
+		if (!alloc.reserve()) return xml_attribute();
+
+		xml_attribute a(impl::allocate_attribute(alloc));
+		if (!a) return xml_attribute();
+
+		impl::prepend_attribute(a._attr, _root);
+
+		a.set_name(name_);
+
+		return a;
+	}
+
+	PUGI_IMPL_FN xml_attribute xml_node::insert_attribute_after(string_view_t name_, const xml_attribute& attr)
+	{
+		if (!impl::allow_insert_attribute(type())) return xml_attribute();
+		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
+
+		impl::xml_allocator& alloc = impl::get_allocator(_root);
+		if (!alloc.reserve()) return xml_attribute();
+
+		xml_attribute a(impl::allocate_attribute(alloc));
+		if (!a) return xml_attribute();
+
+		impl::insert_attribute_after(a._attr, attr._attr, _root);
+
+		a.set_name(name_);
+
+		return a;
+	}
+
+	PUGI_IMPL_FN xml_attribute xml_node::insert_attribute_before(string_view_t name_, const xml_attribute& attr)
+	{
+		if (!impl::allow_insert_attribute(type())) return xml_attribute();
+		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
+
+		impl::xml_allocator& alloc = impl::get_allocator(_root);
+		if (!alloc.reserve()) return xml_attribute();
+
+		xml_attribute a(impl::allocate_attribute(alloc));
+		if (!a) return xml_attribute();
+
+		impl::insert_attribute_before(a._attr, attr._attr, _root);
+
+		a.set_name(name_);
+
+		return a;
+	}
+#endif
+
 	PUGI_IMPL_FN xml_attribute xml_node::append_copy(const xml_attribute& proto)
 	{
 		if (!proto) return xml_attribute();
@@ -6156,6 +6354,44 @@ namespace pugi
 		return result;
 	}
 
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_node xml_node::append_child(string_view_t name_)
+	{
+		xml_node result = append_child(node_element);
+
+		result.set_name(name_);
+
+		return result;
+	}
+
+	PUGI_IMPL_FN xml_node xml_node::prepend_child(string_view_t name_)
+	{
+		xml_node result = prepend_child(node_element);
+
+		result.set_name(name_);
+
+		return result;
+	}
+
+	PUGI_IMPL_FN xml_node xml_node::insert_child_after(string_view_t name_, const xml_node& node)
+	{
+		xml_node result = insert_child_after(node_element, node);
+
+		result.set_name(name_);
+
+		return result;
+	}
+
+	PUGI_IMPL_FN xml_node xml_node::insert_child_before(string_view_t name_, const xml_node& node)
+	{
+		xml_node result = insert_child_before(node_element, node);
+
+		result.set_name(name_);
+
+		return result;
+	}
+#endif
+
 	PUGI_IMPL_FN xml_node xml_node::append_copy(const xml_node& proto)
 	{
 		xml_node_type type_ = proto.type();
@@ -6299,6 +6535,13 @@ namespace pugi
 		return remove_attribute(attribute(name_));
 	}
 
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_node::remove_attribute(string_view_t name_)
+	{
+		return remove_attribute(attribute(name_));
+	}
+#endif
+
 	PUGI_IMPL_FN bool xml_node::remove_attribute(const xml_attribute& a)
 	{
 		if (!_root || !a._attr) return false;
@@ -6338,6 +6581,13 @@ namespace pugi
 	{
 		return remove_child(child(name_));
 	}
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_node::remove_child(string_view_t name_)
+	{
+		return remove_child(child(name_));
+	}
+#endif
 
 	PUGI_IMPL_FN bool xml_node::remove_child(const xml_node& n)
 	{
@@ -6934,6 +7184,14 @@ namespace pugi
 		set(rhs);
 		return *this;
 	}
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_text& xml_text::operator=(string_view_t rhs)
+	{
+		set(rhs);
+		return *this;
+	}
+#endif
 
 #ifdef PUGIXML_HAS_LONG_LONG
 	PUGI_IMPL_FN xml_text& xml_text::operator=(long long rhs)

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -477,6 +477,10 @@ namespace pugi
 		xml_attribute& operator=(float rhs);
 		xml_attribute& operator=(bool rhs);
 
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_attribute& operator=(string_view_t rhs);
+	#endif
+
 	#ifdef PUGIXML_HAS_LONG_LONG
 		xml_attribute& operator=(long long rhs);
 		xml_attribute& operator=(unsigned long long rhs);
@@ -571,9 +575,18 @@ namespace pugi
 		xml_attribute attribute(const char_t* name) const;
 		xml_node next_sibling(const char_t* name) const;
 		xml_node previous_sibling(const char_t* name) const;
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_node child(string_view_t name) const;
+		xml_attribute attribute(string_view_t name) const;
+		xml_node next_sibling(string_view_t name) const;
+		xml_node previous_sibling(string_view_t name) const;
+	#endif
 
 		// Get attribute, starting the search from a hint (and updating hint so that searching for a sequence of attributes is fast)
 		xml_attribute attribute(const char_t* name, xml_attribute& hint) const;
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_attribute attribute(string_view_t name, xml_attribute& hint) const;
+	#endif
 
 		// Get child value of current node; that is, value of the first child node of type PCDATA/CDATA
 		const char_t* child_value() const;
@@ -598,6 +611,12 @@ namespace pugi
 		xml_attribute prepend_attribute(const char_t* name);
 		xml_attribute insert_attribute_after(const char_t* name, const xml_attribute& attr);
 		xml_attribute insert_attribute_before(const char_t* name, const xml_attribute& attr);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_attribute append_attribute(string_view_t name);
+		xml_attribute prepend_attribute(string_view_t name);
+		xml_attribute insert_attribute_after(string_view_t name, const xml_attribute& attr);
+		xml_attribute insert_attribute_before(string_view_t name, const xml_attribute& attr);
+	#endif
 
 		// Add a copy of the specified attribute. Returns added attribute, or empty attribute on errors.
 		xml_attribute append_copy(const xml_attribute& proto);
@@ -616,6 +635,12 @@ namespace pugi
 		xml_node prepend_child(const char_t* name);
 		xml_node insert_child_after(const char_t* name, const xml_node& node);
 		xml_node insert_child_before(const char_t* name, const xml_node& node);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_node append_child(string_view_t name);
+		xml_node prepend_child(string_view_t name);
+		xml_node insert_child_after(string_view_t, const xml_node& node);
+		xml_node insert_child_before(string_view_t name, const xml_node& node);
+	#endif
 
 		// Add a copy of the specified node as a child. Returns added node, or empty node on errors.
 		xml_node append_copy(const xml_node& proto);
@@ -632,6 +657,9 @@ namespace pugi
 		// Remove specified attribute
 		bool remove_attribute(const xml_attribute& a);
 		bool remove_attribute(const char_t* name);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		bool remove_attribute(string_view_t name);
+	#endif
 
 		// Remove all attributes
 		bool remove_attributes();
@@ -639,6 +667,9 @@ namespace pugi
 		// Remove specified child
 		bool remove_child(const xml_node& n);
 		bool remove_child(const char_t* name);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		bool remove_child(string_view_t name);
+	#endif
 
 		// Remove all children
 		bool remove_children();
@@ -850,6 +881,10 @@ namespace pugi
 		xml_text& operator=(double rhs);
 		xml_text& operator=(float rhs);
 		xml_text& operator=(bool rhs);
+
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_text& operator=(string_view_t rhs);
+	#endif
 
 	#ifdef PUGIXML_HAS_LONG_LONG
 		xml_text& operator=(long long rhs);

--- a/tests/test_dom_traverse.cpp
+++ b/tests/test_dom_traverse.cpp
@@ -536,6 +536,42 @@ TEST_XML(dom_node_child, "<node><child1/><child2/></node>")
 	CHECK(doc.child(STR("node")).child(STR("child2")) == doc.child(STR("node")).last_child());
 }
 
+#ifdef PUGIXML_HAS_STRING_VIEW
+TEST_XML(dom_node_child_stringview, "<node><child1/><child2/></node>")
+{
+	CHECK(xml_node().child(string_view_t(STR("n"))) == xml_node());
+	CHECK(doc.child(string_view_t()) == xml_node());
+	CHECK(doc.child(string_view_t(STR("n"))) == xml_node());
+
+	xml_node node = doc.child(string_view_t(STR("node")));
+	CHECK_NAME_VALUE(node, STR("node"), STR(""));
+	CHECK(node.child(string_view_t(STR("child2"))) == node.last_child());
+
+	// verify only the characters in the view of the string view are included in the comparison
+	CHECK_NAME_VALUE(doc.child(string_view_t(STR("node_andextratext"), 4)), STR("node"), STR(""));
+	CHECK(doc.child(string_view_t(STR("node"), 2)) == xml_node());
+}
+
+TEST_XML(dom_node_child_interior_null, "<node><child1/><child2/></node>")
+{
+	const char_t name[] = STR("node\0extra");
+	size_t len = (sizeof(name) / sizeof(char_t)) - 1;
+	CHECK(len == 10);
+
+	xml_node node = doc.child(string_view_t(name, 4)); // "node" view excluding null
+	CHECK_NAME_VALUE(node, STR("node"), STR(""));
+	CHECK(doc.child(string_view_t(name, 5)) == xml_node()); // "node\0" view including null
+	CHECK(doc.child(string_view_t(name, len)) == xml_node()); // "node\0extra" view
+
+	node.set_name(string_view_t(name, len));
+	CHECK_NODE(doc, STR("<node><child1/><child2/></node>"));
+	CHECK_NAME_VALUE(node, STR("node"), STR(""));
+	CHECK_NAME_VALUE(doc.child(string_view_t(name, 4)), STR("node"), STR(""));  // "node" view excluding null
+	CHECK(doc.child(string_view_t(name, 5)) == xml_node()); // "node\0" view including null
+	CHECK(doc.child(string_view_t(name, len)) == xml_node()); // "node\0extra" view
+}
+#endif
+
 TEST_XML(dom_node_attribute, "<node attr1='0' attr2='1'/>")
 {
 	CHECK(xml_node().attribute(STR("a")) == xml_attribute());
@@ -546,6 +582,46 @@ TEST_XML(dom_node_attribute, "<node attr1='0' attr2='1'/>")
 	CHECK_NAME_VALUE(node.attribute(STR("attr1")), STR("attr1"), STR("0"));
 	CHECK(node.attribute(STR("attr2")) == node.last_attribute());
 }
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+TEST_XML(dom_node_attribute_stringview, "<node attr1='0' attr2='1'/>")
+{
+	CHECK(xml_node().attribute(string_view_t(STR("a"))) == xml_attribute());
+
+	xml_node node = doc.child(string_view_t(STR("node")));
+
+	CHECK(node.attribute(string_view_t()) == xml_attribute());
+	CHECK(node.attribute(string_view_t(STR("n"))) == xml_attribute());
+	CHECK_NAME_VALUE(node.attribute(string_view_t(STR("attr1"))), STR("attr1"), STR("0"));
+	CHECK(node.attribute(string_view_t(STR("attr2"))) == node.last_attribute());
+
+	// verify only the characters in the view of the string view are included in the comparison
+	CHECK_NAME_VALUE(node.attribute(string_view_t(STR("attr1_andextratext"), 5)), STR("attr1"), STR("0"));
+	CHECK(node.attribute(string_view_t(STR("attr1"), 2)) == xml_attribute());
+}
+
+TEST_XML(dom_node_attribute_interior_null, "<node attr1='0' attr2='1'/>")
+{
+	xml_node node = doc.child(STR("node"));
+	CHECK_NAME_VALUE(node, STR("node"), STR(""));
+
+	const char_t name[] = STR("attr2\0extra");
+	size_t len = (sizeof(name) / sizeof(char_t)) - 1;
+	CHECK(len == 11);
+	CHECK_NAME_VALUE(node.attribute(string_view_t(name, 5)), STR("attr2"), STR("1")); // "attr2" view excluding null
+	CHECK(node.attribute(string_view_t(name, 6)) == xml_attribute()); // "attr2\0" view including null
+	CHECK(node.attribute(string_view_t(name, len)) == xml_attribute()); // "attr2\0extra" view
+
+	xml_attribute attr = node.attribute(STR("attr2"));
+	CHECK_NAME_VALUE(attr, STR("attr2"), STR("1"));
+	attr.set_name(string_view_t(name, len));
+
+	CHECK_NODE(doc, STR("<node attr1=\"0\" attr2=\"1\"/>"));
+	CHECK_NAME_VALUE(node.attribute(string_view_t(name, 5)), STR("attr2"), STR("1")); // "attr2" view excluding null
+	CHECK(node.attribute(string_view_t(name, 6)) == xml_attribute()); // "attr2\0" view including null
+	CHECK(node.attribute(string_view_t(name, len)) == xml_attribute()); // "attr2\0extra" view
+}
+#endif
 
 TEST_XML(dom_node_next_previous_sibling, "<node><child1/><child2/><child3/></node>")
 {
@@ -567,9 +643,17 @@ TEST_XML(dom_node_next_previous_sibling, "<node><child1/><child2/><child3/></nod
 
 	CHECK(child1.next_sibling(STR("child3")) == child3);
 	CHECK(child1.next_sibling(STR("child")) == xml_node());
+#ifdef PUGIXML_HAS_STRING_VIEW
+	CHECK(child1.next_sibling(string_view_t(STR("child3"))) == child3);
+	CHECK(child1.next_sibling(string_view_t(STR("child"))) == xml_node());
+#endif
 
 	CHECK(child3.previous_sibling(STR("child1")) == child1);
 	CHECK(child3.previous_sibling(STR("child")) == xml_node());
+#ifdef PUGIXML_HAS_STRING_VIEW
+	CHECK(child3.previous_sibling(string_view_t(STR("child1"))) == child1);
+	CHECK(child3.previous_sibling(string_view_t(STR("child"))) == xml_node());
+#endif
 }
 
 TEST_XML(dom_node_child_value, "<node><novalue/><child1>value1</child1><child2>value2<n/></child2><child3><![CDATA[value3]]></child3>value4</node>")
@@ -1301,4 +1385,36 @@ TEST(dom_node_anonymous)
 	CHECK(doc.last_child().previous_sibling(STR("node")) == xml_node());
 	CHECK_STRING(doc.child_value(), STR(""));
 	CHECK_STRING(doc.last_child().child_value(), STR(""));
+}
+
+TEST_XML(dom_node_anonymous_child, "<node></node>")
+{
+	xml_node node = doc.child(STR("node"));
+	CHECK_NAME_VALUE(node, STR("node"), STR(""));
+	node.set_name(STR(""));
+	CHECK_NODE(doc, "<:anonymous/>");
+	CHECK(doc.first_child() != xml_node());
+	CHECK_NAME_VALUE(doc.first_child(), STR(""), STR(""));
+
+	// searching for empty string does not find a node with empty name
+	CHECK(doc.child(STR("")) == xml_node());
+#ifdef PUGIXML_HAS_STRING_VIEW
+	CHECK(doc.child(string_view_t()) == xml_node());
+	CHECK(doc.child(string_view_t("hi", 0)) == xml_node());
+#endif
+}
+
+TEST_XML(dom_node_anonymous_attribute, "<node attr='0'/>")
+{
+	xml_attribute attr = doc.first_child().attribute(STR("attr"));
+	CHECK(attr != xml_attribute());
+	attr.set_name(STR(""));
+	CHECK_NODE(doc, "<node :anonymous=\"0\"/>");
+	CHECK_NAME_VALUE(doc.first_child().first_attribute(), STR(""), STR("0"));
+
+	CHECK(doc.first_child().attribute(STR("")) == xml_attribute());
+#ifdef PUGIXML_STRING_VIEW
+	CHECK(doc.first_child().attribute(string_view_t()) == xml_attribute());
+	CHECK(doc.first_child().attribute(string_view_t("hi", 0)) == xml_attribute());
+#endif
 }


### PR DESCRIPTION
Completing the std::string_view support work defined in https://github.com/zeux/pugixml/issues/626

The key new functionality is adding a helper function for checking equality between string_view and null terminated c-strings `impl::stringview_equal`. Using strncmp/wsncmp directly would not work, because that stops comparison at the first null, and the string_view might have a null in the middle -- we do not want a string_view of "n\0pe" to be considered equal to a node name "n" for lookups. string_view has a comparison function that has an overload for const char* (null terminated c-string) that would give the comparison we want. However, that helper works by constructing a string_view from the const char* and then comparing to the new string_view, which would trigger an extra iteration over the const char*.

These overloads are created by copying and pasting the original and substituting the new equality function:
```
xml_node xml_node::child(string_view_t name) const;
xml_attribute xml_node::attribute(string_view_t name) const;
xml_node xml_node::next_sibling(string_view_t name) const;
xml_node xml_node::previous_sibling(string_view_t name) const;
xml_attribute xml_node::attribute(string_view_t name, xml_attribute& hint) const;
```
Added some unit tests for `child(string_view_t)` and `attribute(string_view_t)`. Also added unit tests documenting the behavior of child and attribute lookup when the node/attribute has null name -- searching does not find these nodes, even if an empty argument name is provided.

These other functions also gained overloads, but they just pass the string_view_t to another overloaded function. No new unit tests were added for these functions.
```
xml_attribute& xml_attribute::operator=(string_view_t rhs);

xml_attribute xml_node::append_attribute(string_view_t name);
xml_attribute xml_node::prepend_attribute(string_view_t name);
xml_attribute xml_node::insert_attribute_after(string_view_t name, const xml_attribute& attr);
xml_attribute xml_node::insert_attribute_before(string_view_t name, const xml_attribute& attr);
xml_node xml_node::append_child(string_view_t name);
xml_node xml_node::prepend_child(string_view_t name);
xml_node xml_node::insert_child_after(string_view_t name, const xml_node& node);
xml_node xml_node::insert_child_before(string_view_t name, const xml_node& node);
bool xml_node::remove_attribute(string_view_t name);
bool xml_node::remove_child(string_view_t name);

xml_text& xml_text::operator=(string_view_t rhs);
```

Documentation will be updated to cover the new overloads after the opt-in define PUGIXML_STRING_VIEW is removed