### PR TITLE
refactor: use nullptr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,14 +24,12 @@ jobs:
       run: |
         export CXX=${{matrix.compiler}}
         make test cxxstd=c++11 defines=${{matrix.defines}} config=release -j2
-        make test cxxstd=c++98 defines=${{matrix.defines}} config=debug -j2
         make test cxxstd=c++17 defines=${{matrix.defines}} config=debug -j2
-        make test defines=${{matrix.defines}} config=sanitize -j2
     - name: make coverage
       if: ${{!(matrix.os == 'ubuntu' && matrix.compiler == 'clang++')}} # linux/clang produces coverage info gcov can't parse
       run: |
         export CXX=${{matrix.compiler}}
-        make test defines=${{matrix.defines}} config=coverage -j2
+        make test cxxstd=c++11 defines=${{matrix.defines}} config=coverage -j2
         bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov -X search -t ${{secrets.CODECOV_TOKEN}} -B ${{github.ref}}
 
   unix-cmake:

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -316,7 +316,7 @@ PUGI_IMPL_NS_BEGIN
 		T* release()
 		{
 			T* result = data;
-			data = NULL;
+			data = PUGIXML_NULL;
 			return result;
 		}
 	};
@@ -327,7 +327,7 @@ PUGI_IMPL_NS_BEGIN
 	class compact_hash_table
 	{
 	public:
-		compact_hash_table(): _items(NULL), _capacity(0), _count(0)
+		compact_hash_table(): _items(PUGIXML_NULL), _capacity(0), _count(0)
 		{
 		}
 
@@ -336,7 +336,7 @@ PUGI_IMPL_NS_BEGIN
 			if (_items)
 			{
 				xml_memory::deallocate(_items);
-				_items = NULL;
+				_items = PUGIXML_NULL;
 				_capacity = 0;
 				_count = 0;
 			}
@@ -344,11 +344,11 @@ PUGI_IMPL_NS_BEGIN
 
 		void* find(const void* key)
 		{
-			if (_capacity == 0) return NULL;
+			if (_capacity == 0) return PUGIXML_NULL;
 
 			item_t* item = get_item(key);
 			assert(item);
-			assert(item->key == key || (item->key == NULL && item->value == NULL));
+			assert(item->key == key || (item->key == PUGIXML_NULL && item->value == PUGIXML_NULL));
 
 			return item->value;
 		}
@@ -360,7 +360,7 @@ PUGI_IMPL_NS_BEGIN
 			item_t* item = get_item(key);
 			assert(item);
 
-			if (item->key == NULL)
+			if (item->key == PUGIXML_NULL)
 			{
 				_count++;
 				item->key = key;
@@ -403,7 +403,7 @@ PUGI_IMPL_NS_BEGIN
 			{
 				item_t& probe_item = _items[bucket];
 
-				if (probe_item.key == key || probe_item.key == NULL)
+				if (probe_item.key == key || probe_item.key == PUGIXML_NULL)
 					return &probe_item;
 
 				// hash collision, quadratic probing
@@ -411,7 +411,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 
 			assert(false && "Hash table is full"); // unreachable
-			return NULL;
+			return PUGIXML_NULL;
 		}
 
 		static PUGI_IMPL_UNSIGNED_OVERFLOW unsigned int hash(const void* key)
@@ -499,16 +499,16 @@ PUGI_IMPL_NS_BEGIN
 		{
 			xml_memory_page* result = static_cast<xml_memory_page*>(memory);
 
-			result->allocator = NULL;
-			result->prev = NULL;
-			result->next = NULL;
+			result->allocator = PUGIXML_NULL;
+			result->prev = PUGIXML_NULL;
+			result->next = PUGIXML_NULL;
 			result->busy_size = 0;
 			result->freed_size = 0;
 
 		#ifdef PUGIXML_COMPACT
-			result->compact_string_base = NULL;
-			result->compact_shared_parent = NULL;
-			result->compact_page_marker = NULL;
+			result->compact_string_base = PUGIXML_NULL;
+			result->compact_shared_parent = PUGIXML_NULL;
+			result->compact_page_marker = PUGIXML_NULL;
 		#endif
 
 			return result;
@@ -548,7 +548,7 @@ PUGI_IMPL_NS_BEGIN
 		xml_allocator(xml_memory_page* root): _root(root), _busy_size(root->busy_size)
 		{
 		#ifdef PUGIXML_COMPACT
-			_hash = NULL;
+			_hash = PUGIXML_NULL;
 		#endif
 		}
 
@@ -558,7 +558,7 @@ PUGI_IMPL_NS_BEGIN
 
 			// allocate block with some alignment, leaving memory for worst-case padding
 			void* memory = xml_memory::allocate(size);
-			if (!memory) return NULL;
+			if (!memory) return PUGIXML_NULL;
 
 			// prepare page structure
 			xml_memory_page* page = xml_memory_page::construct(memory);
@@ -595,7 +595,7 @@ PUGI_IMPL_NS_BEGIN
 		void* allocate_object(size_t size, xml_memory_page*& out_page)
 		{
 			void* result = allocate_memory(size + sizeof(uint32_t), out_page);
-			if (!result) return NULL;
+			if (!result) return PUGIXML_NULL;
 
 			// adjust for marker
 			ptrdiff_t offset = static_cast<char*>(result) - reinterpret_cast<char*>(out_page->compact_page_marker);
@@ -641,7 +641,7 @@ PUGI_IMPL_NS_BEGIN
 
 			if (page->freed_size == page->busy_size)
 			{
-				if (page->next == NULL)
+				if (page->next == PUGIXML_NULL)
 				{
 					assert(_root == page);
 
@@ -651,9 +651,9 @@ PUGI_IMPL_NS_BEGIN
 
 				#ifdef PUGIXML_COMPACT
 					// reset compact state to maximize efficiency
-					page->compact_string_base = NULL;
-					page->compact_shared_parent = NULL;
-					page->compact_page_marker = NULL;
+					page->compact_string_base = PUGIXML_NULL;
+					page->compact_shared_parent = PUGIXML_NULL;
+					page->compact_page_marker = PUGIXML_NULL;
 				#endif
 
 					_busy_size = 0;
@@ -688,7 +688,7 @@ PUGI_IMPL_NS_BEGIN
 			xml_memory_page* page;
 			xml_memory_string_header* header = static_cast<xml_memory_string_header*>(allocate_memory(full_size, page));
 
-			if (!header) return NULL;
+			if (!header) return PUGIXML_NULL;
 
 			// setup header
 			ptrdiff_t page_offset = reinterpret_cast<char*>(header) - reinterpret_cast<char*>(page) - sizeof(xml_memory_page);
@@ -750,7 +750,7 @@ PUGI_IMPL_NS_BEGIN
 		xml_memory_page* page = allocate_page(size <= large_allocation_threshold ? xml_memory_page_size : size);
 		out_page = page;
 
-		if (!page) return NULL;
+		if (!page) return PUGIXML_NULL;
 
 		if (size <= large_allocation_threshold)
 		{
@@ -897,7 +897,7 @@ PUGI_IMPL_NS_BEGIN
 					return compact_get_value<header_offset, T>(this);
 			}
 			else
-				return NULL;
+				return PUGIXML_NULL;
 		}
 
 		T* operator->() const
@@ -940,7 +940,7 @@ PUGI_IMPL_NS_BEGIN
 				{
 					xml_memory_page* page = compact_get_page(this, header_offset);
 
-					if (PUGI_IMPL_UNLIKELY(page->compact_shared_parent == NULL))
+					if (PUGI_IMPL_UNLIKELY(page->compact_shared_parent == PUGIXML_NULL))
 						page->compact_shared_parent = value;
 
 					if (page->compact_shared_parent == value)
@@ -977,7 +977,7 @@ PUGI_IMPL_NS_BEGIN
 					return compact_get_value<header_offset, T>(this);
 			}
 			else
-				return NULL;
+				return PUGIXML_NULL;
 		}
 
 		T* operator->() const
@@ -1007,7 +1007,7 @@ PUGI_IMPL_NS_BEGIN
 			{
 				xml_memory_page* page = compact_get_page(this, header_offset);
 
-				if (PUGI_IMPL_UNLIKELY(page->compact_string_base == NULL))
+				if (PUGI_IMPL_UNLIKELY(page->compact_string_base == PUGIXML_NULL))
 					page->compact_string_base = value;
 
 				ptrdiff_t offset = value - page->compact_string_base;
@@ -1073,7 +1073,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 			}
 			else
-				return NULL;
+				return PUGIXML_NULL;
 		}
 
 	private:
@@ -1132,7 +1132,7 @@ namespace pugi
 {
 	struct xml_attribute_struct
 	{
-		xml_attribute_struct(impl::xml_memory_page* page): name(NULL), value(NULL), prev_attribute_c(NULL), next_attribute(NULL)
+		xml_attribute_struct(impl::xml_memory_page* page): name(PUGIXML_NULL), value(PUGIXML_NULL), prev_attribute_c(PUGIXML_NULL), next_attribute(PUGIXML_NULL)
 		{
 			header = PUGI_IMPL_GETHEADER_IMPL(this, page, 0);
 		}
@@ -1148,7 +1148,7 @@ namespace pugi
 
 	struct xml_node_struct
 	{
-		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): name(NULL), value(NULL), parent(NULL), first_child(NULL), prev_sibling_c(NULL), next_sibling(NULL), first_attribute(NULL)
+		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): name(PUGIXML_NULL), value(PUGIXML_NULL), parent(PUGIXML_NULL), first_child(PUGIXML_NULL), prev_sibling_c(PUGIXML_NULL), next_sibling(PUGIXML_NULL), first_attribute(PUGIXML_NULL)
 		{
 			header = PUGI_IMPL_GETHEADER_IMPL(this, page, type);
 		}
@@ -1179,7 +1179,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xml_document_struct: public xml_node_struct, public xml_allocator
 	{
-		xml_document_struct(xml_memory_page* page): xml_node_struct(page, node_document), xml_allocator(page), buffer(NULL), extra_buffers(NULL)
+		xml_document_struct(xml_memory_page* page): xml_node_struct(page, node_document), xml_allocator(page), buffer(PUGIXML_NULL), extra_buffers(PUGIXML_NULL)
 		{
 		}
 
@@ -1213,7 +1213,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		xml_memory_page* page;
 		void* memory = alloc.allocate_object(sizeof(xml_attribute_struct), page);
-		if (!memory) return NULL;
+		if (!memory) return PUGIXML_NULL;
 
 		return new (memory) xml_attribute_struct(page);
 	}
@@ -1222,7 +1222,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		xml_memory_page* page;
 		void* memory = alloc.allocate_object(sizeof(xml_node_struct), page);
-		if (!memory) return NULL;
+		if (!memory) return PUGIXML_NULL;
 
 		return new (memory) xml_node_struct(page, type);
 	}
@@ -1361,9 +1361,9 @@ PUGI_IMPL_NS_BEGIN
 		else
 			parent->first_child = next;
 
-		node->parent = NULL;
-		node->prev_sibling_c = NULL;
-		node->next_sibling = NULL;
+		node->parent = PUGIXML_NULL;
+		node->prev_sibling_c = PUGIXML_NULL;
+		node->next_sibling = PUGIXML_NULL;
 	}
 
 	inline void append_attribute(xml_attribute_struct* attr, xml_node_struct* node)
@@ -1444,16 +1444,16 @@ PUGI_IMPL_NS_BEGIN
 		else
 			node->first_attribute = next;
 
-		attr->prev_attribute_c = NULL;
-		attr->next_attribute = NULL;
+		attr->prev_attribute_c = PUGIXML_NULL;
+		attr->next_attribute = PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN_NO_INLINE xml_node_struct* append_new_node(xml_node_struct* node, xml_allocator& alloc, xml_node_type type = node_element)
 	{
-		if (!alloc.reserve()) return NULL;
+		if (!alloc.reserve()) return PUGIXML_NULL;
 
 		xml_node_struct* child = allocate_node(alloc, type);
-		if (!child) return NULL;
+		if (!child) return PUGIXML_NULL;
 
 		append_node(child, node);
 
@@ -1462,10 +1462,10 @@ PUGI_IMPL_NS_BEGIN
 
 	PUGI_IMPL_FN_NO_INLINE xml_attribute_struct* append_new_attribute(xml_node_struct* node, xml_allocator& alloc)
 	{
-		if (!alloc.reserve()) return NULL;
+		if (!alloc.reserve()) return PUGIXML_NULL;
 
 		xml_attribute_struct* attr = allocate_attribute(alloc);
-		if (!attr) return NULL;
+		if (!attr) return PUGIXML_NULL;
 
 		append_attribute(attr, node);
 
@@ -2047,7 +2047,7 @@ PUGI_IMPL_NS_BEGIN
 		if (d0 == 0x3c && d1 == 0) return encoding_utf16_le;
 
 		// no known BOM detected; parse declaration
-		const uint8_t* enc = NULL;
+		const uint8_t* enc = PUGIXML_NULL;
 		size_t enc_length = 0;
 
 		if (d0 == 0x3c && d1 == 0x3f && d2 == 0x78 && d3 == 0x6d && parse_declaration_encoding(data, size, enc, enc_length))
@@ -2418,7 +2418,7 @@ PUGI_IMPL_NS_BEGIN
 			if (header & header_mask) alloc->deallocate_string(dest);
 
 			// mark the string as not allocated
-			dest = NULL;
+			dest = PUGIXML_NULL;
 			header &= ~header_mask;
 
 			return true;
@@ -2461,7 +2461,7 @@ PUGI_IMPL_NS_BEGIN
 		char_t* end;
 		size_t size;
 
-		gap(): end(NULL), size(0)
+		gap(): end(PUGIXML_NULL), size(0)
 		{
 		}
 
@@ -2673,7 +2673,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 			else if (*s == 0)
 			{
-				return NULL;
+				return PUGIXML_NULL;
 			}
 			else ++s;
 		}
@@ -2701,7 +2701,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 			else if (*s == 0)
 			{
-				return NULL;
+				return PUGIXML_NULL;
 			}
 			else ++s;
 		}
@@ -2774,7 +2774,7 @@ PUGI_IMPL_NS_BEGIN
 		case 5: return strconv_pcdata_impl<opt_true, opt_false, opt_true>::parse;
 		case 6: return strconv_pcdata_impl<opt_true, opt_true, opt_false>::parse;
 		case 7: return strconv_pcdata_impl<opt_true, opt_true, opt_true>::parse;
-		default: assert(false); return NULL; // unreachable
+		default: assert(false); return PUGIXML_NULL; // unreachable
 		}
 	}
 
@@ -2828,7 +2828,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return NULL;
+					return PUGIXML_NULL;
 				}
 				else ++s;
 			}
@@ -2864,7 +2864,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return NULL;
+					return PUGIXML_NULL;
 				}
 				else ++s;
 			}
@@ -2896,7 +2896,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return NULL;
+					return PUGIXML_NULL;
 				}
 				else ++s;
 			}
@@ -2922,7 +2922,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return NULL;
+					return PUGIXML_NULL;
 				}
 				else ++s;
 			}
@@ -2951,7 +2951,7 @@ PUGI_IMPL_NS_BEGIN
 		case 13: return strconv_attribute_impl<opt_true>::parse_wnorm;
 		case 14: return strconv_attribute_impl<opt_false>::parse_wnorm;
 		case 15: return strconv_attribute_impl<opt_true>::parse_wnorm;
-		default: assert(false); return NULL; // unreachable
+		default: assert(false); return PUGIXML_NULL; // unreachable
 		}
 	}
 
@@ -2970,7 +2970,7 @@ PUGI_IMPL_NS_BEGIN
 		char_t* error_offset;
 		xml_parse_status error_status;
 
-		xml_parser(xml_allocator* alloc_): alloc(alloc_), error_offset(NULL), error_status(status_ok)
+		xml_parser(xml_allocator* alloc_): alloc(alloc_), error_offset(PUGIXML_NULL), error_status(status_ok)
 		{
 		}
 
@@ -3582,7 +3582,7 @@ PUGI_IMPL_NS_BEGIN
 				return make_parse_result(PUGI_IMPL_OPTSET(parse_fragment) ? status_ok : status_no_document_element);
 
 			// get last child of the root before parsing
-			xml_node_struct* last_root_child = root->first_child ? root->first_child->prev_sibling_c + 0 : NULL;
+			xml_node_struct* last_root_child = root->first_child ? root->first_child->prev_sibling_c + 0 : PUGIXML_NULL;
 
 			// create parser on stack
 			xml_parser parser(static_cast<xml_allocator*>(xmldoc));
@@ -4499,7 +4499,7 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN void node_copy_tree(xml_node_struct* dn, xml_node_struct* sn)
 	{
 		xml_allocator& alloc = get_allocator(dn);
-		xml_allocator* shared_alloc = (&alloc == &get_allocator(sn)) ? &alloc : NULL;
+		xml_allocator* shared_alloc = (&alloc == &get_allocator(sn)) ? &alloc : PUGIXML_NULL;
 
 		node_copy_contents(dn, sn, shared_alloc);
 
@@ -4553,7 +4553,7 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN void node_copy_attribute(xml_attribute_struct* da, xml_attribute_struct* sa)
 	{
 		xml_allocator& alloc = get_allocator(da);
-		xml_allocator* shared_alloc = (&alloc == &get_allocator(sa)) ? &alloc : NULL;
+		xml_allocator* shared_alloc = (&alloc == &get_allocator(sa)) ? &alloc : PUGIXML_NULL;
 
 		node_copy_string(da->name, da->header, xml_memory_page_name_allocated_mask, sa->name, sa->header, shared_alloc);
 		node_copy_string(da->value, da->header, xml_memory_page_value_allocated_mask, sa->value, sa->header, shared_alloc);
@@ -4664,7 +4664,7 @@ PUGI_IMPL_NS_BEGIN
 	#ifdef PUGIXML_WCHAR_MODE
 		return wcstod(value, NULL);
 	#else
-		return strtod(value, NULL);
+		return strtod(value, PUGIXML_NULL);
 	#endif
 	}
 
@@ -4673,7 +4673,7 @@ PUGI_IMPL_NS_BEGIN
 	#ifdef PUGIXML_WCHAR_MODE
 		return static_cast<float>(wcstod(value, NULL));
 	#else
-		return static_cast<float>(strtod(value, NULL));
+		return static_cast<float>(strtod(value, PUGIXML_NULL));
 	#endif
 	}
 
@@ -4778,10 +4778,10 @@ PUGI_IMPL_NS_BEGIN
 		xml_encoding buffer_encoding = impl::get_buffer_encoding(encoding, contents, size);
 
 		// if convert_buffer below throws bad_alloc, we still need to deallocate contents if we own it
-		auto_deleter<void> contents_guard(own ? contents : NULL, xml_memory::deallocate);
+		auto_deleter<void> contents_guard(own ? contents : PUGIXML_NULL, xml_memory::deallocate);
 
 		// get private buffer
-		char_t* buffer = NULL;
+		char_t* buffer = PUGIXML_NULL;
 		size_t length = 0;
 
 		// coverity[var_deref_model]
@@ -4925,7 +4925,7 @@ PUGI_IMPL_NS_BEGIN
 		static xml_stream_chunk* create()
 		{
 			void* memory = xml_memory::allocate(sizeof(xml_stream_chunk));
-			if (!memory) return NULL;
+			if (!memory) return PUGIXML_NULL;
 
 			return new (memory) xml_stream_chunk();
 		}
@@ -4943,7 +4943,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 		}
 
-		xml_stream_chunk(): next(NULL), size(0)
+		xml_stream_chunk(): next(PUGIXML_NULL), size(0)
 		{
 		}
 
@@ -4955,11 +4955,11 @@ PUGI_IMPL_NS_BEGIN
 
 	template <typename T> PUGI_IMPL_FN xml_parse_status load_stream_data_noseek(std::basic_istream<T>& stream, void** out_buffer, size_t* out_size)
 	{
-		auto_deleter<xml_stream_chunk<T> > chunks(NULL, xml_stream_chunk<T>::destroy);
+		auto_deleter<xml_stream_chunk<T> > chunks(PUGIXML_NULL, xml_stream_chunk<T>::destroy);
 
 		// read file to a chunk list
 		size_t total = 0;
-		xml_stream_chunk<T>* last = NULL;
+		xml_stream_chunk<T>* last = PUGIXML_NULL;
 
 		while (!stream.eof())
 		{
@@ -5045,7 +5045,7 @@ PUGI_IMPL_NS_BEGIN
 
 	template <typename T> PUGI_IMPL_FN xml_parse_result load_stream_impl(xml_document_struct* doc, std::basic_istream<T>& stream, unsigned int options, xml_encoding encoding, char_t** out_buffer)
 	{
-		void* buffer = NULL;
+		void* buffer = PUGIXML_NULL;
 		size_t size = 0;
 		xml_parse_status status = status_ok;
 
@@ -5098,7 +5098,7 @@ PUGI_IMPL_NS_BEGIN
 
 		// allocate resulting string
 		char* result = static_cast<char*>(xml_memory::allocate(size + 1));
-		if (!result) return NULL;
+		if (!result) return PUGIXML_NULL;
 
 		// second pass: convert to utf8
 		as_utf8_end(result, size, str, length);
@@ -5113,7 +5113,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		// there is no standard function to open wide paths, so our best bet is to try utf8 path
 		char* path_utf8 = convert_path_heap(path);
-		if (!path_utf8) return NULL;
+		if (!path_utf8) return PUGIXML_NULL;
 
 		// convert mode to ASCII (we mirror _wfopen interface)
 		char mode_ascii[4] = {0};
@@ -5156,7 +5156,7 @@ PUGI_IMPL_NS_BEGIN
 
 		name_null_sentry(xml_node_struct* node_): node(node_), name(node_->name)
 		{
-			node->name = NULL;
+			node->name = PUGIXML_NULL;
 		}
 
 		~name_null_sentry()
@@ -5183,11 +5183,11 @@ namespace pugi
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<char>& stream): narrow_stream(&stream), wide_stream(NULL)
+	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<char>& stream): narrow_stream(&stream), wide_stream(PUGIXML_NULL)
 	{
 	}
 
-	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<wchar_t>& stream): narrow_stream(NULL), wide_stream(&stream)
+	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<wchar_t>& stream): narrow_stream(PUGIXML_NULL), wide_stream(&stream)
 	{
 	}
 
@@ -5231,7 +5231,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI_IMPL_FN xml_attribute::xml_attribute(): _attr(NULL)
+	PUGI_IMPL_FN xml_attribute::xml_attribute(): _attr(PUGIXML_NULL)
 	{
 	}
 
@@ -5245,7 +5245,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_attribute::operator xml_attribute::unspecified_bool_type() const
 	{
-		return _attr ? unspecified_bool_xml_attribute : NULL;
+		return _attr ? unspecified_bool_xml_attribute : PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xml_attribute::operator!() const
@@ -5590,7 +5590,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI_IMPL_FN xml_node::xml_node(): _root(NULL)
+	PUGI_IMPL_FN xml_node::xml_node(): _root(PUGIXML_NULL)
 	{
 	}
 
@@ -5604,7 +5604,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_node::operator xml_node::unspecified_bool_type() const
 	{
-		return _root ? unspecified_bool_xml_node : NULL;
+		return _root ? unspecified_bool_xml_node : PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xml_node::operator!() const
@@ -5614,22 +5614,22 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_node::iterator xml_node::begin() const
 	{
-		return iterator(_root ? _root->first_child + 0 : NULL, _root);
+		return iterator(_root ? _root->first_child + 0 : PUGIXML_NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::iterator xml_node::end() const
 	{
-		return iterator(NULL, _root);
+		return iterator(PUGIXML_NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::attribute_iterator xml_node::attributes_begin() const
 	{
-		return attribute_iterator(_root ? _root->first_attribute + 0 : NULL, _root);
+		return attribute_iterator(_root ? _root->first_attribute + 0 : PUGIXML_NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::attribute_iterator xml_node::attributes_end() const
 	{
-		return attribute_iterator(NULL, _root);
+		return attribute_iterator(PUGIXML_NULL, _root);
 	}
 
 	PUGI_IMPL_FN xml_object_range<xml_node_iterator> xml_node::children() const
@@ -5639,7 +5639,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_object_range<xml_named_node_iterator> xml_node::children(const char_t* name_) const
 	{
-		return xml_object_range<xml_named_node_iterator>(xml_named_node_iterator(child(name_)._root, _root, name_), xml_named_node_iterator(NULL, _root, name_));
+		return xml_object_range<xml_named_node_iterator>(xml_named_node_iterator(child(name_)._root, _root, name_), xml_named_node_iterator(PUGIXML_NULL, _root, name_));
 	}
 
 	PUGI_IMPL_FN xml_object_range<xml_attribute_iterator> xml_node::attributes() const
@@ -6571,7 +6571,7 @@ namespace pugi
 			attr = next;
 		}
 
-		_root->first_attribute = NULL;
+		_root->first_attribute = PUGIXML_NULL;
 
 		return true;
 	}
@@ -6617,7 +6617,7 @@ namespace pugi
 			cur = next;
 		}
 
-		_root->first_child = NULL;
+		_root->first_child = PUGIXML_NULL;
 
 		return true;
 	}
@@ -6637,7 +6637,7 @@ namespace pugi
 		doc->header |= impl::xml_memory_page_contents_shared_mask;
 
 		// get extra buffer element (we'll store the document fragment buffer there so that we can deallocate it later)
-		impl::xml_memory_page* page = NULL;
+		impl::xml_memory_page* page = PUGIXML_NULL;
 		impl::xml_extra_buffer* extra = static_cast<impl::xml_extra_buffer*>(doc->allocate_memory(sizeof(impl::xml_extra_buffer) + sizeof(void*), page));
 		(void)page;
 
@@ -6650,7 +6650,7 @@ namespace pugi
 	#endif
 
 		// add extra buffer to the list
-		extra->buffer = NULL;
+		extra->buffer = PUGIXML_NULL;
 		extra->next = doc->extra_buffers;
 		doc->extra_buffers = extra;
 
@@ -6790,7 +6790,7 @@ namespace pugi
 		xml_node arg_begin(_root);
 		if (!walker.begin(arg_begin)) return false;
 
-		xml_node_struct* cur = _root ? _root->first_child + 0 : NULL;
+		xml_node_struct* cur = _root ? _root->first_child + 0 : PUGIXML_NULL;
 
 		if (cur)
 		{
@@ -6926,7 +6926,7 @@ namespace pugi
 			if (impl::is_text_node(node))
 				return node;
 
-		return NULL;
+		return PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN xml_node_struct* xml_text::_data_new()
@@ -6937,7 +6937,7 @@ namespace pugi
 		return xml_node(_root).append_child(node_pcdata).internal_object();
 	}
 
-	PUGI_IMPL_FN xml_text::xml_text(): _root(NULL)
+	PUGI_IMPL_FN xml_text::xml_text(): _root(PUGIXML_NULL)
 	{
 	}
 
@@ -6947,7 +6947,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_text::operator xml_text::unspecified_bool_type() const
 	{
-		return _data() ? unspecified_bool_xml_text : NULL;
+		return _data() ? unspecified_bool_xml_text : PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xml_text::operator!() const
@@ -6957,7 +6957,7 @@ namespace pugi
 
 	PUGI_IMPL_FN bool xml_text::empty() const
 	{
-		return _data() == NULL;
+		return _data() == PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN const char_t* xml_text::get() const
@@ -7345,7 +7345,7 @@ namespace pugi
 		return temp;
 	}
 
-	PUGI_IMPL_FN xml_named_node_iterator::xml_named_node_iterator(): _name(NULL)
+	PUGI_IMPL_FN xml_named_node_iterator::xml_named_node_iterator(): _name(PUGIXML_NULL)
 	{
 	}
 
@@ -7455,7 +7455,7 @@ namespace pugi
 		}
 	}
 
-	PUGI_IMPL_FN xml_document::xml_document(): _buffer(NULL)
+	PUGI_IMPL_FN xml_document::xml_document(): _buffer(PUGIXML_NULL)
 	{
 		_create();
 	}
@@ -7466,7 +7466,7 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI_IMPL_FN xml_document::xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT: _buffer(NULL)
+	PUGI_IMPL_FN xml_document::xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT: _buffer(PUGIXML_NULL)
 	{
 		_create();
 		_move(rhs);
@@ -7548,7 +7548,7 @@ namespace pugi
 		if (_buffer)
 		{
 			impl::xml_memory::deallocate(_buffer);
-			_buffer = NULL;
+			_buffer = PUGIXML_NULL;
 		}
 
 		// destroy extra buffers (note: no need to destroy linked list nodes, they're allocated using document allocator)
@@ -7576,7 +7576,7 @@ namespace pugi
 		static_cast<impl::xml_document_struct*>(_root)->hash.clear();
 	#endif
 
-		_root = NULL;
+		_root = PUGIXML_NULL;
 	}
 
 #ifdef PUGIXML_HAS_MOVE
@@ -7631,7 +7631,7 @@ namespace pugi
 		doc->_hash = &doc->hash;
 
 		// make sure we don't access other hash up until the end when we reinitialize other document
-		other->_hash = NULL;
+		other->_hash = PUGIXML_NULL;
 	#endif
 
 		// move page structure
@@ -7649,7 +7649,7 @@ namespace pugi
 			page->prev = doc_page;
 
 			doc_page->next = page;
-			other_page->next = NULL;
+			other_page->next = PUGIXML_NULL;
 		}
 
 		// make sure pages point to the correct document state
@@ -7686,7 +7686,7 @@ namespace pugi
 
 		// reset other document
 		new (other) impl::xml_document_struct(PUGI_IMPL_GETPAGE(other));
-		rhs._buffer = NULL;
+		rhs._buffer = PUGIXML_NULL;
 	}
 #endif
 
@@ -8113,7 +8113,7 @@ PUGI_IMPL_NS_BEGIN
 
 		for (size_t probe = 0; probe <= hashmod; ++probe)
 		{
-			if (table[bucket] == NULL)
+			if (table[bucket] == PUGIXML_NULL)
 			{
 				table[bucket] = key;
 				return true;
@@ -8161,7 +8161,7 @@ PUGI_IMPL_NS_BEGIN
 		size_t _root_size;
 		bool* _error;
 
-		xpath_allocator(xpath_memory_block* root, bool* error = NULL): _root(root), _root_size(0), _error(error)
+		xpath_allocator(xpath_memory_block* root, bool* error = PUGIXML_NULL): _root(root), _root_size(0), _error(error)
 		{
 		}
 
@@ -8189,7 +8189,7 @@ PUGI_IMPL_NS_BEGIN
 				if (!block)
 				{
 					if (_error) *_error = true;
-					return NULL;
+					return PUGIXML_NULL;
 				}
 
 				block->next = _root;
@@ -8209,7 +8209,7 @@ PUGI_IMPL_NS_BEGIN
 			new_size = (new_size + xpath_memory_block_alignment - 1) & ~(xpath_memory_block_alignment - 1);
 
 			// we can only reallocate the last object
-			assert(ptr == NULL || static_cast<char*>(ptr) + old_size == &_root->data[0] + _root_size);
+			assert(ptr == PUGIXML_NULL || static_cast<char*>(ptr) + old_size == &_root->data[0] + _root_size);
 
 			// try to reallocate the object inplace
 			if (ptr && _root_size - old_size + new_size <= _root->capacity)
@@ -8220,7 +8220,7 @@ PUGI_IMPL_NS_BEGIN
 
 			// allocate a new block
 			void* result = allocate(new_size);
-			if (!result) return NULL;
+			if (!result) return PUGIXML_NULL;
 
 			// we have a new block
 			if (ptr)
@@ -8315,7 +8315,7 @@ PUGI_IMPL_NS_BEGIN
 
 		xpath_stack_data(): result(blocks + 0, &oom), temp(blocks + 1, &oom), oom(false)
 		{
-			blocks[0].next = blocks[1].next = NULL;
+			blocks[0].next = blocks[1].next = PUGIXML_NULL;
 			blocks[0].capacity = blocks[1].capacity = sizeof(blocks[0].data);
 
 			stack.result = &result;
@@ -8341,7 +8341,7 @@ PUGI_IMPL_NS_BEGIN
 		static char_t* duplicate_string(const char_t* string, size_t length, xpath_allocator* alloc)
 		{
 			char_t* result = static_cast<char_t*>(alloc->allocate((length + 1) * sizeof(char_t)));
-			if (!result) return NULL;
+			if (!result) return PUGIXML_NULL;
 
 			memcpy(result, string, length * sizeof(char_t));
 			result[length] = 0;
@@ -8401,7 +8401,7 @@ PUGI_IMPL_NS_BEGIN
 				size_t result_length = target_length + source_length;
 
 				// allocate new buffer
-				char_t* result = static_cast<char_t*>(alloc->reallocate(_uses_heap ? const_cast<char_t*>(_buffer) : NULL, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
+				char_t* result = static_cast<char_t*>(alloc->reallocate(_uses_heap ? const_cast<char_t*>(_buffer) : PUGIXML_NULL, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
 				if (!result) return;
 
 				// append first string to the new buffer in case there was no reallocation
@@ -8436,7 +8436,7 @@ PUGI_IMPL_NS_BEGIN
 				size_t length_ = strlength(_buffer);
 				const char_t* data_ = duplicate_string(_buffer, length_, alloc);
 
-				if (!data_) return NULL;
+				if (!data_) return PUGIXML_NULL;
 
 				_buffer = data_;
 				_uses_heap = true;
@@ -8645,7 +8645,7 @@ PUGI_IMPL_NS_BEGIN
 				if (node->value && (node->header & impl::xml_memory_page_value_allocated_or_shared_mask) == 0) return node->value;
 			}
 
-			return NULL;
+			return PUGIXML_NULL;
 		}
 
 		xml_attribute_struct* attr = xnode.attribute().internal_object();
@@ -8658,10 +8658,10 @@ PUGI_IMPL_NS_BEGIN
 				if ((attr->header & impl::xml_memory_page_value_allocated_or_shared_mask) == 0) return attr->value;
 			}
 
-			return NULL;
+			return PUGIXML_NULL;
 		}
 
-		return NULL;
+		return PUGIXML_NULL;
 	}
 
 	struct document_order_comparator
@@ -8774,7 +8774,7 @@ PUGI_IMPL_NS_BEGIN
 		if (v == 0) return PUGIXML_TEXT("0");
 		if (v != v) return PUGIXML_TEXT("NaN");
 		if (v * 2 == v) return value > 0 ? PUGIXML_TEXT("Infinity") : PUGIXML_TEXT("-Infinity");
-		return NULL;
+		return PUGIXML_NULL;
 	#endif
 	}
 
@@ -8941,7 +8941,7 @@ PUGI_IMPL_NS_BEGIN
 	#ifdef PUGIXML_WCHAR_MODE
 		return wcstod(string, NULL);
 	#else
-		return strtod(string, NULL);
+		return strtod(string, PUGIXML_NULL);
 	#endif
 	}
 
@@ -9003,7 +9003,7 @@ PUGI_IMPL_NS_BEGIN
 		{
 			const char_t* pos = find_char(name, ':');
 
-			prefix = pos ? name : NULL;
+			prefix = pos ? name : PUGIXML_NULL;
 			prefix_length = pos ? static_cast<size_t>(pos - name) : 0;
 		}
 
@@ -9121,7 +9121,7 @@ PUGI_IMPL_NS_BEGIN
 			unsigned int tc = static_cast<unsigned int>(*to);
 
 			if (fc >= 128 || tc >= 128)
-				return NULL;
+				return PUGIXML_NULL;
 
 			// code=128 means "skip character"
 			if (!table[fc])
@@ -9136,7 +9136,7 @@ PUGI_IMPL_NS_BEGIN
 				table[i] = static_cast<unsigned char>(i);
 
 		void* result = alloc->allocate(sizeof(table));
-		if (!result) return NULL;
+		if (!result) return PUGIXML_NULL;
 
 		memcpy(result, table, sizeof(table));
 
@@ -9200,7 +9200,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_string: xpath_variable
 	{
-		xpath_variable_string(): xpath_variable(xpath_type_string), value(NULL)
+		xpath_variable_string(): xpath_variable(xpath_type_string), value(PUGIXML_NULL)
 		{
 		}
 
@@ -9247,11 +9247,11 @@ PUGI_IMPL_NS_BEGIN
 	template <typename T> PUGI_IMPL_FN T* new_xpath_variable(const char_t* name)
 	{
 		size_t length = strlength(name);
-		if (length == 0) return NULL; // empty variable names are invalid
+		if (length == 0) return PUGIXML_NULL; // empty variable names are invalid
 
 		// $$ we can't use offsetof(T, name) because T is non-POD, so we just allocate additional length characters
 		void* memory = xml_memory::allocate(sizeof(T) + length * sizeof(char_t));
-		if (!memory) return NULL;
+		if (!memory) return PUGIXML_NULL;
 
 		T* result = new (memory) T();
 
@@ -9277,7 +9277,7 @@ PUGI_IMPL_NS_BEGIN
 			return new_xpath_variable<xpath_variable_boolean>(name);
 
 		default:
-			return NULL;
+			return PUGIXML_NULL;
 		}
 	}
 
@@ -9430,7 +9430,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_node* _eos;
 
 	public:
-		xpath_node_set_raw(): _type(xpath_node_set::type_unsorted), _begin(NULL), _end(NULL), _eos(NULL)
+		xpath_node_set_raw(): _type(xpath_node_set::type_unsorted), _begin(PUGIXML_NULL), _end(PUGIXML_NULL), _eos(PUGIXML_NULL)
 		{
 		}
 
@@ -9622,7 +9622,7 @@ PUGI_IMPL_NS_BEGIN
 		const char_t* begin;
 		const char_t* end;
 
-		xpath_lexer_string(): begin(NULL), end(NULL)
+		xpath_lexer_string(): begin(PUGIXML_NULL), end(PUGIXML_NULL)
 		{
 		}
 
@@ -10810,40 +10810,40 @@ PUGI_IMPL_NS_BEGIN
 
 	public:
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, const char_t* value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(NULL), _right(NULL), _next(NULL)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
 		{
 			assert(type == ast_string_constant);
 			_data.string = value;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, double value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(NULL), _right(NULL), _next(NULL)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
 		{
 			assert(type == ast_number_constant);
 			_data.number = value;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_variable* value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(NULL), _right(NULL), _next(NULL)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
 		{
 			assert(type == ast_variable);
 			_data.variable = value;
 		}
 
-		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_ast_node* left = NULL, xpath_ast_node* right = NULL):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(left), _right(right), _next(NULL)
+		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_ast_node* left = PUGIXML_NULL, xpath_ast_node* right = PUGIXML_NULL):
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(left), _right(right), _next(PUGIXML_NULL)
 		{
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_ast_node* left, axis_t axis, nodetest_t test, const char_t* contents):
-			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(static_cast<char>(axis)), _test(static_cast<char>(test)), _left(left), _right(NULL), _next(NULL)
+			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(static_cast<char>(axis)), _test(static_cast<char>(test)), _left(left), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
 		{
 			assert(type == ast_step);
 			_data.nodetest = contents;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_ast_node* left, xpath_ast_node* right, predicate_t test):
-			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(0), _test(static_cast<char>(test)), _left(left), _right(right), _next(NULL)
+			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(0), _test(static_cast<char>(test)), _left(left), _right(right), _next(PUGIXML_NULL)
 		{
 			assert(type == ast_filter || type == ast_predicate);
 		}
@@ -10903,7 +10903,7 @@ PUGI_IMPL_NS_BEGIN
 				xpath_string lr = _left->eval_string(c, stack);
 				xpath_string rr = _right->eval_string(c, stack);
 
-				return find_substring(lr.c_str(), rr.c_str()) != NULL;
+				return find_substring(lr.c_str(), rr.c_str()) != PUGIXML_NULL;
 			}
 
 			case ast_func_boolean:
@@ -11712,7 +11712,7 @@ PUGI_IMPL_NS_BEGIN
 			_result->error = message;
 			_result->offset = _lexer.current_pos() - _query;
 
-			return NULL;
+			return PUGIXML_NULL;
 		}
 
 		xpath_ast_node* error_oom()
@@ -11720,7 +11720,7 @@ PUGI_IMPL_NS_BEGIN
 			assert(_alloc->_error);
 			*_alloc->_error = true;
 
-			return NULL;
+			return PUGIXML_NULL;
 		}
 
 		xpath_ast_node* error_rec()
@@ -11736,37 +11736,37 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, const char_t* value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, double value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_variable* value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
 		}
 
-		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_ast_node* left = NULL, xpath_ast_node* right = NULL)
+		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_ast_node* left = PUGIXML_NULL, xpath_ast_node* right = PUGIXML_NULL)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, left, right) : NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, left, right) : PUGIXML_NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, axis_t axis, nodetest_t test, const char_t* contents)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, left, axis, test, contents) : NULL;
+			return memory ? new (memory) xpath_ast_node(type, left, axis, test, contents) : PUGIXML_NULL;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, xpath_ast_node* right, predicate_t test)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, left, right, test) : NULL;
+			return memory ? new (memory) xpath_ast_node(type, left, right, test) : PUGIXML_NULL;
 		}
 
 		const char_t* alloc_string(const xpath_lexer_string& value)
@@ -11777,7 +11777,7 @@ PUGI_IMPL_NS_BEGIN
 			size_t length = static_cast<size_t>(value.end - value.begin);
 
 			char_t* c = static_cast<char_t*>(_alloc->allocate((length + 1) * sizeof(char_t)));
-			if (!c) return NULL;
+			if (!c) return PUGIXML_NULL;
 
 			memcpy(c, value.begin, length * sizeof(char_t));
 			c[length] = 0;
@@ -12020,7 +12020,7 @@ PUGI_IMPL_NS_BEGIN
 				if (!_variables)
 					return error("Unknown variable: variable set is not provided");
 
-				xpath_variable* var = NULL;
+				xpath_variable* var = PUGIXML_NULL;
 				if (!get_variable_scratch(_scratch, _variables, name.begin, name.end, &var))
 					return error_oom();
 
@@ -12037,7 +12037,7 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = parse_expression();
-				if (!n) return NULL;
+				if (!n) return PUGIXML_NULL;
 
 				if (_lexer.current() != lex_close_brace)
 					return error("Expected ')' to match an opening '('");
@@ -12050,7 +12050,7 @@ PUGI_IMPL_NS_BEGIN
 			case lex_quoted_string:
 			{
 				const char_t* value = alloc_string(_lexer.contents());
-				if (!value) return NULL;
+				if (!value) return PUGIXML_NULL;
 
 				_lexer.next();
 
@@ -12071,13 +12071,13 @@ PUGI_IMPL_NS_BEGIN
 
 			case lex_string:
 			{
-				xpath_ast_node* args[2] = {NULL};
+				xpath_ast_node* args[2] = {PUGIXML_NULL};
 				size_t argc = 0;
 
 				xpath_lexer_string function = _lexer.contents();
 				_lexer.next();
 
-				xpath_ast_node* last_arg = NULL;
+				xpath_ast_node* last_arg = PUGIXML_NULL;
 
 				if (_lexer.current() != lex_open_brace)
 					return error("Unrecognized function call");
@@ -12098,7 +12098,7 @@ PUGI_IMPL_NS_BEGIN
 						return error_rec();
 
 					xpath_ast_node* n = parse_expression();
-					if (!n) return NULL;
+					if (!n) return PUGIXML_NULL;
 
 					if (argc < 2) args[argc] = n;
 					else last_arg->set_next(n);
@@ -12125,7 +12125,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse_filter_expression()
 		{
 			xpath_ast_node* n = parse_primary_expression();
-			if (!n) return NULL;
+			if (!n) return PUGIXML_NULL;
 
 			size_t old_depth = _depth;
 
@@ -12140,10 +12140,10 @@ PUGI_IMPL_NS_BEGIN
 					return error("Predicate has to be applied to node set");
 
 				xpath_ast_node* expr = parse_expression();
-				if (!expr) return NULL;
+				if (!expr) return PUGIXML_NULL;
 
 				n = alloc_node(ast_filter, n, expr, predicate_default);
-				if (!n) return NULL;
+				if (!n) return PUGIXML_NULL;
 
 				if (_lexer.current() != lex_close_square_brace)
 					return error("Expected ']' to match an opening '['");
@@ -12183,7 +12183,7 @@ PUGI_IMPL_NS_BEGIN
 				if (_lexer.current() == lex_open_square_brace)
 					return error("Predicates are not allowed after an abbreviated step");
 
-				return alloc_node(ast_step, set, axis_self, nodetest_type_node, NULL);
+				return alloc_node(ast_step, set, axis_self, nodetest_type_node, PUGIXML_NULL);
 			}
 			else if (_lexer.current() == lex_double_dot)
 			{
@@ -12192,7 +12192,7 @@ PUGI_IMPL_NS_BEGIN
 				if (_lexer.current() == lex_open_square_brace)
 					return error("Predicates are not allowed after an abbreviated step");
 
-				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, NULL);
+				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, PUGIXML_NULL);
 			}
 
 			nodetest_t nt_type = nodetest_none;
@@ -12299,14 +12299,14 @@ PUGI_IMPL_NS_BEGIN
 			}
 
 			const char_t* nt_name_copy = alloc_string(nt_name);
-			if (!nt_name_copy) return NULL;
+			if (!nt_name_copy) return PUGIXML_NULL;
 
 			xpath_ast_node* n = alloc_node(ast_step, set, axis, nt_type, nt_name_copy);
-			if (!n) return NULL;
+			if (!n) return PUGIXML_NULL;
 
 			size_t old_depth = _depth;
 
-			xpath_ast_node* last = NULL;
+			xpath_ast_node* last = PUGIXML_NULL;
 
 			while (_lexer.current() == lex_open_square_brace)
 			{
@@ -12316,10 +12316,10 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				xpath_ast_node* expr = parse_expression();
-				if (!expr) return NULL;
+				if (!expr) return PUGIXML_NULL;
 
-				xpath_ast_node* pred = alloc_node(ast_predicate, NULL, expr, predicate_default);
-				if (!pred) return NULL;
+				xpath_ast_node* pred = alloc_node(ast_predicate, PUGIXML_NULL, expr, predicate_default);
+				if (!pred) return PUGIXML_NULL;
 
 				if (_lexer.current() != lex_close_square_brace)
 					return error("Expected ']' to match an opening '['");
@@ -12340,7 +12340,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse_relative_location_path(xpath_ast_node* set)
 		{
 			xpath_ast_node* n = parse_step(set);
-			if (!n) return NULL;
+			if (!n) return PUGIXML_NULL;
 
 			size_t old_depth = _depth;
 
@@ -12351,8 +12351,8 @@ PUGI_IMPL_NS_BEGIN
 
 				if (l == lex_double_slash)
 				{
-					n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, NULL);
-					if (!n) return NULL;
+					n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
+					if (!n) return PUGIXML_NULL;
 
 					++_depth;
 				}
@@ -12361,7 +12361,7 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				n = parse_step(n);
-				if (!n) return NULL;
+				if (!n) return PUGIXML_NULL;
 			}
 
 			_depth = old_depth;
@@ -12378,7 +12378,7 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
-				if (!n) return NULL;
+				if (!n) return PUGIXML_NULL;
 
 				// relative location path can start from axis_attribute, dot, double_dot, multiply and string lexemes; any other lexeme means standalone root path
 				lexeme_t l = _lexer.current();
@@ -12393,16 +12393,16 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
-				if (!n) return NULL;
+				if (!n) return PUGIXML_NULL;
 
-				n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, NULL);
-				if (!n) return NULL;
+				n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
+				if (!n) return PUGIXML_NULL;
 
 				return parse_relative_location_path(n);
 			}
 
 			// else clause moved outside of if because of bogus warning 'control may reach end of non-void function being inlined' in gcc 4.0.1
-			return parse_relative_location_path(NULL);
+			return parse_relative_location_path(PUGIXML_NULL);
 		}
 
 		// PathExpr ::= LocationPath
@@ -12439,7 +12439,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 
 				xpath_ast_node* n = parse_filter_expression();
-				if (!n) return NULL;
+				if (!n) return PUGIXML_NULL;
 
 				if (_lexer.current() == lex_slash || _lexer.current() == lex_double_slash)
 				{
@@ -12451,8 +12451,8 @@ PUGI_IMPL_NS_BEGIN
 						if (n->rettype() != xpath_type_node_set)
 							return error("Step has to be applied to node set");
 
-						n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, NULL);
-						if (!n) return NULL;
+						n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
+						if (!n) return PUGIXML_NULL;
 					}
 
 					// select from location path
@@ -12467,7 +12467,7 @@ PUGI_IMPL_NS_BEGIN
 
 				// precedence 7+ - only parses union expressions
 				xpath_ast_node* n = parse_expression(7);
-				if (!n) return NULL;
+				if (!n) return PUGIXML_NULL;
 
 				return alloc_node(ast_op_negate, xpath_type_number, n);
 			}
@@ -12555,14 +12555,14 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				xpath_ast_node* rhs = parse_path_or_unary_expression();
-				if (!rhs) return NULL;
+				if (!rhs) return PUGIXML_NULL;
 
 				binary_op_t nextop = binary_op_t::parse(_lexer);
 
 				while (nextop.asttype != ast_unknown && nextop.precedence > op.precedence)
 				{
 					rhs = parse_expression_rec(rhs, nextop.precedence);
-					if (!rhs) return NULL;
+					if (!rhs) return PUGIXML_NULL;
 
 					nextop = binary_op_t::parse(_lexer);
 				}
@@ -12571,7 +12571,7 @@ PUGI_IMPL_NS_BEGIN
 					return error("Union operator has to be applied to node sets");
 
 				lhs = alloc_node(op.asttype, op.rettype, lhs, rhs);
-				if (!lhs) return NULL;
+				if (!lhs) return PUGIXML_NULL;
 
 				op = binary_op_t::parse(_lexer);
 			}
@@ -12605,7 +12605,7 @@ PUGI_IMPL_NS_BEGIN
 				return error_rec();
 
 			xpath_ast_node* n = parse_path_or_unary_expression();
-			if (!n) return NULL;
+			if (!n) return PUGIXML_NULL;
 
 			n = parse_expression_rec(n, limit);
 
@@ -12621,7 +12621,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse()
 		{
 			xpath_ast_node* n = parse_expression();
-			if (!n) return NULL;
+			if (!n) return PUGIXML_NULL;
 
 			assert(_depth == 0);
 
@@ -12645,7 +12645,7 @@ PUGI_IMPL_NS_BEGIN
 		static xpath_query_impl* create()
 		{
 			void* memory = xml_memory::allocate(sizeof(xpath_query_impl));
-			if (!memory) return NULL;
+			if (!memory) return PUGIXML_NULL;
 
 			return new (memory) xpath_query_impl();
 		}
@@ -12659,9 +12659,9 @@ PUGI_IMPL_NS_BEGIN
 			xml_memory::deallocate(impl);
 		}
 
-		xpath_query_impl(): root(NULL), alloc(&block, &oom), oom(false)
+		xpath_query_impl(): root(PUGIXML_NULL), alloc(&block, &oom), oom(false)
 		{
-			block.next = NULL;
+			block.next = PUGIXML_NULL;
 			block.capacity = sizeof(block.data);
 		}
 
@@ -12673,7 +12673,7 @@ PUGI_IMPL_NS_BEGIN
 
 	PUGI_IMPL_FN impl::xpath_ast_node* evaluate_node_set_prepare(xpath_query_impl* impl)
 	{
-		if (!impl) return NULL;
+		if (!impl) return PUGIXML_NULL;
 
 		if (impl->root->rettype() != xpath_type_node_set)
 		{
@@ -12743,7 +12743,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_node::operator xpath_node::unspecified_bool_type() const
 	{
-		return (_node || _attribute) ? unspecified_bool_xpath_node : NULL;
+		return (_node || _attribute) ? unspecified_bool_xpath_node : PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xpath_node::operator!() const
@@ -12913,7 +12913,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_parse_result::operator bool() const
 	{
-		return error == NULL;
+		return error == PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN const char* xpath_parse_result::description() const
@@ -12921,7 +12921,7 @@ namespace pugi
 		return error ? error : "No error";
 	}
 
-	PUGI_IMPL_FN xpath_variable::xpath_variable(xpath_value_type type_): _type(type_), _next(NULL)
+	PUGI_IMPL_FN xpath_variable::xpath_variable(xpath_value_type type_): _type(type_), _next(PUGIXML_NULL)
 	{
 	}
 
@@ -12943,7 +12943,7 @@ namespace pugi
 
 		default:
 			assert(false && "Invalid variable type"); // unreachable
-			return NULL;
+			return PUGIXML_NULL;
 		}
 	}
 
@@ -12964,7 +12964,7 @@ namespace pugi
 
 	PUGI_IMPL_FN const char_t* xpath_variable::get_string() const
 	{
-		const char_t* value = (_type == xpath_type_string) ? static_cast<const impl::xpath_variable_string*>(this)->value : NULL;
+		const char_t* value = (_type == xpath_type_string) ? static_cast<const impl::xpath_variable_string*>(this)->value : PUGIXML_NULL;
 		return value ? value : PUGIXML_TEXT("");
 	}
 
@@ -13021,7 +13021,7 @@ namespace pugi
 	PUGI_IMPL_FN xpath_variable_set::xpath_variable_set()
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
-			_data[i] = NULL;
+			_data[i] = PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN xpath_variable_set::~xpath_variable_set()
@@ -13033,7 +13033,7 @@ namespace pugi
 	PUGI_IMPL_FN xpath_variable_set::xpath_variable_set(const xpath_variable_set& rhs)
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
-			_data[i] = NULL;
+			_data[i] = PUGIXML_NULL;
 
 		_assign(rhs);
 	}
@@ -13053,7 +13053,7 @@ namespace pugi
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
 		{
 			_data[i] = rhs._data[i];
-			rhs._data[i] = NULL;
+			rhs._data[i] = PUGIXML_NULL;
 		}
 	}
 
@@ -13064,7 +13064,7 @@ namespace pugi
 			_destroy(_data[i]);
 
 			_data[i] = rhs._data[i];
-			rhs._data[i] = NULL;
+			rhs._data[i] = PUGIXML_NULL;
 		}
 
 		return *this;
@@ -13103,12 +13103,12 @@ namespace pugi
 			if (impl::strequal(var->name(), name))
 				return var;
 
-		return NULL;
+		return PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xpath_variable_set::_clone(xpath_variable* var, xpath_variable** out_result)
 	{
-		xpath_variable* last = NULL;
+		xpath_variable* last = PUGIXML_NULL;
 
 		while (var)
 		{
@@ -13153,7 +13153,7 @@ namespace pugi
 		// look for existing variable
 		for (xpath_variable* var = _data[hash]; var; var = var->_next)
 			if (impl::strequal(var->name(), name))
-				return var->type() == type ? var : NULL;
+				return var->type() == type ? var : PUGIXML_NULL;
 
 		// add new variable
 		xpath_variable* result = impl::new_xpath_variable(type, name);
@@ -13202,7 +13202,7 @@ namespace pugi
 		return _find(name);
 	}
 
-	PUGI_IMPL_FN xpath_query::xpath_query(const char_t* query, xpath_variable_set* variables): _impl(NULL)
+	PUGI_IMPL_FN xpath_query::xpath_query(const char_t* query, xpath_variable_set* variables): _impl(PUGIXML_NULL)
 	{
 		impl::xpath_query_impl* qimpl = impl::xpath_query_impl::create();
 
@@ -13226,7 +13226,7 @@ namespace pugi
 				qimpl->root->optimize(&qimpl->alloc);
 
 				_impl = impl.release();
-				_result.error = NULL;
+				_result.error = PUGIXML_NULL;
 			}
 			else
 			{
@@ -13240,7 +13240,7 @@ namespace pugi
 		}
 	}
 
-	PUGI_IMPL_FN xpath_query::xpath_query(): _impl(NULL)
+	PUGI_IMPL_FN xpath_query::xpath_query(): _impl(PUGIXML_NULL)
 	{
 	}
 
@@ -13255,7 +13255,7 @@ namespace pugi
 	{
 		_impl = rhs._impl;
 		_result = rhs._result;
-		rhs._impl = NULL;
+		rhs._impl = PUGIXML_NULL;
 		rhs._result = xpath_parse_result();
 	}
 
@@ -13268,7 +13268,7 @@ namespace pugi
 
 		_impl = rhs._impl;
 		_result = rhs._result;
-		rhs._impl = NULL;
+		rhs._impl = PUGIXML_NULL;
 		rhs._result = xpath_parse_result();
 
 		return *this;
@@ -13432,7 +13432,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_query::operator xpath_query::unspecified_bool_type() const
 	{
-		return _impl ? unspecified_bool_xpath_query : NULL;
+		return _impl ? unspecified_bool_xpath_query : PUGIXML_NULL;
 	}
 
 	PUGI_IMPL_FN bool xpath_query::operator!() const

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -316,7 +316,7 @@ PUGI_IMPL_NS_BEGIN
 		T* release()
 		{
 			T* result = data;
-			data = PUGIXML_NULL;
+			data = nullptr;
 			return result;
 		}
 	};
@@ -327,7 +327,7 @@ PUGI_IMPL_NS_BEGIN
 	class compact_hash_table
 	{
 	public:
-		compact_hash_table(): _items(PUGIXML_NULL), _capacity(0), _count(0)
+		compact_hash_table(): _items(nullptr), _capacity(0), _count(0)
 		{
 		}
 
@@ -336,7 +336,7 @@ PUGI_IMPL_NS_BEGIN
 			if (_items)
 			{
 				xml_memory::deallocate(_items);
-				_items = PUGIXML_NULL;
+				_items = nullptr;
 				_capacity = 0;
 				_count = 0;
 			}
@@ -344,11 +344,11 @@ PUGI_IMPL_NS_BEGIN
 
 		void* find(const void* key)
 		{
-			if (_capacity == 0) return PUGIXML_NULL;
+			if (_capacity == 0) return nullptr;
 
 			item_t* item = get_item(key);
 			assert(item);
-			assert(item->key == key || (item->key == PUGIXML_NULL && item->value == PUGIXML_NULL));
+			assert(item->key == key || (item->key == nullptr && item->value == nullptr));
 
 			return item->value;
 		}
@@ -360,7 +360,7 @@ PUGI_IMPL_NS_BEGIN
 			item_t* item = get_item(key);
 			assert(item);
 
-			if (item->key == PUGIXML_NULL)
+			if (item->key == nullptr)
 			{
 				_count++;
 				item->key = key;
@@ -403,7 +403,7 @@ PUGI_IMPL_NS_BEGIN
 			{
 				item_t& probe_item = _items[bucket];
 
-				if (probe_item.key == key || probe_item.key == PUGIXML_NULL)
+				if (probe_item.key == key || probe_item.key == nullptr)
 					return &probe_item;
 
 				// hash collision, quadratic probing
@@ -411,7 +411,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 
 			assert(false && "Hash table is full"); // unreachable
-			return PUGIXML_NULL;
+			return nullptr;
 		}
 
 		static PUGI_IMPL_UNSIGNED_OVERFLOW unsigned int hash(const void* key)
@@ -499,16 +499,16 @@ PUGI_IMPL_NS_BEGIN
 		{
 			xml_memory_page* result = static_cast<xml_memory_page*>(memory);
 
-			result->allocator = PUGIXML_NULL;
-			result->prev = PUGIXML_NULL;
-			result->next = PUGIXML_NULL;
+			result->allocator = nullptr;
+			result->prev = nullptr;
+			result->next = nullptr;
 			result->busy_size = 0;
 			result->freed_size = 0;
 
 		#ifdef PUGIXML_COMPACT
-			result->compact_string_base = PUGIXML_NULL;
-			result->compact_shared_parent = PUGIXML_NULL;
-			result->compact_page_marker = PUGIXML_NULL;
+			result->compact_string_base = nullptr;
+			result->compact_shared_parent = nullptr;
+			result->compact_page_marker = nullptr;
 		#endif
 
 			return result;
@@ -548,7 +548,7 @@ PUGI_IMPL_NS_BEGIN
 		xml_allocator(xml_memory_page* root): _root(root), _busy_size(root->busy_size)
 		{
 		#ifdef PUGIXML_COMPACT
-			_hash = PUGIXML_NULL;
+			_hash = nullptr;
 		#endif
 		}
 
@@ -558,7 +558,7 @@ PUGI_IMPL_NS_BEGIN
 
 			// allocate block with some alignment, leaving memory for worst-case padding
 			void* memory = xml_memory::allocate(size);
-			if (!memory) return PUGIXML_NULL;
+			if (!memory) return nullptr;
 
 			// prepare page structure
 			xml_memory_page* page = xml_memory_page::construct(memory);
@@ -595,7 +595,7 @@ PUGI_IMPL_NS_BEGIN
 		void* allocate_object(size_t size, xml_memory_page*& out_page)
 		{
 			void* result = allocate_memory(size + sizeof(uint32_t), out_page);
-			if (!result) return PUGIXML_NULL;
+			if (!result) return nullptr;
 
 			// adjust for marker
 			ptrdiff_t offset = static_cast<char*>(result) - reinterpret_cast<char*>(out_page->compact_page_marker);
@@ -641,7 +641,7 @@ PUGI_IMPL_NS_BEGIN
 
 			if (page->freed_size == page->busy_size)
 			{
-				if (page->next == PUGIXML_NULL)
+				if (page->next == nullptr)
 				{
 					assert(_root == page);
 
@@ -651,9 +651,9 @@ PUGI_IMPL_NS_BEGIN
 
 				#ifdef PUGIXML_COMPACT
 					// reset compact state to maximize efficiency
-					page->compact_string_base = PUGIXML_NULL;
-					page->compact_shared_parent = PUGIXML_NULL;
-					page->compact_page_marker = PUGIXML_NULL;
+					page->compact_string_base = nullptr;
+					page->compact_shared_parent = nullptr;
+					page->compact_page_marker = nullptr;
 				#endif
 
 					_busy_size = 0;
@@ -688,7 +688,7 @@ PUGI_IMPL_NS_BEGIN
 			xml_memory_page* page;
 			xml_memory_string_header* header = static_cast<xml_memory_string_header*>(allocate_memory(full_size, page));
 
-			if (!header) return PUGIXML_NULL;
+			if (!header) return nullptr;
 
 			// setup header
 			ptrdiff_t page_offset = reinterpret_cast<char*>(header) - reinterpret_cast<char*>(page) - sizeof(xml_memory_page);
@@ -750,7 +750,7 @@ PUGI_IMPL_NS_BEGIN
 		xml_memory_page* page = allocate_page(size <= large_allocation_threshold ? xml_memory_page_size : size);
 		out_page = page;
 
-		if (!page) return PUGIXML_NULL;
+		if (!page) return nullptr;
 
 		if (size <= large_allocation_threshold)
 		{
@@ -897,7 +897,7 @@ PUGI_IMPL_NS_BEGIN
 					return compact_get_value<header_offset, T>(this);
 			}
 			else
-				return PUGIXML_NULL;
+				return nullptr;
 		}
 
 		T* operator->() const
@@ -940,7 +940,7 @@ PUGI_IMPL_NS_BEGIN
 				{
 					xml_memory_page* page = compact_get_page(this, header_offset);
 
-					if (PUGI_IMPL_UNLIKELY(page->compact_shared_parent == PUGIXML_NULL))
+					if (PUGI_IMPL_UNLIKELY(page->compact_shared_parent == nullptr))
 						page->compact_shared_parent = value;
 
 					if (page->compact_shared_parent == value)
@@ -977,7 +977,7 @@ PUGI_IMPL_NS_BEGIN
 					return compact_get_value<header_offset, T>(this);
 			}
 			else
-				return PUGIXML_NULL;
+				return nullptr;
 		}
 
 		T* operator->() const
@@ -1007,7 +1007,7 @@ PUGI_IMPL_NS_BEGIN
 			{
 				xml_memory_page* page = compact_get_page(this, header_offset);
 
-				if (PUGI_IMPL_UNLIKELY(page->compact_string_base == PUGIXML_NULL))
+				if (PUGI_IMPL_UNLIKELY(page->compact_string_base == nullptr))
 					page->compact_string_base = value;
 
 				ptrdiff_t offset = value - page->compact_string_base;
@@ -1073,7 +1073,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 			}
 			else
-				return PUGIXML_NULL;
+				return nullptr;
 		}
 
 	private:
@@ -1132,7 +1132,7 @@ namespace pugi
 {
 	struct xml_attribute_struct
 	{
-		xml_attribute_struct(impl::xml_memory_page* page): name(PUGIXML_NULL), value(PUGIXML_NULL), prev_attribute_c(PUGIXML_NULL), next_attribute(PUGIXML_NULL)
+		xml_attribute_struct(impl::xml_memory_page* page): name(nullptr), value(nullptr), prev_attribute_c(nullptr), next_attribute(nullptr)
 		{
 			header = PUGI_IMPL_GETHEADER_IMPL(this, page, 0);
 		}
@@ -1148,7 +1148,7 @@ namespace pugi
 
 	struct xml_node_struct
 	{
-		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): name(PUGIXML_NULL), value(PUGIXML_NULL), parent(PUGIXML_NULL), first_child(PUGIXML_NULL), prev_sibling_c(PUGIXML_NULL), next_sibling(PUGIXML_NULL), first_attribute(PUGIXML_NULL)
+		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): name(nullptr), value(nullptr), parent(nullptr), first_child(nullptr), prev_sibling_c(nullptr), next_sibling(nullptr), first_attribute(nullptr)
 		{
 			header = PUGI_IMPL_GETHEADER_IMPL(this, page, type);
 		}
@@ -1179,7 +1179,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xml_document_struct: public xml_node_struct, public xml_allocator
 	{
-		xml_document_struct(xml_memory_page* page): xml_node_struct(page, node_document), xml_allocator(page), buffer(PUGIXML_NULL), extra_buffers(PUGIXML_NULL)
+		xml_document_struct(xml_memory_page* page): xml_node_struct(page, node_document), xml_allocator(page), buffer(nullptr), extra_buffers(nullptr)
 		{
 		}
 
@@ -1213,7 +1213,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		xml_memory_page* page;
 		void* memory = alloc.allocate_object(sizeof(xml_attribute_struct), page);
-		if (!memory) return PUGIXML_NULL;
+		if (!memory) return nullptr;
 
 		return new (memory) xml_attribute_struct(page);
 	}
@@ -1222,7 +1222,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		xml_memory_page* page;
 		void* memory = alloc.allocate_object(sizeof(xml_node_struct), page);
-		if (!memory) return PUGIXML_NULL;
+		if (!memory) return nullptr;
 
 		return new (memory) xml_node_struct(page, type);
 	}
@@ -1361,9 +1361,9 @@ PUGI_IMPL_NS_BEGIN
 		else
 			parent->first_child = next;
 
-		node->parent = PUGIXML_NULL;
-		node->prev_sibling_c = PUGIXML_NULL;
-		node->next_sibling = PUGIXML_NULL;
+		node->parent = nullptr;
+		node->prev_sibling_c = nullptr;
+		node->next_sibling = nullptr;
 	}
 
 	inline void append_attribute(xml_attribute_struct* attr, xml_node_struct* node)
@@ -1444,16 +1444,16 @@ PUGI_IMPL_NS_BEGIN
 		else
 			node->first_attribute = next;
 
-		attr->prev_attribute_c = PUGIXML_NULL;
-		attr->next_attribute = PUGIXML_NULL;
+		attr->prev_attribute_c = nullptr;
+		attr->next_attribute = nullptr;
 	}
 
 	PUGI_IMPL_FN_NO_INLINE xml_node_struct* append_new_node(xml_node_struct* node, xml_allocator& alloc, xml_node_type type = node_element)
 	{
-		if (!alloc.reserve()) return PUGIXML_NULL;
+		if (!alloc.reserve()) return nullptr;
 
 		xml_node_struct* child = allocate_node(alloc, type);
-		if (!child) return PUGIXML_NULL;
+		if (!child) return nullptr;
 
 		append_node(child, node);
 
@@ -1462,10 +1462,10 @@ PUGI_IMPL_NS_BEGIN
 
 	PUGI_IMPL_FN_NO_INLINE xml_attribute_struct* append_new_attribute(xml_node_struct* node, xml_allocator& alloc)
 	{
-		if (!alloc.reserve()) return PUGIXML_NULL;
+		if (!alloc.reserve()) return nullptr;
 
 		xml_attribute_struct* attr = allocate_attribute(alloc);
-		if (!attr) return PUGIXML_NULL;
+		if (!attr) return nullptr;
 
 		append_attribute(attr, node);
 
@@ -2047,7 +2047,7 @@ PUGI_IMPL_NS_BEGIN
 		if (d0 == 0x3c && d1 == 0) return encoding_utf16_le;
 
 		// no known BOM detected; parse declaration
-		const uint8_t* enc = PUGIXML_NULL;
+		const uint8_t* enc = nullptr;
 		size_t enc_length = 0;
 
 		if (d0 == 0x3c && d1 == 0x3f && d2 == 0x78 && d3 == 0x6d && parse_declaration_encoding(data, size, enc, enc_length))
@@ -2418,7 +2418,7 @@ PUGI_IMPL_NS_BEGIN
 			if (header & header_mask) alloc->deallocate_string(dest);
 
 			// mark the string as not allocated
-			dest = PUGIXML_NULL;
+			dest = nullptr;
 			header &= ~header_mask;
 
 			return true;
@@ -2461,7 +2461,7 @@ PUGI_IMPL_NS_BEGIN
 		char_t* end;
 		size_t size;
 
-		gap(): end(PUGIXML_NULL), size(0)
+		gap(): end(nullptr), size(0)
 		{
 		}
 
@@ -2648,7 +2648,7 @@ PUGI_IMPL_NS_BEGIN
 	#define PUGI_IMPL_SCANWHILE(X)          { while (X) ++s; }
 	#define PUGI_IMPL_SCANWHILE_UNROLL(X)   { for (;;) { char_t ss = s[0]; if (PUGI_IMPL_UNLIKELY(!(X))) { break; } ss = s[1]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 1; break; } ss = s[2]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 2; break; } ss = s[3]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 3; break; } s += 4; } }
 	#define PUGI_IMPL_ENDSEG()              { ch = *s; *s = 0; ++s; }
-	#define PUGI_IMPL_THROW_ERROR(err, m)   return error_offset = m, error_status = err, static_cast<char_t*>(NULL)
+	#define PUGI_IMPL_THROW_ERROR(err, m)   return error_offset = m, error_status = err, static_cast<char_t*>(nullptr)
 	#define PUGI_IMPL_CHECK_ERROR(err, m)   { if (*s == 0) PUGI_IMPL_THROW_ERROR(err, m); }
 
 	PUGI_IMPL_FN char_t* strconv_comment(char_t* s, char_t endch)
@@ -2673,7 +2673,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 			else if (*s == 0)
 			{
-				return PUGIXML_NULL;
+				return nullptr;
 			}
 			else ++s;
 		}
@@ -2701,7 +2701,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 			else if (*s == 0)
 			{
-				return PUGIXML_NULL;
+				return nullptr;
 			}
 			else ++s;
 		}
@@ -2774,7 +2774,7 @@ PUGI_IMPL_NS_BEGIN
 		case 5: return strconv_pcdata_impl<opt_true, opt_false, opt_true>::parse;
 		case 6: return strconv_pcdata_impl<opt_true, opt_true, opt_false>::parse;
 		case 7: return strconv_pcdata_impl<opt_true, opt_true, opt_true>::parse;
-		default: assert(false); return PUGIXML_NULL; // unreachable
+		default: assert(false); return nullptr; // unreachable
 		}
 	}
 
@@ -2828,7 +2828,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return PUGIXML_NULL;
+					return nullptr;
 				}
 				else ++s;
 			}
@@ -2864,7 +2864,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return PUGIXML_NULL;
+					return nullptr;
 				}
 				else ++s;
 			}
@@ -2896,7 +2896,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return PUGIXML_NULL;
+					return nullptr;
 				}
 				else ++s;
 			}
@@ -2922,7 +2922,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return PUGIXML_NULL;
+					return nullptr;
 				}
 				else ++s;
 			}
@@ -2951,7 +2951,7 @@ PUGI_IMPL_NS_BEGIN
 		case 13: return strconv_attribute_impl<opt_true>::parse_wnorm;
 		case 14: return strconv_attribute_impl<opt_false>::parse_wnorm;
 		case 15: return strconv_attribute_impl<opt_true>::parse_wnorm;
-		default: assert(false); return PUGIXML_NULL; // unreachable
+		default: assert(false); return nullptr; // unreachable
 		}
 	}
 
@@ -2970,7 +2970,7 @@ PUGI_IMPL_NS_BEGIN
 		char_t* error_offset;
 		xml_parse_status error_status;
 
-		xml_parser(xml_allocator* alloc_): alloc(alloc_), error_offset(PUGIXML_NULL), error_status(status_ok)
+		xml_parser(xml_allocator* alloc_): alloc(alloc_), error_offset(nullptr), error_status(status_ok)
 		{
 		}
 
@@ -3582,7 +3582,7 @@ PUGI_IMPL_NS_BEGIN
 				return make_parse_result(PUGI_IMPL_OPTSET(parse_fragment) ? status_ok : status_no_document_element);
 
 			// get last child of the root before parsing
-			xml_node_struct* last_root_child = root->first_child ? root->first_child->prev_sibling_c + 0 : PUGIXML_NULL;
+			xml_node_struct* last_root_child = root->first_child ? root->first_child->prev_sibling_c + 0 : nullptr;
 
 			// create parser on stack
 			xml_parser parser(static_cast<xml_allocator*>(xmldoc));
@@ -4499,7 +4499,7 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN void node_copy_tree(xml_node_struct* dn, xml_node_struct* sn)
 	{
 		xml_allocator& alloc = get_allocator(dn);
-		xml_allocator* shared_alloc = (&alloc == &get_allocator(sn)) ? &alloc : PUGIXML_NULL;
+		xml_allocator* shared_alloc = (&alloc == &get_allocator(sn)) ? &alloc : nullptr;
 
 		node_copy_contents(dn, sn, shared_alloc);
 
@@ -4553,7 +4553,7 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN void node_copy_attribute(xml_attribute_struct* da, xml_attribute_struct* sa)
 	{
 		xml_allocator& alloc = get_allocator(da);
-		xml_allocator* shared_alloc = (&alloc == &get_allocator(sa)) ? &alloc : PUGIXML_NULL;
+		xml_allocator* shared_alloc = (&alloc == &get_allocator(sa)) ? &alloc : nullptr;
 
 		node_copy_string(da->name, da->header, xml_memory_page_name_allocated_mask, sa->name, sa->header, shared_alloc);
 		node_copy_string(da->value, da->header, xml_memory_page_value_allocated_mask, sa->value, sa->header, shared_alloc);
@@ -4662,18 +4662,18 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN double get_value_double(const char_t* value)
 	{
 	#ifdef PUGIXML_WCHAR_MODE
-		return wcstod(value, NULL);
+		return wcstod(value, nullptr);
 	#else
-		return strtod(value, PUGIXML_NULL);
+		return strtod(value, nullptr);
 	#endif
 	}
 
 	PUGI_IMPL_FN float get_value_float(const char_t* value)
 	{
 	#ifdef PUGIXML_WCHAR_MODE
-		return static_cast<float>(wcstod(value, NULL));
+		return static_cast<float>(wcstod(value, nullptr));
 	#else
-		return static_cast<float>(strtod(value, PUGIXML_NULL));
+		return static_cast<float>(strtod(value, nullptr));
 	#endif
 	}
 
@@ -4778,10 +4778,10 @@ PUGI_IMPL_NS_BEGIN
 		xml_encoding buffer_encoding = impl::get_buffer_encoding(encoding, contents, size);
 
 		// if convert_buffer below throws bad_alloc, we still need to deallocate contents if we own it
-		auto_deleter<void> contents_guard(own ? contents : PUGIXML_NULL, xml_memory::deallocate);
+		auto_deleter<void> contents_guard(own ? contents : nullptr, xml_memory::deallocate);
 
 		// get private buffer
-		char_t* buffer = PUGIXML_NULL;
+		char_t* buffer = nullptr;
 		size_t length = 0;
 
 		// coverity[var_deref_model]
@@ -4925,7 +4925,7 @@ PUGI_IMPL_NS_BEGIN
 		static xml_stream_chunk* create()
 		{
 			void* memory = xml_memory::allocate(sizeof(xml_stream_chunk));
-			if (!memory) return PUGIXML_NULL;
+			if (!memory) return nullptr;
 
 			return new (memory) xml_stream_chunk();
 		}
@@ -4943,7 +4943,7 @@ PUGI_IMPL_NS_BEGIN
 			}
 		}
 
-		xml_stream_chunk(): next(PUGIXML_NULL), size(0)
+		xml_stream_chunk(): next(nullptr), size(0)
 		{
 		}
 
@@ -4955,11 +4955,11 @@ PUGI_IMPL_NS_BEGIN
 
 	template <typename T> PUGI_IMPL_FN xml_parse_status load_stream_data_noseek(std::basic_istream<T>& stream, void** out_buffer, size_t* out_size)
 	{
-		auto_deleter<xml_stream_chunk<T> > chunks(PUGIXML_NULL, xml_stream_chunk<T>::destroy);
+		auto_deleter<xml_stream_chunk<T> > chunks(nullptr, xml_stream_chunk<T>::destroy);
 
 		// read file to a chunk list
 		size_t total = 0;
-		xml_stream_chunk<T>* last = PUGIXML_NULL;
+		xml_stream_chunk<T>* last = nullptr;
 
 		while (!stream.eof())
 		{
@@ -5045,7 +5045,7 @@ PUGI_IMPL_NS_BEGIN
 
 	template <typename T> PUGI_IMPL_FN xml_parse_result load_stream_impl(xml_document_struct* doc, std::basic_istream<T>& stream, unsigned int options, xml_encoding encoding, char_t** out_buffer)
 	{
-		void* buffer = PUGIXML_NULL;
+		void* buffer = nullptr;
 		size_t size = 0;
 		xml_parse_status status = status_ok;
 
@@ -5098,7 +5098,7 @@ PUGI_IMPL_NS_BEGIN
 
 		// allocate resulting string
 		char* result = static_cast<char*>(xml_memory::allocate(size + 1));
-		if (!result) return PUGIXML_NULL;
+		if (!result) return nullptr;
 
 		// second pass: convert to utf8
 		as_utf8_end(result, size, str, length);
@@ -5113,7 +5113,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		// there is no standard function to open wide paths, so our best bet is to try utf8 path
 		char* path_utf8 = convert_path_heap(path);
-		if (!path_utf8) return PUGIXML_NULL;
+		if (!path_utf8) return nullptr;
 
 		// convert mode to ASCII (we mirror _wfopen interface)
 		char mode_ascii[4] = {0};
@@ -5156,7 +5156,7 @@ PUGI_IMPL_NS_BEGIN
 
 		name_null_sentry(xml_node_struct* node_): node(node_), name(node_->name)
 		{
-			node->name = PUGIXML_NULL;
+			node->name = nullptr;
 		}
 
 		~name_null_sentry()
@@ -5183,11 +5183,11 @@ namespace pugi
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<char>& stream): narrow_stream(&stream), wide_stream(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<char>& stream): narrow_stream(&stream), wide_stream(nullptr)
 	{
 	}
 
-	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<wchar_t>& stream): narrow_stream(PUGIXML_NULL), wide_stream(&stream)
+	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<wchar_t>& stream): narrow_stream(nullptr), wide_stream(&stream)
 	{
 	}
 
@@ -5231,7 +5231,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI_IMPL_FN xml_attribute::xml_attribute(): _attr(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_attribute::xml_attribute(): _attr(nullptr)
 	{
 	}
 
@@ -5245,7 +5245,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_attribute::operator xml_attribute::unspecified_bool_type() const
 	{
-		return _attr ? unspecified_bool_xml_attribute : PUGIXML_NULL;
+		return _attr ? unspecified_bool_xml_attribute : nullptr;
 	}
 
 	PUGI_IMPL_FN bool xml_attribute::operator!() const
@@ -5590,7 +5590,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI_IMPL_FN xml_node::xml_node(): _root(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_node::xml_node(): _root(nullptr)
 	{
 	}
 
@@ -5604,7 +5604,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_node::operator xml_node::unspecified_bool_type() const
 	{
-		return _root ? unspecified_bool_xml_node : PUGIXML_NULL;
+		return _root ? unspecified_bool_xml_node : nullptr;
 	}
 
 	PUGI_IMPL_FN bool xml_node::operator!() const
@@ -5614,22 +5614,22 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_node::iterator xml_node::begin() const
 	{
-		return iterator(_root ? _root->first_child + 0 : PUGIXML_NULL, _root);
+		return iterator(_root ? _root->first_child + 0 : nullptr, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::iterator xml_node::end() const
 	{
-		return iterator(PUGIXML_NULL, _root);
+		return iterator(nullptr, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::attribute_iterator xml_node::attributes_begin() const
 	{
-		return attribute_iterator(_root ? _root->first_attribute + 0 : PUGIXML_NULL, _root);
+		return attribute_iterator(_root ? _root->first_attribute + 0 : nullptr, _root);
 	}
 
 	PUGI_IMPL_FN xml_node::attribute_iterator xml_node::attributes_end() const
 	{
-		return attribute_iterator(PUGIXML_NULL, _root);
+		return attribute_iterator(nullptr, _root);
 	}
 
 	PUGI_IMPL_FN xml_object_range<xml_node_iterator> xml_node::children() const
@@ -5639,7 +5639,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_object_range<xml_named_node_iterator> xml_node::children(const char_t* name_) const
 	{
-		return xml_object_range<xml_named_node_iterator>(xml_named_node_iterator(child(name_)._root, _root, name_), xml_named_node_iterator(PUGIXML_NULL, _root, name_));
+		return xml_object_range<xml_named_node_iterator>(xml_named_node_iterator(child(name_)._root, _root, name_), xml_named_node_iterator(nullptr, _root, name_));
 	}
 
 	PUGI_IMPL_FN xml_object_range<xml_attribute_iterator> xml_node::attributes() const
@@ -6571,7 +6571,7 @@ namespace pugi
 			attr = next;
 		}
 
-		_root->first_attribute = PUGIXML_NULL;
+		_root->first_attribute = nullptr;
 
 		return true;
 	}
@@ -6617,7 +6617,7 @@ namespace pugi
 			cur = next;
 		}
 
-		_root->first_child = PUGIXML_NULL;
+		_root->first_child = nullptr;
 
 		return true;
 	}
@@ -6637,7 +6637,7 @@ namespace pugi
 		doc->header |= impl::xml_memory_page_contents_shared_mask;
 
 		// get extra buffer element (we'll store the document fragment buffer there so that we can deallocate it later)
-		impl::xml_memory_page* page = PUGIXML_NULL;
+		impl::xml_memory_page* page = nullptr;
 		impl::xml_extra_buffer* extra = static_cast<impl::xml_extra_buffer*>(doc->allocate_memory(sizeof(impl::xml_extra_buffer) + sizeof(void*), page));
 		(void)page;
 
@@ -6650,7 +6650,7 @@ namespace pugi
 	#endif
 
 		// add extra buffer to the list
-		extra->buffer = PUGIXML_NULL;
+		extra->buffer = nullptr;
 		extra->next = doc->extra_buffers;
 		doc->extra_buffers = extra;
 
@@ -6790,7 +6790,7 @@ namespace pugi
 		xml_node arg_begin(_root);
 		if (!walker.begin(arg_begin)) return false;
 
-		xml_node_struct* cur = _root ? _root->first_child + 0 : PUGIXML_NULL;
+		xml_node_struct* cur = _root ? _root->first_child + 0 : nullptr;
 
 		if (cur)
 		{
@@ -6926,7 +6926,7 @@ namespace pugi
 			if (impl::is_text_node(node))
 				return node;
 
-		return PUGIXML_NULL;
+		return nullptr;
 	}
 
 	PUGI_IMPL_FN xml_node_struct* xml_text::_data_new()
@@ -6937,7 +6937,7 @@ namespace pugi
 		return xml_node(_root).append_child(node_pcdata).internal_object();
 	}
 
-	PUGI_IMPL_FN xml_text::xml_text(): _root(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_text::xml_text(): _root(nullptr)
 	{
 	}
 
@@ -6947,7 +6947,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_text::operator xml_text::unspecified_bool_type() const
 	{
-		return _data() ? unspecified_bool_xml_text : PUGIXML_NULL;
+		return _data() ? unspecified_bool_xml_text : nullptr;
 	}
 
 	PUGI_IMPL_FN bool xml_text::operator!() const
@@ -6957,7 +6957,7 @@ namespace pugi
 
 	PUGI_IMPL_FN bool xml_text::empty() const
 	{
-		return _data() == PUGIXML_NULL;
+		return _data() == nullptr;
 	}
 
 	PUGI_IMPL_FN const char_t* xml_text::get() const
@@ -7345,7 +7345,7 @@ namespace pugi
 		return temp;
 	}
 
-	PUGI_IMPL_FN xml_named_node_iterator::xml_named_node_iterator(): _name(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_named_node_iterator::xml_named_node_iterator(): _name(nullptr)
 	{
 	}
 
@@ -7455,7 +7455,7 @@ namespace pugi
 		}
 	}
 
-	PUGI_IMPL_FN xml_document::xml_document(): _buffer(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_document::xml_document(): _buffer(nullptr)
 	{
 		_create();
 	}
@@ -7466,7 +7466,7 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI_IMPL_FN xml_document::xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT: _buffer(PUGIXML_NULL)
+	PUGI_IMPL_FN xml_document::xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT: _buffer(nullptr)
 	{
 		_create();
 		_move(rhs);
@@ -7548,7 +7548,7 @@ namespace pugi
 		if (_buffer)
 		{
 			impl::xml_memory::deallocate(_buffer);
-			_buffer = PUGIXML_NULL;
+			_buffer = nullptr;
 		}
 
 		// destroy extra buffers (note: no need to destroy linked list nodes, they're allocated using document allocator)
@@ -7576,7 +7576,7 @@ namespace pugi
 		static_cast<impl::xml_document_struct*>(_root)->hash.clear();
 	#endif
 
-		_root = PUGIXML_NULL;
+		_root = nullptr;
 	}
 
 #ifdef PUGIXML_HAS_MOVE
@@ -7631,7 +7631,7 @@ namespace pugi
 		doc->_hash = &doc->hash;
 
 		// make sure we don't access other hash up until the end when we reinitialize other document
-		other->_hash = PUGIXML_NULL;
+		other->_hash = nullptr;
 	#endif
 
 		// move page structure
@@ -7649,7 +7649,7 @@ namespace pugi
 			page->prev = doc_page;
 
 			doc_page->next = page;
-			other_page->next = PUGIXML_NULL;
+			other_page->next = nullptr;
 		}
 
 		// make sure pages point to the correct document state
@@ -7686,7 +7686,7 @@ namespace pugi
 
 		// reset other document
 		new (other) impl::xml_document_struct(PUGI_IMPL_GETPAGE(other));
-		rhs._buffer = PUGIXML_NULL;
+		rhs._buffer = nullptr;
 	}
 #endif
 
@@ -8113,7 +8113,7 @@ PUGI_IMPL_NS_BEGIN
 
 		for (size_t probe = 0; probe <= hashmod; ++probe)
 		{
-			if (table[bucket] == PUGIXML_NULL)
+			if (table[bucket] == nullptr)
 			{
 				table[bucket] = key;
 				return true;
@@ -8161,7 +8161,7 @@ PUGI_IMPL_NS_BEGIN
 		size_t _root_size;
 		bool* _error;
 
-		xpath_allocator(xpath_memory_block* root, bool* error = PUGIXML_NULL): _root(root), _root_size(0), _error(error)
+		xpath_allocator(xpath_memory_block* root, bool* error = nullptr): _root(root), _root_size(0), _error(error)
 		{
 		}
 
@@ -8189,7 +8189,7 @@ PUGI_IMPL_NS_BEGIN
 				if (!block)
 				{
 					if (_error) *_error = true;
-					return PUGIXML_NULL;
+					return nullptr;
 				}
 
 				block->next = _root;
@@ -8209,7 +8209,7 @@ PUGI_IMPL_NS_BEGIN
 			new_size = (new_size + xpath_memory_block_alignment - 1) & ~(xpath_memory_block_alignment - 1);
 
 			// we can only reallocate the last object
-			assert(ptr == PUGIXML_NULL || static_cast<char*>(ptr) + old_size == &_root->data[0] + _root_size);
+			assert(ptr == nullptr || static_cast<char*>(ptr) + old_size == &_root->data[0] + _root_size);
 
 			// try to reallocate the object inplace
 			if (ptr && _root_size - old_size + new_size <= _root->capacity)
@@ -8220,7 +8220,7 @@ PUGI_IMPL_NS_BEGIN
 
 			// allocate a new block
 			void* result = allocate(new_size);
-			if (!result) return PUGIXML_NULL;
+			if (!result) return nullptr;
 
 			// we have a new block
 			if (ptr)
@@ -8315,7 +8315,7 @@ PUGI_IMPL_NS_BEGIN
 
 		xpath_stack_data(): result(blocks + 0, &oom), temp(blocks + 1, &oom), oom(false)
 		{
-			blocks[0].next = blocks[1].next = PUGIXML_NULL;
+			blocks[0].next = blocks[1].next = nullptr;
 			blocks[0].capacity = blocks[1].capacity = sizeof(blocks[0].data);
 
 			stack.result = &result;
@@ -8341,7 +8341,7 @@ PUGI_IMPL_NS_BEGIN
 		static char_t* duplicate_string(const char_t* string, size_t length, xpath_allocator* alloc)
 		{
 			char_t* result = static_cast<char_t*>(alloc->allocate((length + 1) * sizeof(char_t)));
-			if (!result) return PUGIXML_NULL;
+			if (!result) return nullptr;
 
 			memcpy(result, string, length * sizeof(char_t));
 			result[length] = 0;
@@ -8401,7 +8401,7 @@ PUGI_IMPL_NS_BEGIN
 				size_t result_length = target_length + source_length;
 
 				// allocate new buffer
-				char_t* result = static_cast<char_t*>(alloc->reallocate(_uses_heap ? const_cast<char_t*>(_buffer) : PUGIXML_NULL, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
+				char_t* result = static_cast<char_t*>(alloc->reallocate(_uses_heap ? const_cast<char_t*>(_buffer) : nullptr, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
 				if (!result) return;
 
 				// append first string to the new buffer in case there was no reallocation
@@ -8436,7 +8436,7 @@ PUGI_IMPL_NS_BEGIN
 				size_t length_ = strlength(_buffer);
 				const char_t* data_ = duplicate_string(_buffer, length_, alloc);
 
-				if (!data_) return PUGIXML_NULL;
+				if (!data_) return nullptr;
 
 				_buffer = data_;
 				_uses_heap = true;
@@ -8645,7 +8645,7 @@ PUGI_IMPL_NS_BEGIN
 				if (node->value && (node->header & impl::xml_memory_page_value_allocated_or_shared_mask) == 0) return node->value;
 			}
 
-			return PUGIXML_NULL;
+			return nullptr;
 		}
 
 		xml_attribute_struct* attr = xnode.attribute().internal_object();
@@ -8658,10 +8658,10 @@ PUGI_IMPL_NS_BEGIN
 				if ((attr->header & impl::xml_memory_page_value_allocated_or_shared_mask) == 0) return attr->value;
 			}
 
-			return PUGIXML_NULL;
+			return nullptr;
 		}
 
-		return PUGIXML_NULL;
+		return nullptr;
 	}
 
 	struct document_order_comparator
@@ -8774,7 +8774,7 @@ PUGI_IMPL_NS_BEGIN
 		if (v == 0) return PUGIXML_TEXT("0");
 		if (v != v) return PUGIXML_TEXT("NaN");
 		if (v * 2 == v) return value > 0 ? PUGIXML_TEXT("Infinity") : PUGIXML_TEXT("-Infinity");
-		return PUGIXML_NULL;
+		return nullptr;
 	#endif
 	}
 
@@ -8939,9 +8939,9 @@ PUGI_IMPL_NS_BEGIN
 
 		// parse string
 	#ifdef PUGIXML_WCHAR_MODE
-		return wcstod(string, NULL);
+		return wcstod(string, nullptr);
 	#else
-		return strtod(string, PUGIXML_NULL);
+		return strtod(string, nullptr);
 	#endif
 	}
 
@@ -9003,7 +9003,7 @@ PUGI_IMPL_NS_BEGIN
 		{
 			const char_t* pos = find_char(name, ':');
 
-			prefix = pos ? name : PUGIXML_NULL;
+			prefix = pos ? name : nullptr;
 			prefix_length = pos ? static_cast<size_t>(pos - name) : 0;
 		}
 
@@ -9121,7 +9121,7 @@ PUGI_IMPL_NS_BEGIN
 			unsigned int tc = static_cast<unsigned int>(*to);
 
 			if (fc >= 128 || tc >= 128)
-				return PUGIXML_NULL;
+				return nullptr;
 
 			// code=128 means "skip character"
 			if (!table[fc])
@@ -9136,7 +9136,7 @@ PUGI_IMPL_NS_BEGIN
 				table[i] = static_cast<unsigned char>(i);
 
 		void* result = alloc->allocate(sizeof(table));
-		if (!result) return PUGIXML_NULL;
+		if (!result) return nullptr;
 
 		memcpy(result, table, sizeof(table));
 
@@ -9200,7 +9200,7 @@ PUGI_IMPL_NS_BEGIN
 
 	struct xpath_variable_string: xpath_variable
 	{
-		xpath_variable_string(): xpath_variable(xpath_type_string), value(PUGIXML_NULL)
+		xpath_variable_string(): xpath_variable(xpath_type_string), value(nullptr)
 		{
 		}
 
@@ -9247,11 +9247,11 @@ PUGI_IMPL_NS_BEGIN
 	template <typename T> PUGI_IMPL_FN T* new_xpath_variable(const char_t* name)
 	{
 		size_t length = strlength(name);
-		if (length == 0) return PUGIXML_NULL; // empty variable names are invalid
+		if (length == 0) return nullptr; // empty variable names are invalid
 
 		// $$ we can't use offsetof(T, name) because T is non-POD, so we just allocate additional length characters
 		void* memory = xml_memory::allocate(sizeof(T) + length * sizeof(char_t));
-		if (!memory) return PUGIXML_NULL;
+		if (!memory) return nullptr;
 
 		T* result = new (memory) T();
 
@@ -9277,7 +9277,7 @@ PUGI_IMPL_NS_BEGIN
 			return new_xpath_variable<xpath_variable_boolean>(name);
 
 		default:
-			return PUGIXML_NULL;
+			return nullptr;
 		}
 	}
 
@@ -9430,7 +9430,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_node* _eos;
 
 	public:
-		xpath_node_set_raw(): _type(xpath_node_set::type_unsorted), _begin(PUGIXML_NULL), _end(PUGIXML_NULL), _eos(PUGIXML_NULL)
+		xpath_node_set_raw(): _type(xpath_node_set::type_unsorted), _begin(nullptr), _end(nullptr), _eos(nullptr)
 		{
 		}
 
@@ -9622,7 +9622,7 @@ PUGI_IMPL_NS_BEGIN
 		const char_t* begin;
 		const char_t* end;
 
-		xpath_lexer_string(): begin(PUGIXML_NULL), end(PUGIXML_NULL)
+		xpath_lexer_string(): begin(nullptr), end(nullptr)
 		{
 		}
 
@@ -10810,40 +10810,40 @@ PUGI_IMPL_NS_BEGIN
 
 	public:
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, const char_t* value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(nullptr), _right(nullptr), _next(nullptr)
 		{
 			assert(type == ast_string_constant);
 			_data.string = value;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, double value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(nullptr), _right(nullptr), _next(nullptr)
 		{
 			assert(type == ast_number_constant);
 			_data.number = value;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_variable* value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(PUGIXML_NULL), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(nullptr), _right(nullptr), _next(nullptr)
 		{
 			assert(type == ast_variable);
 			_data.variable = value;
 		}
 
-		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_ast_node* left = PUGIXML_NULL, xpath_ast_node* right = PUGIXML_NULL):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(left), _right(right), _next(PUGIXML_NULL)
+		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_ast_node* left = nullptr, xpath_ast_node* right = nullptr):
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(left), _right(right), _next(nullptr)
 		{
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_ast_node* left, axis_t axis, nodetest_t test, const char_t* contents):
-			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(static_cast<char>(axis)), _test(static_cast<char>(test)), _left(left), _right(PUGIXML_NULL), _next(PUGIXML_NULL)
+			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(static_cast<char>(axis)), _test(static_cast<char>(test)), _left(left), _right(nullptr), _next(nullptr)
 		{
 			assert(type == ast_step);
 			_data.nodetest = contents;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_ast_node* left, xpath_ast_node* right, predicate_t test):
-			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(0), _test(static_cast<char>(test)), _left(left), _right(right), _next(PUGIXML_NULL)
+			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(0), _test(static_cast<char>(test)), _left(left), _right(right), _next(nullptr)
 		{
 			assert(type == ast_filter || type == ast_predicate);
 		}
@@ -10903,7 +10903,7 @@ PUGI_IMPL_NS_BEGIN
 				xpath_string lr = _left->eval_string(c, stack);
 				xpath_string rr = _right->eval_string(c, stack);
 
-				return find_substring(lr.c_str(), rr.c_str()) != PUGIXML_NULL;
+				return find_substring(lr.c_str(), rr.c_str()) != nullptr;
 			}
 
 			case ast_func_boolean:
@@ -11712,7 +11712,7 @@ PUGI_IMPL_NS_BEGIN
 			_result->error = message;
 			_result->offset = _lexer.current_pos() - _query;
 
-			return PUGIXML_NULL;
+			return nullptr;
 		}
 
 		xpath_ast_node* error_oom()
@@ -11720,7 +11720,7 @@ PUGI_IMPL_NS_BEGIN
 			assert(_alloc->_error);
 			*_alloc->_error = true;
 
-			return PUGIXML_NULL;
+			return nullptr;
 		}
 
 		xpath_ast_node* error_rec()
@@ -11736,37 +11736,37 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, const char_t* value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : nullptr;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, double value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : nullptr;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_variable* value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : nullptr;
 		}
 
-		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_ast_node* left = PUGIXML_NULL, xpath_ast_node* right = PUGIXML_NULL)
+		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_ast_node* left = nullptr, xpath_ast_node* right = nullptr)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, left, right) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, rettype, left, right) : nullptr;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, axis_t axis, nodetest_t test, const char_t* contents)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, left, axis, test, contents) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, left, axis, test, contents) : nullptr;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, xpath_ast_node* right, predicate_t test)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, left, right, test) : PUGIXML_NULL;
+			return memory ? new (memory) xpath_ast_node(type, left, right, test) : nullptr;
 		}
 
 		const char_t* alloc_string(const xpath_lexer_string& value)
@@ -11777,7 +11777,7 @@ PUGI_IMPL_NS_BEGIN
 			size_t length = static_cast<size_t>(value.end - value.begin);
 
 			char_t* c = static_cast<char_t*>(_alloc->allocate((length + 1) * sizeof(char_t)));
-			if (!c) return PUGIXML_NULL;
+			if (!c) return nullptr;
 
 			memcpy(c, value.begin, length * sizeof(char_t));
 			c[length] = 0;
@@ -12020,7 +12020,7 @@ PUGI_IMPL_NS_BEGIN
 				if (!_variables)
 					return error("Unknown variable: variable set is not provided");
 
-				xpath_variable* var = PUGIXML_NULL;
+				xpath_variable* var = nullptr;
 				if (!get_variable_scratch(_scratch, _variables, name.begin, name.end, &var))
 					return error_oom();
 
@@ -12037,7 +12037,7 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = parse_expression();
-				if (!n) return PUGIXML_NULL;
+				if (!n) return nullptr;
 
 				if (_lexer.current() != lex_close_brace)
 					return error("Expected ')' to match an opening '('");
@@ -12050,7 +12050,7 @@ PUGI_IMPL_NS_BEGIN
 			case lex_quoted_string:
 			{
 				const char_t* value = alloc_string(_lexer.contents());
-				if (!value) return PUGIXML_NULL;
+				if (!value) return nullptr;
 
 				_lexer.next();
 
@@ -12071,13 +12071,13 @@ PUGI_IMPL_NS_BEGIN
 
 			case lex_string:
 			{
-				xpath_ast_node* args[2] = {PUGIXML_NULL};
+				xpath_ast_node* args[2] = {nullptr};
 				size_t argc = 0;
 
 				xpath_lexer_string function = _lexer.contents();
 				_lexer.next();
 
-				xpath_ast_node* last_arg = PUGIXML_NULL;
+				xpath_ast_node* last_arg = nullptr;
 
 				if (_lexer.current() != lex_open_brace)
 					return error("Unrecognized function call");
@@ -12098,7 +12098,7 @@ PUGI_IMPL_NS_BEGIN
 						return error_rec();
 
 					xpath_ast_node* n = parse_expression();
-					if (!n) return PUGIXML_NULL;
+					if (!n) return nullptr;
 
 					if (argc < 2) args[argc] = n;
 					else last_arg->set_next(n);
@@ -12125,7 +12125,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse_filter_expression()
 		{
 			xpath_ast_node* n = parse_primary_expression();
-			if (!n) return PUGIXML_NULL;
+			if (!n) return nullptr;
 
 			size_t old_depth = _depth;
 
@@ -12140,10 +12140,10 @@ PUGI_IMPL_NS_BEGIN
 					return error("Predicate has to be applied to node set");
 
 				xpath_ast_node* expr = parse_expression();
-				if (!expr) return PUGIXML_NULL;
+				if (!expr) return nullptr;
 
 				n = alloc_node(ast_filter, n, expr, predicate_default);
-				if (!n) return PUGIXML_NULL;
+				if (!n) return nullptr;
 
 				if (_lexer.current() != lex_close_square_brace)
 					return error("Expected ']' to match an opening '['");
@@ -12183,7 +12183,7 @@ PUGI_IMPL_NS_BEGIN
 				if (_lexer.current() == lex_open_square_brace)
 					return error("Predicates are not allowed after an abbreviated step");
 
-				return alloc_node(ast_step, set, axis_self, nodetest_type_node, PUGIXML_NULL);
+				return alloc_node(ast_step, set, axis_self, nodetest_type_node, nullptr);
 			}
 			else if (_lexer.current() == lex_double_dot)
 			{
@@ -12192,7 +12192,7 @@ PUGI_IMPL_NS_BEGIN
 				if (_lexer.current() == lex_open_square_brace)
 					return error("Predicates are not allowed after an abbreviated step");
 
-				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, PUGIXML_NULL);
+				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, nullptr);
 			}
 
 			nodetest_t nt_type = nodetest_none;
@@ -12299,14 +12299,14 @@ PUGI_IMPL_NS_BEGIN
 			}
 
 			const char_t* nt_name_copy = alloc_string(nt_name);
-			if (!nt_name_copy) return PUGIXML_NULL;
+			if (!nt_name_copy) return nullptr;
 
 			xpath_ast_node* n = alloc_node(ast_step, set, axis, nt_type, nt_name_copy);
-			if (!n) return PUGIXML_NULL;
+			if (!n) return nullptr;
 
 			size_t old_depth = _depth;
 
-			xpath_ast_node* last = PUGIXML_NULL;
+			xpath_ast_node* last = nullptr;
 
 			while (_lexer.current() == lex_open_square_brace)
 			{
@@ -12316,10 +12316,10 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				xpath_ast_node* expr = parse_expression();
-				if (!expr) return PUGIXML_NULL;
+				if (!expr) return nullptr;
 
-				xpath_ast_node* pred = alloc_node(ast_predicate, PUGIXML_NULL, expr, predicate_default);
-				if (!pred) return PUGIXML_NULL;
+				xpath_ast_node* pred = alloc_node(ast_predicate, nullptr, expr, predicate_default);
+				if (!pred) return nullptr;
 
 				if (_lexer.current() != lex_close_square_brace)
 					return error("Expected ']' to match an opening '['");
@@ -12340,7 +12340,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse_relative_location_path(xpath_ast_node* set)
 		{
 			xpath_ast_node* n = parse_step(set);
-			if (!n) return PUGIXML_NULL;
+			if (!n) return nullptr;
 
 			size_t old_depth = _depth;
 
@@ -12351,8 +12351,8 @@ PUGI_IMPL_NS_BEGIN
 
 				if (l == lex_double_slash)
 				{
-					n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
-					if (!n) return PUGIXML_NULL;
+					n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, nullptr);
+					if (!n) return nullptr;
 
 					++_depth;
 				}
@@ -12361,7 +12361,7 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				n = parse_step(n);
-				if (!n) return PUGIXML_NULL;
+				if (!n) return nullptr;
 			}
 
 			_depth = old_depth;
@@ -12378,7 +12378,7 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
-				if (!n) return PUGIXML_NULL;
+				if (!n) return nullptr;
 
 				// relative location path can start from axis_attribute, dot, double_dot, multiply and string lexemes; any other lexeme means standalone root path
 				lexeme_t l = _lexer.current();
@@ -12393,16 +12393,16 @@ PUGI_IMPL_NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
-				if (!n) return PUGIXML_NULL;
+				if (!n) return nullptr;
 
-				n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
-				if (!n) return PUGIXML_NULL;
+				n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, nullptr);
+				if (!n) return nullptr;
 
 				return parse_relative_location_path(n);
 			}
 
 			// else clause moved outside of if because of bogus warning 'control may reach end of non-void function being inlined' in gcc 4.0.1
-			return parse_relative_location_path(PUGIXML_NULL);
+			return parse_relative_location_path(nullptr);
 		}
 
 		// PathExpr ::= LocationPath
@@ -12439,7 +12439,7 @@ PUGI_IMPL_NS_BEGIN
 				}
 
 				xpath_ast_node* n = parse_filter_expression();
-				if (!n) return PUGIXML_NULL;
+				if (!n) return nullptr;
 
 				if (_lexer.current() == lex_slash || _lexer.current() == lex_double_slash)
 				{
@@ -12451,8 +12451,8 @@ PUGI_IMPL_NS_BEGIN
 						if (n->rettype() != xpath_type_node_set)
 							return error("Step has to be applied to node set");
 
-						n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, PUGIXML_NULL);
-						if (!n) return PUGIXML_NULL;
+						n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, nullptr);
+						if (!n) return nullptr;
 					}
 
 					// select from location path
@@ -12467,7 +12467,7 @@ PUGI_IMPL_NS_BEGIN
 
 				// precedence 7+ - only parses union expressions
 				xpath_ast_node* n = parse_expression(7);
-				if (!n) return PUGIXML_NULL;
+				if (!n) return nullptr;
 
 				return alloc_node(ast_op_negate, xpath_type_number, n);
 			}
@@ -12555,14 +12555,14 @@ PUGI_IMPL_NS_BEGIN
 					return error_rec();
 
 				xpath_ast_node* rhs = parse_path_or_unary_expression();
-				if (!rhs) return PUGIXML_NULL;
+				if (!rhs) return nullptr;
 
 				binary_op_t nextop = binary_op_t::parse(_lexer);
 
 				while (nextop.asttype != ast_unknown && nextop.precedence > op.precedence)
 				{
 					rhs = parse_expression_rec(rhs, nextop.precedence);
-					if (!rhs) return PUGIXML_NULL;
+					if (!rhs) return nullptr;
 
 					nextop = binary_op_t::parse(_lexer);
 				}
@@ -12571,7 +12571,7 @@ PUGI_IMPL_NS_BEGIN
 					return error("Union operator has to be applied to node sets");
 
 				lhs = alloc_node(op.asttype, op.rettype, lhs, rhs);
-				if (!lhs) return PUGIXML_NULL;
+				if (!lhs) return nullptr;
 
 				op = binary_op_t::parse(_lexer);
 			}
@@ -12605,7 +12605,7 @@ PUGI_IMPL_NS_BEGIN
 				return error_rec();
 
 			xpath_ast_node* n = parse_path_or_unary_expression();
-			if (!n) return PUGIXML_NULL;
+			if (!n) return nullptr;
 
 			n = parse_expression_rec(n, limit);
 
@@ -12621,7 +12621,7 @@ PUGI_IMPL_NS_BEGIN
 		xpath_ast_node* parse()
 		{
 			xpath_ast_node* n = parse_expression();
-			if (!n) return PUGIXML_NULL;
+			if (!n) return nullptr;
 
 			assert(_depth == 0);
 
@@ -12645,7 +12645,7 @@ PUGI_IMPL_NS_BEGIN
 		static xpath_query_impl* create()
 		{
 			void* memory = xml_memory::allocate(sizeof(xpath_query_impl));
-			if (!memory) return PUGIXML_NULL;
+			if (!memory) return nullptr;
 
 			return new (memory) xpath_query_impl();
 		}
@@ -12659,9 +12659,9 @@ PUGI_IMPL_NS_BEGIN
 			xml_memory::deallocate(impl);
 		}
 
-		xpath_query_impl(): root(PUGIXML_NULL), alloc(&block, &oom), oom(false)
+		xpath_query_impl(): root(nullptr), alloc(&block, &oom), oom(false)
 		{
-			block.next = PUGIXML_NULL;
+			block.next = nullptr;
 			block.capacity = sizeof(block.data);
 		}
 
@@ -12673,7 +12673,7 @@ PUGI_IMPL_NS_BEGIN
 
 	PUGI_IMPL_FN impl::xpath_ast_node* evaluate_node_set_prepare(xpath_query_impl* impl)
 	{
-		if (!impl) return PUGIXML_NULL;
+		if (!impl) return nullptr;
 
 		if (impl->root->rettype() != xpath_type_node_set)
 		{
@@ -12743,7 +12743,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_node::operator xpath_node::unspecified_bool_type() const
 	{
-		return (_node || _attribute) ? unspecified_bool_xpath_node : PUGIXML_NULL;
+		return (_node || _attribute) ? unspecified_bool_xpath_node : nullptr;
 	}
 
 	PUGI_IMPL_FN bool xpath_node::operator!() const
@@ -12913,7 +12913,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_parse_result::operator bool() const
 	{
-		return error == PUGIXML_NULL;
+		return error == nullptr;
 	}
 
 	PUGI_IMPL_FN const char* xpath_parse_result::description() const
@@ -12921,7 +12921,7 @@ namespace pugi
 		return error ? error : "No error";
 	}
 
-	PUGI_IMPL_FN xpath_variable::xpath_variable(xpath_value_type type_): _type(type_), _next(PUGIXML_NULL)
+	PUGI_IMPL_FN xpath_variable::xpath_variable(xpath_value_type type_): _type(type_), _next(nullptr)
 	{
 	}
 
@@ -12943,7 +12943,7 @@ namespace pugi
 
 		default:
 			assert(false && "Invalid variable type"); // unreachable
-			return PUGIXML_NULL;
+			return nullptr;
 		}
 	}
 
@@ -12964,7 +12964,7 @@ namespace pugi
 
 	PUGI_IMPL_FN const char_t* xpath_variable::get_string() const
 	{
-		const char_t* value = (_type == xpath_type_string) ? static_cast<const impl::xpath_variable_string*>(this)->value : PUGIXML_NULL;
+		const char_t* value = (_type == xpath_type_string) ? static_cast<const impl::xpath_variable_string*>(this)->value : nullptr;
 		return value ? value : PUGIXML_TEXT("");
 	}
 
@@ -13021,7 +13021,7 @@ namespace pugi
 	PUGI_IMPL_FN xpath_variable_set::xpath_variable_set()
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
-			_data[i] = PUGIXML_NULL;
+			_data[i] = nullptr;
 	}
 
 	PUGI_IMPL_FN xpath_variable_set::~xpath_variable_set()
@@ -13033,7 +13033,7 @@ namespace pugi
 	PUGI_IMPL_FN xpath_variable_set::xpath_variable_set(const xpath_variable_set& rhs)
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
-			_data[i] = PUGIXML_NULL;
+			_data[i] = nullptr;
 
 		_assign(rhs);
 	}
@@ -13053,7 +13053,7 @@ namespace pugi
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
 		{
 			_data[i] = rhs._data[i];
-			rhs._data[i] = PUGIXML_NULL;
+			rhs._data[i] = nullptr;
 		}
 	}
 
@@ -13064,7 +13064,7 @@ namespace pugi
 			_destroy(_data[i]);
 
 			_data[i] = rhs._data[i];
-			rhs._data[i] = PUGIXML_NULL;
+			rhs._data[i] = nullptr;
 		}
 
 		return *this;
@@ -13103,12 +13103,12 @@ namespace pugi
 			if (impl::strequal(var->name(), name))
 				return var;
 
-		return PUGIXML_NULL;
+		return nullptr;
 	}
 
 	PUGI_IMPL_FN bool xpath_variable_set::_clone(xpath_variable* var, xpath_variable** out_result)
 	{
-		xpath_variable* last = PUGIXML_NULL;
+		xpath_variable* last = nullptr;
 
 		while (var)
 		{
@@ -13153,7 +13153,7 @@ namespace pugi
 		// look for existing variable
 		for (xpath_variable* var = _data[hash]; var; var = var->_next)
 			if (impl::strequal(var->name(), name))
-				return var->type() == type ? var : PUGIXML_NULL;
+				return var->type() == type ? var : nullptr;
 
 		// add new variable
 		xpath_variable* result = impl::new_xpath_variable(type, name);
@@ -13202,7 +13202,7 @@ namespace pugi
 		return _find(name);
 	}
 
-	PUGI_IMPL_FN xpath_query::xpath_query(const char_t* query, xpath_variable_set* variables): _impl(PUGIXML_NULL)
+	PUGI_IMPL_FN xpath_query::xpath_query(const char_t* query, xpath_variable_set* variables): _impl(nullptr)
 	{
 		impl::xpath_query_impl* qimpl = impl::xpath_query_impl::create();
 
@@ -13226,7 +13226,7 @@ namespace pugi
 				qimpl->root->optimize(&qimpl->alloc);
 
 				_impl = impl.release();
-				_result.error = PUGIXML_NULL;
+				_result.error = nullptr;
 			}
 			else
 			{
@@ -13240,7 +13240,7 @@ namespace pugi
 		}
 	}
 
-	PUGI_IMPL_FN xpath_query::xpath_query(): _impl(PUGIXML_NULL)
+	PUGI_IMPL_FN xpath_query::xpath_query(): _impl(nullptr)
 	{
 	}
 
@@ -13255,7 +13255,7 @@ namespace pugi
 	{
 		_impl = rhs._impl;
 		_result = rhs._result;
-		rhs._impl = PUGIXML_NULL;
+		rhs._impl = nullptr;
 		rhs._result = xpath_parse_result();
 	}
 
@@ -13268,7 +13268,7 @@ namespace pugi
 
 		_impl = rhs._impl;
 		_result = rhs._result;
-		rhs._impl = PUGIXML_NULL;
+		rhs._impl = nullptr;
 		rhs._result = xpath_parse_result();
 
 		return *this;
@@ -13432,7 +13432,7 @@ namespace pugi
 
 	PUGI_IMPL_FN xpath_query::operator xpath_query::unspecified_bool_type() const
 	{
-		return _impl ? unspecified_bool_xpath_query : PUGIXML_NULL;
+		return _impl ? unspecified_bool_xpath_query : nullptr;
 	}
 
 	PUGI_IMPL_FN bool xpath_query::operator!() const

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -125,17 +125,6 @@
 #	endif
 #endif
 
-// If C++ is 2011 or higher, use 'nullptr'
-#ifndef PUGIXML_NULL
-#	if __cplusplus >= 201103
-#		define PUGIXML_NULL nullptr
-#	elif defined(_MSC_VER) && _MSC_VER >= 1600
-#		define PUGIXML_NULL nullptr
-#	else
-#		define PUGIXML_NULL 0
-#	endif
-#endif
-
 // Character interface macros
 #ifdef PUGIXML_WCHAR_MODE
 #	define PUGIXML_TEXT(t) L ## t
@@ -744,15 +733,15 @@ namespace pugi
 
 	#ifndef PUGIXML_NO_XPATH
 		// Select single node by evaluating XPath query. Returns first node from the resulting node set.
-		xpath_node select_node(const char_t* query, xpath_variable_set* variables = PUGIXML_NULL) const;
+		xpath_node select_node(const char_t* query, xpath_variable_set* variables = nullptr) const;
 		xpath_node select_node(const xpath_query& query) const;
 
 		// Select node set by evaluating XPath query
-		xpath_node_set select_nodes(const char_t* query, xpath_variable_set* variables = PUGIXML_NULL) const;
+		xpath_node_set select_nodes(const char_t* query, xpath_variable_set* variables = nullptr) const;
 		xpath_node_set select_nodes(const xpath_query& query) const;
 
 		// (deprecated: use select_node instead) Select single node by evaluating XPath query.
-		PUGIXML_DEPRECATED xpath_node select_single_node(const char_t* query, xpath_variable_set* variables = PUGIXML_NULL) const;
+		PUGIXML_DEPRECATED xpath_node select_single_node(const char_t* query, xpath_variable_set* variables = nullptr) const;
 		PUGIXML_DEPRECATED xpath_node select_single_node(const xpath_query& query) const;
 
 	#endif
@@ -1307,7 +1296,7 @@ namespace pugi
 	public:
 		// Construct a compiled object from XPath expression.
 		// If PUGIXML_NO_EXCEPTIONS is not defined, throws xpath_exception on compilation errors.
-		explicit xpath_query(const char_t* query, xpath_variable_set* variables = PUGIXML_NULL);
+		explicit xpath_query(const char_t* query, xpath_variable_set* variables = nullptr);
 
 		// Constructor
 		xpath_query();

--- a/tests/allocator.cpp
+++ b/tests/allocator.cpp
@@ -1,3 +1,4 @@
+#include "pugixml.hpp"
 #include "allocator.hpp"
 
 #include <string.h>
@@ -102,7 +103,7 @@ namespace
 		size_t aligned_size = align_to_page(size);
 
 		void* ptr = allocate_page_aligned(aligned_size + page_size);
-		if (!ptr) return 0;
+		if (!ptr) return PUGIXML_NULL;
 
 		char* end = static_cast<char*>(ptr) + aligned_size;
 
@@ -147,7 +148,7 @@ const size_t memory_alignment = sizeof(double) > sizeof(void*) ? sizeof(double) 
 void* memory_allocate(size_t size)
 {
 	void* result = allocate(size + memory_alignment);
-	if (!result) return 0;
+	if (!result) return PUGIXML_NULL;
 
 	memcpy(result, &size, sizeof(size_t));
 

--- a/tests/allocator.cpp
+++ b/tests/allocator.cpp
@@ -1,4 +1,3 @@
-#include "pugixml.hpp"
 #include "allocator.hpp"
 
 #include <string.h>
@@ -103,7 +102,7 @@ namespace
 		size_t aligned_size = align_to_page(size);
 
 		void* ptr = allocate_page_aligned(aligned_size + page_size);
-		if (!ptr) return PUGIXML_NULL;
+		if (!ptr) return nullptr;
 
 		char* end = static_cast<char*>(ptr) + aligned_size;
 
@@ -148,7 +147,7 @@ const size_t memory_alignment = sizeof(double) > sizeof(void*) ? sizeof(double) 
 void* memory_allocate(size_t size)
 {
 	void* result = allocate(size + memory_alignment);
-	if (!result) return PUGIXML_NULL;
+	if (!result) return nullptr;
 
 	memcpy(result, &size, sizeof(size_t));
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -18,7 +18,7 @@
 #   include <windows.h>
 #endif
 
-test_runner* test_runner::_tests = 0;
+test_runner* test_runner::_tests = PUGIXML_NULL;
 size_t test_runner::_memory_fail_threshold = 0;
 bool test_runner::_memory_fail_triggered = false;
 jmp_buf test_runner::_failure_buffer;
@@ -36,12 +36,12 @@ static void* custom_allocate(size_t size)
 		g_memory_fail_triggered = true;
 		test_runner::_memory_fail_triggered = true;
 
-		return 0;
+		return PUGIXML_NULL;
 	}
 	else
 	{
 		void* ptr = memory_allocate(size);
-		if (!ptr) return 0;
+		if (!ptr) return PUGIXML_NULL;
 
 		g_memory_total_size += memory_size(ptr);
 		g_memory_total_count++;
@@ -183,7 +183,7 @@ int main(int, char** argv)
 	unsigned int total = 0;
 	unsigned int passed = 0;
 
-	test_runner* test = 0; // gcc3 "variable might be used uninitialized in this function" bug workaround
+	test_runner* test = PUGIXML_NULL; // gcc3 "variable might be used uninitialized in this function" bug workaround
 
 	for (test = test_runner::_tests; test; test = test->_next)
 	{

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -18,7 +18,7 @@
 #   include <windows.h>
 #endif
 
-test_runner* test_runner::_tests = PUGIXML_NULL;
+test_runner* test_runner::_tests = nullptr;
 size_t test_runner::_memory_fail_threshold = 0;
 bool test_runner::_memory_fail_triggered = false;
 jmp_buf test_runner::_failure_buffer;
@@ -36,12 +36,12 @@ static void* custom_allocate(size_t size)
 		g_memory_fail_triggered = true;
 		test_runner::_memory_fail_triggered = true;
 
-		return PUGIXML_NULL;
+		return nullptr;
 	}
 	else
 	{
 		void* ptr = memory_allocate(size);
-		if (!ptr) return PUGIXML_NULL;
+		if (!ptr) return nullptr;
 
 		g_memory_total_size += memory_size(ptr);
 		g_memory_total_count++;
@@ -183,7 +183,7 @@ int main(int, char** argv)
 	unsigned int total = 0;
 	unsigned int passed = 0;
 
-	test_runner* test = PUGIXML_NULL; // gcc3 "variable might be used uninitialized in this function" bug workaround
+	test_runner* test = nullptr; // gcc3 "variable might be used uninitialized in this function" bug workaround
 
 	for (test = test_runner::_tests; test; test = test->_next)
 	{

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -164,7 +164,7 @@ xpath_node_set_tester::xpath_node_set_tester(const pugi::xpath_node_set& set, co
 
 	if (result.empty())
 	{
-		document_order = 0;
+		document_order = PUGIXML_NULL;
 		document_size = 0;
 	}
 	else

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -164,7 +164,7 @@ xpath_node_set_tester::xpath_node_set_tester(const pugi::xpath_node_set& set, co
 
 	if (result.empty())
 	{
-		document_order = PUGIXML_NULL;
+		document_order = nullptr;
 		document_size = 0;
 	}
 	else

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -889,7 +889,7 @@ TEST(document_parse_result_description)
 	{
 		result.status = static_cast<xml_parse_status>(i);
 
-		CHECK(result.description() != 0);
+		CHECK(result.description() != PUGIXML_NULL);
 		CHECK(result.description()[0] != 0);
 	}
 }
@@ -1098,11 +1098,11 @@ TEST(document_contents_preserve)
 {
 	file_data_t files[] =
 	{
-		{"tests/data/utftest_utf16_be_clean.xml", encoding_utf16_be, 0, 0},
-		{"tests/data/utftest_utf16_le_clean.xml", encoding_utf16_le, 0, 0},
-		{"tests/data/utftest_utf32_be_clean.xml", encoding_utf32_be, 0, 0},
-		{"tests/data/utftest_utf32_le_clean.xml", encoding_utf32_le, 0, 0},
-		{"tests/data/utftest_utf8_clean.xml", encoding_utf8, 0, 0}
+		{"tests/data/utftest_utf16_be_clean.xml", encoding_utf16_be, PUGIXML_NULL, 0},
+		{"tests/data/utftest_utf16_le_clean.xml", encoding_utf16_le, PUGIXML_NULL, 0},
+		{"tests/data/utftest_utf32_be_clean.xml", encoding_utf32_be, PUGIXML_NULL, 0},
+		{"tests/data/utftest_utf32_le_clean.xml", encoding_utf32_le, PUGIXML_NULL, 0},
+		{"tests/data/utftest_utf8_clean.xml", encoding_utf8, PUGIXML_NULL, 0}
 	};
 
 	// load files in memory
@@ -1136,8 +1136,8 @@ TEST(document_contents_preserve_latin1)
 {
 	file_data_t files[] =
 	{
-		{"tests/data/latintest_utf8.xml", encoding_utf8, 0, 0},
-		{"tests/data/latintest_latin1.xml", encoding_latin1, 0, 0}
+		{"tests/data/latintest_utf8.xml", encoding_utf8, PUGIXML_NULL, 0},
+		{"tests/data/latintest_latin1.xml", encoding_latin1, PUGIXML_NULL, 0}
 	};
 
 	// load files in memory
@@ -1239,15 +1239,15 @@ TEST(document_load_buffer_empty)
 
 		xml_document doc;
 		CHECK(doc.load_buffer(buffer, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
-		CHECK(doc.load_buffer(0, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
+		CHECK(doc.load_buffer(PUGIXML_NULL, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
 
 		CHECK(doc.load_buffer_inplace(buffer, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
-		CHECK(doc.load_buffer_inplace(0, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
+		CHECK(doc.load_buffer_inplace(PUGIXML_NULL, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
 
 		void* own_buffer = get_memory_allocation_function()(1);
 
 		CHECK(doc.load_buffer_inplace_own(own_buffer, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
-		CHECK(doc.load_buffer_inplace_own(0, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
+		CHECK(doc.load_buffer_inplace_own(PUGIXML_NULL, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
 	}
 }
 
@@ -1275,15 +1275,15 @@ TEST(document_load_buffer_empty_fragment)
 
 		xml_document doc;
 		CHECK(doc.load_buffer(buffer, 0, parse_fragment, encoding) && !doc.first_child());
-		CHECK(doc.load_buffer(0, 0, parse_fragment, encoding) && !doc.first_child());
+		CHECK(doc.load_buffer(PUGIXML_NULL, 0, parse_fragment, encoding) && !doc.first_child());
 
 		CHECK(doc.load_buffer_inplace(buffer, 0, parse_fragment, encoding) && !doc.first_child());
-		CHECK(doc.load_buffer_inplace(0, 0, parse_fragment, encoding) && !doc.first_child());
+		CHECK(doc.load_buffer_inplace(PUGIXML_NULL, 0, parse_fragment, encoding) && !doc.first_child());
 
 		void* own_buffer = get_memory_allocation_function()(1);
 
 		CHECK(doc.load_buffer_inplace_own(own_buffer, 0, parse_fragment, encoding) && !doc.first_child());
-		CHECK(doc.load_buffer_inplace_own(0, 0, parse_fragment, encoding) && !doc.first_child());
+		CHECK(doc.load_buffer_inplace_own(PUGIXML_NULL, 0, parse_fragment, encoding) && !doc.first_child());
 	}
 }
 
@@ -1291,11 +1291,11 @@ TEST(document_load_buffer_null)
 {
 	xml_document doc;
 
-	CHECK(doc.load_buffer(0, 12).status == status_io_error && !doc.first_child());
-	CHECK(doc.load_buffer(0, 12, parse_fragment).status == status_io_error && !doc.first_child());
+	CHECK(doc.load_buffer(PUGIXML_NULL, 12).status == status_io_error && !doc.first_child());
+	CHECK(doc.load_buffer(PUGIXML_NULL, 12, parse_fragment).status == status_io_error && !doc.first_child());
 
-	CHECK(doc.load_buffer_inplace(0, 12).status == status_io_error && !doc.first_child());
-	CHECK(doc.load_buffer_inplace_own(0, 12).status == status_io_error && !doc.first_child());
+	CHECK(doc.load_buffer_inplace(PUGIXML_NULL, 12).status == status_io_error && !doc.first_child());
+	CHECK(doc.load_buffer_inplace_own(PUGIXML_NULL, 12).status == status_io_error && !doc.first_child());
 }
 
 TEST(document_progressive_truncation)
@@ -1350,7 +1350,7 @@ TEST(document_load_buffer_short)
 	CHECK(doc.load_buffer(data + 2, 2).status == status_no_document_element);
 	CHECK(doc.load_buffer(data + 3, 1).status == status_no_document_element);
 	CHECK(doc.load_buffer(data + 4, 0).status == status_no_document_element);
-	CHECK(doc.load_buffer(0, 0).status == status_no_document_element);
+	CHECK(doc.load_buffer(PUGIXML_NULL, 0).status == status_no_document_element);
 
 	delete[] data;
 }
@@ -1367,7 +1367,7 @@ TEST(document_load_buffer_short_fragment)
 	CHECK(doc.load_buffer(data + 2, 2, parse_fragment) && test_string_equal(doc.text().get(), STR("cd")));
 	CHECK(doc.load_buffer(data + 3, 1, parse_fragment) && test_string_equal(doc.text().get(), STR("d")));
 	CHECK(doc.load_buffer(data + 4, 0, parse_fragment) && !doc.first_child());
-	CHECK(doc.load_buffer(0, 0, parse_fragment) && !doc.first_child());
+	CHECK(doc.load_buffer(PUGIXML_NULL, 0, parse_fragment) && !doc.first_child());
 
 	delete[] data;
 }
@@ -1384,7 +1384,7 @@ TEST(document_load_buffer_inplace_short)
 	CHECK(doc.load_buffer_inplace(data + 2, 2).status == status_no_document_element);
 	CHECK(doc.load_buffer_inplace(data + 3, 1).status == status_no_document_element);
 	CHECK(doc.load_buffer_inplace(data + 4, 0).status == status_no_document_element);
-	CHECK(doc.load_buffer_inplace(0, 0).status == status_no_document_element);
+	CHECK(doc.load_buffer_inplace(PUGIXML_NULL, 0).status == status_no_document_element);
 
 	delete[] data;
 }
@@ -1597,12 +1597,12 @@ TEST(document_convert_out_of_memory)
 {
 	file_data_t files[] =
 	{
-		{"tests/data/utftest_utf16_be_clean.xml", encoding_utf16_be, 0, 0},
-		{"tests/data/utftest_utf16_le_clean.xml", encoding_utf16_le, 0, 0},
-		{"tests/data/utftest_utf32_be_clean.xml", encoding_utf32_be, 0, 0},
-		{"tests/data/utftest_utf32_le_clean.xml", encoding_utf32_le, 0, 0},
-		{"tests/data/utftest_utf8_clean.xml", encoding_utf8, 0, 0},
-		{"tests/data/latintest_latin1.xml", encoding_latin1, 0, 0}
+		{"tests/data/utftest_utf16_be_clean.xml", encoding_utf16_be, PUGIXML_NULL, 0},
+		{"tests/data/utftest_utf16_le_clean.xml", encoding_utf16_le, PUGIXML_NULL, 0},
+		{"tests/data/utftest_utf32_be_clean.xml", encoding_utf32_be, PUGIXML_NULL, 0},
+		{"tests/data/utftest_utf32_le_clean.xml", encoding_utf32_le, PUGIXML_NULL, 0},
+		{"tests/data/utftest_utf8_clean.xml", encoding_utf8, PUGIXML_NULL, 0},
+		{"tests/data/latintest_latin1.xml", encoding_latin1, PUGIXML_NULL, 0}
 	};
 
 	// load files in memory

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -889,7 +889,7 @@ TEST(document_parse_result_description)
 	{
 		result.status = static_cast<xml_parse_status>(i);
 
-		CHECK(result.description() != PUGIXML_NULL);
+		CHECK(result.description() != nullptr);
 		CHECK(result.description()[0] != 0);
 	}
 }
@@ -1098,11 +1098,11 @@ TEST(document_contents_preserve)
 {
 	file_data_t files[] =
 	{
-		{"tests/data/utftest_utf16_be_clean.xml", encoding_utf16_be, PUGIXML_NULL, 0},
-		{"tests/data/utftest_utf16_le_clean.xml", encoding_utf16_le, PUGIXML_NULL, 0},
-		{"tests/data/utftest_utf32_be_clean.xml", encoding_utf32_be, PUGIXML_NULL, 0},
-		{"tests/data/utftest_utf32_le_clean.xml", encoding_utf32_le, PUGIXML_NULL, 0},
-		{"tests/data/utftest_utf8_clean.xml", encoding_utf8, PUGIXML_NULL, 0}
+		{"tests/data/utftest_utf16_be_clean.xml", encoding_utf16_be, nullptr, 0},
+		{"tests/data/utftest_utf16_le_clean.xml", encoding_utf16_le, nullptr, 0},
+		{"tests/data/utftest_utf32_be_clean.xml", encoding_utf32_be, nullptr, 0},
+		{"tests/data/utftest_utf32_le_clean.xml", encoding_utf32_le, nullptr, 0},
+		{"tests/data/utftest_utf8_clean.xml", encoding_utf8, nullptr, 0}
 	};
 
 	// load files in memory
@@ -1136,8 +1136,8 @@ TEST(document_contents_preserve_latin1)
 {
 	file_data_t files[] =
 	{
-		{"tests/data/latintest_utf8.xml", encoding_utf8, PUGIXML_NULL, 0},
-		{"tests/data/latintest_latin1.xml", encoding_latin1, PUGIXML_NULL, 0}
+		{"tests/data/latintest_utf8.xml", encoding_utf8, nullptr, 0},
+		{"tests/data/latintest_latin1.xml", encoding_latin1, nullptr, 0}
 	};
 
 	// load files in memory
@@ -1239,15 +1239,15 @@ TEST(document_load_buffer_empty)
 
 		xml_document doc;
 		CHECK(doc.load_buffer(buffer, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
-		CHECK(doc.load_buffer(PUGIXML_NULL, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
+		CHECK(doc.load_buffer(nullptr, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
 
 		CHECK(doc.load_buffer_inplace(buffer, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
-		CHECK(doc.load_buffer_inplace(PUGIXML_NULL, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
+		CHECK(doc.load_buffer_inplace(nullptr, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
 
 		void* own_buffer = get_memory_allocation_function()(1);
 
 		CHECK(doc.load_buffer_inplace_own(own_buffer, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
-		CHECK(doc.load_buffer_inplace_own(PUGIXML_NULL, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
+		CHECK(doc.load_buffer_inplace_own(nullptr, 0, parse_default, encoding).status == status_no_document_element && !doc.first_child());
 	}
 }
 
@@ -1275,15 +1275,15 @@ TEST(document_load_buffer_empty_fragment)
 
 		xml_document doc;
 		CHECK(doc.load_buffer(buffer, 0, parse_fragment, encoding) && !doc.first_child());
-		CHECK(doc.load_buffer(PUGIXML_NULL, 0, parse_fragment, encoding) && !doc.first_child());
+		CHECK(doc.load_buffer(nullptr, 0, parse_fragment, encoding) && !doc.first_child());
 
 		CHECK(doc.load_buffer_inplace(buffer, 0, parse_fragment, encoding) && !doc.first_child());
-		CHECK(doc.load_buffer_inplace(PUGIXML_NULL, 0, parse_fragment, encoding) && !doc.first_child());
+		CHECK(doc.load_buffer_inplace(nullptr, 0, parse_fragment, encoding) && !doc.first_child());
 
 		void* own_buffer = get_memory_allocation_function()(1);
 
 		CHECK(doc.load_buffer_inplace_own(own_buffer, 0, parse_fragment, encoding) && !doc.first_child());
-		CHECK(doc.load_buffer_inplace_own(PUGIXML_NULL, 0, parse_fragment, encoding) && !doc.first_child());
+		CHECK(doc.load_buffer_inplace_own(nullptr, 0, parse_fragment, encoding) && !doc.first_child());
 	}
 }
 
@@ -1291,11 +1291,11 @@ TEST(document_load_buffer_null)
 {
 	xml_document doc;
 
-	CHECK(doc.load_buffer(PUGIXML_NULL, 12).status == status_io_error && !doc.first_child());
-	CHECK(doc.load_buffer(PUGIXML_NULL, 12, parse_fragment).status == status_io_error && !doc.first_child());
+	CHECK(doc.load_buffer(nullptr, 12).status == status_io_error && !doc.first_child());
+	CHECK(doc.load_buffer(nullptr, 12, parse_fragment).status == status_io_error && !doc.first_child());
 
-	CHECK(doc.load_buffer_inplace(PUGIXML_NULL, 12).status == status_io_error && !doc.first_child());
-	CHECK(doc.load_buffer_inplace_own(PUGIXML_NULL, 12).status == status_io_error && !doc.first_child());
+	CHECK(doc.load_buffer_inplace(nullptr, 12).status == status_io_error && !doc.first_child());
+	CHECK(doc.load_buffer_inplace_own(nullptr, 12).status == status_io_error && !doc.first_child());
 }
 
 TEST(document_progressive_truncation)
@@ -1350,7 +1350,7 @@ TEST(document_load_buffer_short)
 	CHECK(doc.load_buffer(data + 2, 2).status == status_no_document_element);
 	CHECK(doc.load_buffer(data + 3, 1).status == status_no_document_element);
 	CHECK(doc.load_buffer(data + 4, 0).status == status_no_document_element);
-	CHECK(doc.load_buffer(PUGIXML_NULL, 0).status == status_no_document_element);
+	CHECK(doc.load_buffer(nullptr, 0).status == status_no_document_element);
 
 	delete[] data;
 }
@@ -1367,7 +1367,7 @@ TEST(document_load_buffer_short_fragment)
 	CHECK(doc.load_buffer(data + 2, 2, parse_fragment) && test_string_equal(doc.text().get(), STR("cd")));
 	CHECK(doc.load_buffer(data + 3, 1, parse_fragment) && test_string_equal(doc.text().get(), STR("d")));
 	CHECK(doc.load_buffer(data + 4, 0, parse_fragment) && !doc.first_child());
-	CHECK(doc.load_buffer(PUGIXML_NULL, 0, parse_fragment) && !doc.first_child());
+	CHECK(doc.load_buffer(nullptr, 0, parse_fragment) && !doc.first_child());
 
 	delete[] data;
 }
@@ -1384,7 +1384,7 @@ TEST(document_load_buffer_inplace_short)
 	CHECK(doc.load_buffer_inplace(data + 2, 2).status == status_no_document_element);
 	CHECK(doc.load_buffer_inplace(data + 3, 1).status == status_no_document_element);
 	CHECK(doc.load_buffer_inplace(data + 4, 0).status == status_no_document_element);
-	CHECK(doc.load_buffer_inplace(PUGIXML_NULL, 0).status == status_no_document_element);
+	CHECK(doc.load_buffer_inplace(nullptr, 0).status == status_no_document_element);
 
 	delete[] data;
 }
@@ -1597,12 +1597,12 @@ TEST(document_convert_out_of_memory)
 {
 	file_data_t files[] =
 	{
-		{"tests/data/utftest_utf16_be_clean.xml", encoding_utf16_be, PUGIXML_NULL, 0},
-		{"tests/data/utftest_utf16_le_clean.xml", encoding_utf16_le, PUGIXML_NULL, 0},
-		{"tests/data/utftest_utf32_be_clean.xml", encoding_utf32_be, PUGIXML_NULL, 0},
-		{"tests/data/utftest_utf32_le_clean.xml", encoding_utf32_le, PUGIXML_NULL, 0},
-		{"tests/data/utftest_utf8_clean.xml", encoding_utf8, PUGIXML_NULL, 0},
-		{"tests/data/latintest_latin1.xml", encoding_latin1, PUGIXML_NULL, 0}
+		{"tests/data/utftest_utf16_be_clean.xml", encoding_utf16_be, nullptr, 0},
+		{"tests/data/utftest_utf16_le_clean.xml", encoding_utf16_le, nullptr, 0},
+		{"tests/data/utftest_utf32_be_clean.xml", encoding_utf32_be, nullptr, 0},
+		{"tests/data/utftest_utf32_le_clean.xml", encoding_utf32_le, nullptr, 0},
+		{"tests/data/utftest_utf8_clean.xml", encoding_utf8, nullptr, 0},
+		{"tests/data/latintest_latin1.xml", encoding_latin1, nullptr, 0}
 	};
 
 	// load files in memory

--- a/tests/test_dom_modify.cpp
+++ b/tests/test_dom_modify.cpp
@@ -1515,8 +1515,8 @@ TEST_XML(dom_node_append_buffer_empty, "<node />")
 	CHECK(node.append_buffer("", 0).status == status_no_document_element);
 	CHECK(node.append_buffer("", 0, parse_fragment).status == status_ok);
 
-	CHECK(node.append_buffer(PUGIXML_NULL, 0).status == status_no_document_element);
-	CHECK(node.append_buffer(PUGIXML_NULL, 0, parse_fragment).status == status_ok);
+	CHECK(node.append_buffer(nullptr, 0).status == status_no_document_element);
+	CHECK(node.append_buffer(nullptr, 0, parse_fragment).status == status_ok);
 
 	CHECK_NODE(doc, STR("<node/>"));
 }

--- a/tests/test_dom_modify.cpp
+++ b/tests/test_dom_modify.cpp
@@ -1515,8 +1515,8 @@ TEST_XML(dom_node_append_buffer_empty, "<node />")
 	CHECK(node.append_buffer("", 0).status == status_no_document_element);
 	CHECK(node.append_buffer("", 0, parse_fragment).status == status_ok);
 
-	CHECK(node.append_buffer(0, 0).status == status_no_document_element);
-	CHECK(node.append_buffer(0, 0, parse_fragment).status == status_ok);
+	CHECK(node.append_buffer(PUGIXML_NULL, 0).status == status_no_document_element);
+	CHECK(node.append_buffer(PUGIXML_NULL, 0, parse_fragment).status == status_ok);
 
 	CHECK_NODE(doc, STR("<node/>"));
 }

--- a/tests/test_dom_traverse.cpp
+++ b/tests/test_dom_traverse.cpp
@@ -1065,14 +1065,14 @@ TEST_XML(dom_internal_object, "<node attr='value'>value</node>")
 	xml_attribute attr = node.first_attribute();
 	xml_node value = node.first_child();
 
-	CHECK(xml_node().internal_object() == PUGIXML_NULL);
-	CHECK(xml_attribute().internal_object() == PUGIXML_NULL);
+	CHECK(xml_node().internal_object() == nullptr);
+	CHECK(xml_attribute().internal_object() == nullptr);
 
-    CHECK(node.internal_object() != PUGIXML_NULL);
-    CHECK(value.internal_object() != PUGIXML_NULL);
+    CHECK(node.internal_object() != nullptr);
+    CHECK(value.internal_object() != nullptr);
     CHECK(node.internal_object() != value.internal_object());
 
-    CHECK(attr.internal_object() != PUGIXML_NULL);
+    CHECK(attr.internal_object() != nullptr);
 
     xml_node node_copy = node;
     CHECK(node_copy.internal_object() == node.internal_object());
@@ -1184,24 +1184,24 @@ TEST_XML(dom_unspecified_bool_coverage, "<node attr='value'>text</node>")
 	xml_node node = doc.first_child();
 
 	CHECK(node);
-	static_cast<void (*)(xml_node***)>(node)(PUGIXML_NULL);
+	static_cast<void (*)(xml_node***)>(node)(nullptr);
 
 	CHECK(node.first_attribute());
-	static_cast<void (*)(xml_attribute***)>(node.first_attribute())(PUGIXML_NULL);
+	static_cast<void (*)(xml_attribute***)>(node.first_attribute())(nullptr);
 
 	CHECK(node.text());
-	static_cast<void (*)(xml_text***)>(node.text())(PUGIXML_NULL);
+	static_cast<void (*)(xml_text***)>(node.text())(nullptr);
 
 #ifndef PUGIXML_NO_XPATH
 	xpath_query q(STR("/node"));
 
 	CHECK(q);
-	static_cast<void (*)(xpath_query***)>(q)(PUGIXML_NULL);
+	static_cast<void (*)(xpath_query***)>(q)(nullptr);
 
 	xpath_node qn = q.evaluate_node(doc);
 
 	CHECK(qn);
-	static_cast<void (*)(xpath_node***)>(qn)(PUGIXML_NULL);
+	static_cast<void (*)(xpath_node***)>(qn)(nullptr);
 #endif
 }
 

--- a/tests/test_dom_traverse.cpp
+++ b/tests/test_dom_traverse.cpp
@@ -1065,14 +1065,14 @@ TEST_XML(dom_internal_object, "<node attr='value'>value</node>")
 	xml_attribute attr = node.first_attribute();
 	xml_node value = node.first_child();
 
-	CHECK(xml_node().internal_object() == 0);
-	CHECK(xml_attribute().internal_object() == 0);
+	CHECK(xml_node().internal_object() == PUGIXML_NULL);
+	CHECK(xml_attribute().internal_object() == PUGIXML_NULL);
 
-    CHECK(node.internal_object() != 0);
-    CHECK(value.internal_object() != 0);
+    CHECK(node.internal_object() != PUGIXML_NULL);
+    CHECK(value.internal_object() != PUGIXML_NULL);
     CHECK(node.internal_object() != value.internal_object());
 
-    CHECK(attr.internal_object() != 0);
+    CHECK(attr.internal_object() != PUGIXML_NULL);
 
     xml_node node_copy = node;
     CHECK(node_copy.internal_object() == node.internal_object());
@@ -1184,24 +1184,24 @@ TEST_XML(dom_unspecified_bool_coverage, "<node attr='value'>text</node>")
 	xml_node node = doc.first_child();
 
 	CHECK(node);
-	static_cast<void (*)(xml_node***)>(node)(0);
+	static_cast<void (*)(xml_node***)>(node)(PUGIXML_NULL);
 
 	CHECK(node.first_attribute());
-	static_cast<void (*)(xml_attribute***)>(node.first_attribute())(0);
+	static_cast<void (*)(xml_attribute***)>(node.first_attribute())(PUGIXML_NULL);
 
 	CHECK(node.text());
-	static_cast<void (*)(xml_text***)>(node.text())(0);
+	static_cast<void (*)(xml_text***)>(node.text())(PUGIXML_NULL);
 
 #ifndef PUGIXML_NO_XPATH
 	xpath_query q(STR("/node"));
 
 	CHECK(q);
-	static_cast<void (*)(xpath_query***)>(q)(0);
+	static_cast<void (*)(xpath_query***)>(q)(PUGIXML_NULL);
 
 	xpath_node qn = q.evaluate_node(doc);
 
 	CHECK(qn);
-	static_cast<void (*)(xpath_node***)>(qn)(0);
+	static_cast<void (*)(xpath_node***)>(qn)(PUGIXML_NULL);
 #endif
 }
 

--- a/tests/test_xpath.cpp
+++ b/tests/test_xpath.cpp
@@ -416,7 +416,7 @@ TEST_XML(xpath_out_of_memory_evaluate, "<n/>")
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(doc).empty()));
 #endif
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(0, 0, doc) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc) == 1));
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_node(doc) == xpath_node()));
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_node_set(doc).empty()));
 }
@@ -432,7 +432,7 @@ TEST(xpath_out_of_memory_evaluate_concat)
 
 	xpath_query q(query.c_str());
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(0, 0, xml_node()) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, xml_node()) == 1));
 }
 
 TEST(xpath_out_of_memory_evaluate_concat_list)
@@ -448,7 +448,7 @@ TEST(xpath_out_of_memory_evaluate_concat_list)
 
 	test_runner::_memory_fail_threshold = 1;
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(0, 0, xml_node()) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, xml_node()) == 1));
 }
 
 TEST(xpath_out_of_memory_evaluate_substring)
@@ -462,7 +462,7 @@ TEST(xpath_out_of_memory_evaluate_substring)
 
 	xpath_query q(query.c_str());
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(0, 0, xml_node()) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, xml_node()) == 1));
 }
 
 TEST_XML(xpath_out_of_memory_evaluate_union, "<node />")
@@ -516,7 +516,7 @@ TEST_XML(xpath_out_of_memory_evaluate_normalize_space_0, "<node> a b c d e f g h
 
 	xpath_query q(STR("concat(normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space())"));
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(0, 0, doc.first_child()) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc.first_child()) == 1));
 }
 
 TEST_XML(xpath_out_of_memory_evaluate_normalize_space_1, "<node> a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z </node>")
@@ -525,7 +525,7 @@ TEST_XML(xpath_out_of_memory_evaluate_normalize_space_1, "<node> a b c d e f g h
 
 	xpath_query q(STR("concat(normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node))"));
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(0, 0, doc) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc) == 1));
 }
 
 TEST_XML(xpath_out_of_memory_evaluate_translate, "<node> a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z </node>")
@@ -534,7 +534,7 @@ TEST_XML(xpath_out_of_memory_evaluate_translate, "<node> a b c d e f g h i j k l
 
 	xpath_query q(STR("concat(translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'))"));
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(0, 0, doc) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc) == 1));
 }
 
 TEST_XML(xpath_out_of_memory_evaluate_translate_table, "<node> a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z </node>")
@@ -543,7 +543,7 @@ TEST_XML(xpath_out_of_memory_evaluate_translate_table, "<node> a b c d e f g h i
 
 	xpath_query q(STR("concat(translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'))"));
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(0, 0, doc) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc) == 1));
 }
 
 TEST(xpath_out_of_memory_evaluate_string_append)
@@ -563,7 +563,7 @@ TEST(xpath_out_of_memory_evaluate_string_append)
 	xpath_query q(STR("string(n)"));
 	CHECK(q);
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(0, 0, doc) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc) == 1));
 }
 
 TEST(xpath_out_of_memory_evaluate_number_to_string)
@@ -575,7 +575,7 @@ TEST(xpath_out_of_memory_evaluate_number_to_string)
 
 	xpath_query q(STR("concat($x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x)"), &vars);
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(0, 0, xml_node()) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, xml_node()) == 1));
 }
 
 TEST(xpath_memory_concat_massive)
@@ -587,7 +587,7 @@ TEST(xpath_memory_concat_massive)
 		node.append_child(STR("c")).text().set(i % 10);
 
 	xpath_query q(STR("/"));
-	size_t size = q.evaluate_string(0, 0, node);
+	size_t size = q.evaluate_string(PUGIXML_NULL, 0, node);
 
 	CHECK(size == 5001);
 }

--- a/tests/test_xpath.cpp
+++ b/tests/test_xpath.cpp
@@ -416,7 +416,7 @@ TEST_XML(xpath_out_of_memory_evaluate, "<n/>")
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(doc).empty()));
 #endif
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(nullptr, 0, doc) == 1));
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_node(doc) == xpath_node()));
 	CHECK_ALLOC_FAIL(CHECK(q.evaluate_node_set(doc).empty()));
 }
@@ -432,7 +432,7 @@ TEST(xpath_out_of_memory_evaluate_concat)
 
 	xpath_query q(query.c_str());
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, xml_node()) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(nullptr, 0, xml_node()) == 1));
 }
 
 TEST(xpath_out_of_memory_evaluate_concat_list)
@@ -448,7 +448,7 @@ TEST(xpath_out_of_memory_evaluate_concat_list)
 
 	test_runner::_memory_fail_threshold = 1;
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, xml_node()) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(nullptr, 0, xml_node()) == 1));
 }
 
 TEST(xpath_out_of_memory_evaluate_substring)
@@ -462,7 +462,7 @@ TEST(xpath_out_of_memory_evaluate_substring)
 
 	xpath_query q(query.c_str());
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, xml_node()) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(nullptr, 0, xml_node()) == 1));
 }
 
 TEST_XML(xpath_out_of_memory_evaluate_union, "<node />")
@@ -516,7 +516,7 @@ TEST_XML(xpath_out_of_memory_evaluate_normalize_space_0, "<node> a b c d e f g h
 
 	xpath_query q(STR("concat(normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space(), normalize-space())"));
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc.first_child()) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(nullptr, 0, doc.first_child()) == 1));
 }
 
 TEST_XML(xpath_out_of_memory_evaluate_normalize_space_1, "<node> a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z </node>")
@@ -525,7 +525,7 @@ TEST_XML(xpath_out_of_memory_evaluate_normalize_space_1, "<node> a b c d e f g h
 
 	xpath_query q(STR("concat(normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node), normalize-space(node))"));
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(nullptr, 0, doc) == 1));
 }
 
 TEST_XML(xpath_out_of_memory_evaluate_translate, "<node> a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z </node>")
@@ -534,7 +534,7 @@ TEST_XML(xpath_out_of_memory_evaluate_translate, "<node> a b c d e f g h i j k l
 
 	xpath_query q(STR("concat(translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'), translate(node, 'a', '\xe9'))"));
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(nullptr, 0, doc) == 1));
 }
 
 TEST_XML(xpath_out_of_memory_evaluate_translate_table, "<node> a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z </node>")
@@ -543,7 +543,7 @@ TEST_XML(xpath_out_of_memory_evaluate_translate_table, "<node> a b c d e f g h i
 
 	xpath_query q(STR("concat(translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'), translate(node, 'a', 'A'))"));
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(nullptr, 0, doc) == 1));
 }
 
 TEST(xpath_out_of_memory_evaluate_string_append)
@@ -563,7 +563,7 @@ TEST(xpath_out_of_memory_evaluate_string_append)
 	xpath_query q(STR("string(n)"));
 	CHECK(q);
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, doc) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(nullptr, 0, doc) == 1));
 }
 
 TEST(xpath_out_of_memory_evaluate_number_to_string)
@@ -575,7 +575,7 @@ TEST(xpath_out_of_memory_evaluate_number_to_string)
 
 	xpath_query q(STR("concat($x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x, $x)"), &vars);
 
-	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(PUGIXML_NULL, 0, xml_node()) == 1));
+	CHECK_ALLOC_FAIL(CHECK(q.evaluate_string(nullptr, 0, xml_node()) == 1));
 }
 
 TEST(xpath_memory_concat_massive)
@@ -587,7 +587,7 @@ TEST(xpath_memory_concat_massive)
 		node.append_child(STR("c")).text().set(i % 10);
 
 	xpath_query q(STR("/"));
-	size_t size = q.evaluate_string(PUGIXML_NULL, 0, node);
+	size_t size = q.evaluate_string(nullptr, 0, node);
 
 	CHECK(size == 5001);
 }

--- a/tests/test_xpath_api.cpp
+++ b/tests/test_xpath_api.cpp
@@ -277,7 +277,7 @@ TEST(xpath_api_evaluate_string)
 	// test for empty buffer
 	std::basic_string<char_t> s5 = base;
 	CHECK(q.evaluate_string(&s5[0], 0, xml_node()) == 11 && memcmp(&s5[0], STR("xxxxxxxxxxxxxxxx"), 16 * sizeof(char_t)) == 0);
-	CHECK(q.evaluate_string(0, 0, xml_node()) == 11);
+	CHECK(q.evaluate_string(PUGIXML_NULL, 0, xml_node()) == 11);
 }
 
 TEST(xpath_api_return_type)
@@ -315,7 +315,7 @@ TEST(xpath_api_query_result)
 	xpath_query q(STR("node"));
 
 	CHECK(q.result());
-	CHECK(q.result().error == 0);
+	CHECK(q.result().error == PUGIXML_NULL);
 	CHECK(q.result().offset == 0);
 	CHECK(strcmp(q.result().description(), "No error") == 0);
 }
@@ -337,7 +337,7 @@ TEST(xpath_api_query_result_fail)
 		xpath_parse_result result = q.result();
 
 		CHECK(!result);
-		CHECK(result.error != 0 && result.error[0] != 0);
+		CHECK(result.error != PUGIXML_NULL && result.error[0] != 0);
 		CHECK(result.description() == result.error);
 		CHECK(result.offset == 13);
 

--- a/tests/test_xpath_api.cpp
+++ b/tests/test_xpath_api.cpp
@@ -277,7 +277,7 @@ TEST(xpath_api_evaluate_string)
 	// test for empty buffer
 	std::basic_string<char_t> s5 = base;
 	CHECK(q.evaluate_string(&s5[0], 0, xml_node()) == 11 && memcmp(&s5[0], STR("xxxxxxxxxxxxxxxx"), 16 * sizeof(char_t)) == 0);
-	CHECK(q.evaluate_string(PUGIXML_NULL, 0, xml_node()) == 11);
+	CHECK(q.evaluate_string(nullptr, 0, xml_node()) == 11);
 }
 
 TEST(xpath_api_return_type)
@@ -315,7 +315,7 @@ TEST(xpath_api_query_result)
 	xpath_query q(STR("node"));
 
 	CHECK(q.result());
-	CHECK(q.result().error == PUGIXML_NULL);
+	CHECK(q.result().error == nullptr);
 	CHECK(q.result().offset == 0);
 	CHECK(strcmp(q.result().description(), "No error") == 0);
 }
@@ -337,7 +337,7 @@ TEST(xpath_api_query_result_fail)
 		xpath_parse_result result = q.result();
 
 		CHECK(!result);
-		CHECK(result.error != PUGIXML_NULL && result.error[0] != 0);
+		CHECK(result.error != nullptr && result.error[0] != 0);
 		CHECK(result.description() == result.error);
 		CHECK(result.offset == 13);
 

--- a/tests/test_xpath_parse.cpp
+++ b/tests/test_xpath_parse.cpp
@@ -332,7 +332,7 @@ TEST(xpath_parse_result_default)
 	xpath_parse_result result;
 
 	CHECK(!result);
-	CHECK(result.error != 0);
+	CHECK(result.error != PUGIXML_NULL);
 	CHECK(result.offset == 0);
 }
 

--- a/tests/test_xpath_parse.cpp
+++ b/tests/test_xpath_parse.cpp
@@ -332,7 +332,7 @@ TEST(xpath_parse_result_default)
 	xpath_parse_result result;
 
 	CHECK(!result);
-	CHECK(result.error != PUGIXML_NULL);
+	CHECK(result.error != nullptr);
 	CHECK(result.offset == 0);
 }
 

--- a/tests/test_xpath_variables.cpp
+++ b/tests/test_xpath_variables.cpp
@@ -135,15 +135,15 @@ TEST(xpath_variables_set_operations)
 
 	CHECK(set.add(STR("var1"), xpath_type_number) == v1);
 	CHECK(set.add(STR("var2"), xpath_type_string) == v2);
-	CHECK(set.add(STR("var2"), xpath_type_node_set) == 0);
+	CHECK(set.add(STR("var2"), xpath_type_node_set) == PUGIXML_NULL);
 
 	CHECK(set.get(STR("var1")) == v1);
 	CHECK(set.get(STR("var2")) == v2);
-	CHECK(set.get(STR("var")) == 0);
-	CHECK(set.get(STR("var11")) == 0);
+	CHECK(set.get(STR("var")) == PUGIXML_NULL);
+	CHECK(set.get(STR("var11")) == PUGIXML_NULL);
 
 	CHECK(static_cast<const xpath_variable_set&>(set).get(STR("var1")) == v1);
-	CHECK(static_cast<const xpath_variable_set&>(set).get(STR("var3")) == 0);
+	CHECK(static_cast<const xpath_variable_set&>(set).get(STR("var3")) == PUGIXML_NULL);
 }
 
 TEST_XML(xpath_variables_set_operations_set, "<node/>")
@@ -179,7 +179,7 @@ TEST(xpath_variables_set_out_of_memory)
 
 	xpath_variable_set set;
 
-	xpath_variable* var = 0;
+	xpath_variable* var = PUGIXML_NULL;
 	CHECK_ALLOC_FAIL(var = set.add(STR("target"), xpath_type_number));
 	CHECK(!var);
 }

--- a/tests/test_xpath_variables.cpp
+++ b/tests/test_xpath_variables.cpp
@@ -135,15 +135,15 @@ TEST(xpath_variables_set_operations)
 
 	CHECK(set.add(STR("var1"), xpath_type_number) == v1);
 	CHECK(set.add(STR("var2"), xpath_type_string) == v2);
-	CHECK(set.add(STR("var2"), xpath_type_node_set) == PUGIXML_NULL);
+	CHECK(set.add(STR("var2"), xpath_type_node_set) == nullptr);
 
 	CHECK(set.get(STR("var1")) == v1);
 	CHECK(set.get(STR("var2")) == v2);
-	CHECK(set.get(STR("var")) == PUGIXML_NULL);
-	CHECK(set.get(STR("var11")) == PUGIXML_NULL);
+	CHECK(set.get(STR("var")) == nullptr);
+	CHECK(set.get(STR("var11")) == nullptr);
 
 	CHECK(static_cast<const xpath_variable_set&>(set).get(STR("var1")) == v1);
-	CHECK(static_cast<const xpath_variable_set&>(set).get(STR("var3")) == PUGIXML_NULL);
+	CHECK(static_cast<const xpath_variable_set&>(set).get(STR("var3")) == nullptr);
 }
 
 TEST_XML(xpath_variables_set_operations_set, "<node/>")
@@ -179,7 +179,7 @@ TEST(xpath_variables_set_out_of_memory)
 
 	xpath_variable_set set;
 
-	xpath_variable* var = PUGIXML_NULL;
+	xpath_variable* var = nullptr;
 	CHECK_ALLOC_FAIL(var = set.add(STR("target"), xpath_type_number));
 	CHECK(!var);
 }


### PR DESCRIPTION
https://github.com/zeux/pugixml/blob/9d7fcbf7410e20720b093f9bb3d81dfe6500d30d/CMakeLists.txt#L71-L79

C++11 or later is necessary, so `nullptr` must be available.
