### PR TITLE
Add scientific notation support to XPath number parser

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -8921,11 +8921,41 @@ PUGI_IMPL_NS_BEGIN
 		// parse integer part
 		while (PUGI_IMPL_IS_CHARTYPEX(*string, ctx_digit)) ++string;
 
+		// scientific notation no decimal part
+		if (*string == 'e' || *string == 'E')
+		{
+			++string;
+
+			// parse exponent sign
+			if (*string == '+' || *string == '-') ++string;
+
+			// there should be at least one digit in exponent
+			if (!PUGI_IMPL_IS_CHARTYPEX(*string, ctx_digit)) return false;
+
+			// parse exponent digits
+			while (PUGI_IMPL_IS_CHARTYPEX(*string, ctx_digit)) ++string;
+		}
+
 		// parse decimal part
 		if (*string == '.')
 		{
 			++string;
 
+			while (PUGI_IMPL_IS_CHARTYPEX(*string, ctx_digit)) ++string;
+		}
+
+		// scientific notation with decimal part
+		if (*string == 'e' || *string == 'E')
+		{
+			++string;
+
+			// parse exponent sign
+			if (*string == '+' || *string == '-') ++string;
+
+			// there should be at least one digit in exponent
+			if (!PUGI_IMPL_IS_CHARTYPEX(*string, ctx_digit)) return false;
+
+			// parse exponent digits
 			while (PUGI_IMPL_IS_CHARTYPEX(*string, ctx_digit)) ++string;
 		}
 
@@ -9821,6 +9851,14 @@ PUGI_IMPL_NS_BEGIN
 
 					while (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_digit)) cur++;
 
+					// Scientific notation support
+					if (*cur == 'e' || *cur == 'E')
+					{
+						cur++;
+						if (*cur == '+' || *cur == '-') cur++;
+						while (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_digit)) cur++;
+					}
+
 					_cur_lexeme_contents.end = cur;
 
 					_cur_lexeme = lex_number;
@@ -9883,6 +9921,14 @@ PUGI_IMPL_NS_BEGIN
 					{
 						cur++;
 
+						while (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_digit)) cur++;
+					}
+
+					// Scientific notation support
+					if (*cur == 'e' || *cur == 'E')
+					{
+						cur++;
+						if (*cur == '+' || *cur == '-') cur++;
 						while (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_digit)) cur++;
 					}
 

--- a/tests/test_xpath_parse.cpp
+++ b/tests/test_xpath_parse.cpp
@@ -32,6 +32,13 @@ TEST(xpath_number_parse)
 	CHECK_XPATH_NUMBER(c, STR(".123"), 0.123);
 	CHECK_XPATH_NUMBER(c, STR("123.4567890123456789012345"), 123.4567890123456789012345);
 	CHECK_XPATH_NUMBER(c, STR("123."), 123);
+	CHECK_XPATH_NUMBER(c, STR("number(-2.5E-2)"), -2.5E-2);
+	CHECK_XPATH_NUMBER(c, STR("-2.5E-2"), -2.5E-2);
+	CHECK_XPATH_NUMBER(c, STR("3.0e+5"), 3.0e+5);
+	CHECK_XPATH_NUMBER(c, STR("3.0e-5"), 3.0e-5);
+	CHECK_XPATH_NUMBER(c, STR("7.2e0"), 7.2e0);
+	CHECK_XPATH_NUMBER(c, STR("1e3"), 1e3);
+	CHECK_XPATH_NUMBER(c, STR("1.e3"), 1e3);
 }
 
 TEST(xpath_number_error)
@@ -376,7 +383,7 @@ TEST(xpath_parse_oom_propagation)
 	{
 		std::basic_string<char_t> literal(i, 'a');
 		std::basic_string<char_t> query = STR("processing-instruction('") + literal + STR("') | ") + query_base;
-		
+
 		CHECK_ALLOC_FAIL(CHECK_XPATH_FAIL(query.c_str()));
 	}
 }


### PR DESCRIPTION
- Extended xpath_lexer to recognize exponential notation (e/E with optional +/- sign)
- Updated check_string_to_number_format() to validate scientific notation syntax
- Handles formats like: 1.5e10, 3.14E-5, 2e+8, .5e3
- Added comprehensive test cases for scientific notation parsing

Changes made in both lexer tokenization (for numbers starting with digits and with decimal point) and number validation to ensure proper parsing of scientific notation in XPath expressions.