### PR TITLE
Warn if PUGIXML_STRING_VIEW is set without CMAKE_CXX_STANDARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ option(PUGIXML_INSTALL "Enable installation rules" ON)
 option(PUGIXML_NO_XPATH "Disable XPath" OFF)
 option(PUGIXML_NO_STL "Disable STL" OFF)
 option(PUGIXML_NO_EXCEPTIONS "Disable Exceptions" OFF)
-option(PUGIXML_STRING_VIEW "Enable std::string_view overloads" OFF) # requires C++17 and for PUGI_NO_STL to be OFF
+option(PUGIXML_STRING_VIEW "Enable std::string_view overloads" OFF) # requires C++17 and for PUGIXML_NO_STL to be OFF
 mark_as_advanced(PUGIXML_NO_XPATH PUGIXML_NO_STL PUGIXML_NO_EXCEPTIONS PUGIXML_STRING_VIEW)
 
 set(PUGIXML_PUBLIC_DEFINITIONS
@@ -64,6 +64,10 @@ set(PUGIXML_PUBLIC_DEFINITIONS
 if (NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
   set(CMAKE_MSVC_RUNTIME_LIBRARY
     MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<NOT:$<BOOL:${PUGIXML_STATIC_CRT}>>:DLL>)
+endif()
+
+if (PUGIXML_STRING_VIEW AND (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 17))
+  message(WARNING "PUGIXML_STRING_VIEW requires CMAKE_CXX_STANDARD to be set to 17 or later")
 endif()
 
 if (NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)


### PR DESCRIPTION
Even if the compiler supports C++17, we define CMAKE_CXX_STANDARD as 11 by default which implicitly disables string_view support; for now warn in this case.

Note: I am not sure *why* we set CMAKE_CXX_STANDARD to 11. This has been added 5 years ago as part of CMake modernization but I don't know what the justification was for this particular change. We could set it to 17 if the option is enabled, but since the intent for the STRING_VIEW option to be there just for transition, after this option is removed and string_view is enabled by default, C++17 will still need to be set by the user.

We could also set CMAKE_CXX_STANDARD to 17  by default (and remove CMAKE_CXX_STANDARD_REQUIRED to avoid compatibility issues); I'm not sure what the implications for a change like this would be but that's probably best done after the next release.