### PR TITLE
Enhance CMake testing in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,22 @@ jobs:
         make test defines=${{matrix.defines}} config=coverage -j2
         bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov -X search -t ${{secrets.CODECOV_TOKEN}} -B ${{github.ref}}
 
+  unix-cmake:
+    strategy:
+      matrix:
+        os: [ubuntu, macos]
+    name: ${{matrix.os}} cmake
+    runs-on: ${{matrix.os}}-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: cmake configure
+      run: |
+        mkdir cmake && cd cmake
+        cmake .. -D PUGIXML_BUILD_TESTS=ON
+    - name: cmake test
+      run: |
+        make -C cmake -j2
+
   windows:
     runs-on: windows-latest
     strategy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,10 +18,18 @@ build_script:
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2022") { .\scripts\nuget_build.ps1 2022}
 
 test_script:
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\cmake-appveyor.ps1 9 2008 }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\cmake-appveyor.ps1 12 2013 }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\cmake-appveyor.ps1 14 2015 }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2017") { .\tests\cmake-appveyor.ps1 15 2017 }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2019") { .\tests\cmake-appveyor.ps1 16 2019 }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2022") { .\tests\cmake-appveyor.ps1 17 2022 }
+
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\autotest-appveyor.ps1 9 10 11 12 14 }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2017") { .\tests\autotest-appveyor.ps1 15 }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2019") { .\tests\autotest-appveyor.ps1 19 }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2022") { .\tests\autotest-appveyor.ps1 22 }
+
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { & C:\cygwin\bin\bash.exe -c "PATH=/usr/bin:/usr/local/bin:$PATH; make -j2 config=coverage test && bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov 2>&1" }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { & C:\cygwin\bin\bash.exe -c "PATH=/usr/bin:/usr/local/bin:$PATH; make -j2 config=coverage defines=PUGIXML_WCHAR_MODE test && bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov 2>&1" }
 

--- a/tests/cmake-appveyor.ps1
+++ b/tests/cmake-appveyor.ps1
@@ -1,0 +1,57 @@
+$failed = $FALSE
+
+$vs = $args[0]
+$vsy = $args[1]
+
+$target = "cmake_vs${vs}_${vsy}"
+
+Add-AppveyorTest $target -Outcome Running
+
+mkdir $target
+pushd $target
+
+try
+{
+	Write-Output "# Setting up CMake VS$vs"
+	& cmake .. -G "Visual Studio $vs $vsy" | Tee-Object -Variable cmakeOutput
+
+	$sw = [Diagnostics.Stopwatch]::StartNew()
+
+	if ($?)
+	{
+		Write-Output "# Building"
+
+		& cmake --build . | Tee-Object -Variable cmakeOutput
+
+		if ($?)
+		{
+			Write-Output "# Passed"
+
+			Update-AppveyorTest $target -Outcome Passed -StdOut ($cmakeOutput | out-string) -Duration $sw.ElapsedMilliseconds
+		}
+		else
+		{
+			Write-Output "# Failed to build"
+
+			Update-AppveyorTest $target -Outcome Failed -StdOut ($cmakeOutput | out-string) -ErrorMessage "Building failed"
+
+			$failed = $TRUE
+		}
+	}
+	else
+	{
+		Write-Output "# Failed to configure"
+
+		Update-AppveyorTest $target -Outcome Failed -StdOut ($cmakeOutput | out-string) -ErrorMessage "Configuration failed"
+
+		$failed = $TRUE
+	}
+}
+finally
+{
+	popd
+}
+
+if ($failed) { throw "One or more build steps failed" }
+
+Write-Output "# End"


### PR DESCRIPTION
We now test CMake for Linux/macOS on GHA, and test it for all supported VS versions on AppVeyor (previously CMake was only exercised in GHA on Windows).

To reduce the impact on AppVeyor build time we only run a quick library build without actually compiling or running tests. This can be expanded in the future if need be.