### PR TITLE
Makefile now defaults to cxxstd=any

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ MAKEFLAGS+=-r
 
 config=debug
 defines=standard
-cxxstd=c++11
-# set cxxstd=any to disable use of -std=...
+cxxstd=any
 
 BUILD=build/make-$(firstword $(CXX))-$(config)-$(defines)-$(cxxstd)
 


### PR DESCRIPTION
This means that by default we inherit the default language version supported by the compiler; this will help with string_view testing in the future as it will "just work" out of the box once the define is set.

This should also automatically enable CI coverage for string_view; C++11 is still explicitly tested in CI via cxxstd=c++11.