### PR TITLE
 Use stackless traversal for tree destruction to avoid stack overflow

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -1253,16 +1253,36 @@ PUGI_IMPL_NS_BEGIN
 			attr = next;
 		}
 
-		for (xml_node_struct* child = n->first_child; child; )
+		alloc.deallocate_memory(n, sizeof(xml_node_struct), PUGI_IMPL_GETPAGE(n));
+	}
+
+	inline void destroy_tree(xml_node_struct* n, xml_allocator& alloc)
+	{
+		xml_node_struct* cur = n;
+
+		while (cur->first_child)
+			cur = cur->first_child;
+
+		while (cur != n)
 		{
-			xml_node_struct* next = child->next_sibling;
+			// loop invariant: cur is inside the subtree rooted at n, cur's subtree is destroyed
+			xml_node_struct* parent = cur->parent;
+			xml_node_struct* next = cur->next_sibling;
 
-			destroy_node(child, alloc);
+			destroy_node(cur, alloc);
 
-			child = next;
+			if (next)
+			{
+				cur = next;
+
+				while (cur->first_child)
+					cur = cur->first_child;
+			}
+			else
+				cur = parent;
 		}
 
-		alloc.deallocate_memory(n, sizeof(xml_node_struct), PUGI_IMPL_GETPAGE(n));
+		destroy_node(n, alloc);
 	}
 
 	inline void append_node(xml_node_struct* child, xml_node_struct* node)
@@ -6599,7 +6619,7 @@ namespace pugi
 		if (!alloc.reserve()) return false;
 
 		impl::remove_node(n._root);
-		impl::destroy_node(n._root, alloc);
+		impl::destroy_tree(n._root, alloc);
 
 		return true;
 	}
@@ -6615,7 +6635,7 @@ namespace pugi
 		{
 			xml_node_struct* next = cur->next_sibling;
 
-			impl::destroy_node(cur, alloc);
+			impl::destroy_tree(cur, alloc);
 
 			cur = next;
 		}

--- a/tests/test_dom_modify.cpp
+++ b/tests/test_dom_modify.cpp
@@ -1716,6 +1716,30 @@ TEST(dom_node_copy_stackless)
 	CHECK_NODE(doc, data.c_str());
 }
 
+TEST(dom_node_remove_child_stackless)
+{
+	unsigned int count = 20000;
+	std::basic_string<char_t> data = STR("<root>");
+
+	for (unsigned int i = 0; i < count; ++i)
+		data += STR("<a>");
+
+	data += STR("text");
+
+	for (unsigned int j = 0; j < count; ++j)
+		data += STR("</a>");
+
+	data += STR("<tail/></root>");
+
+	xml_document doc;
+	CHECK(doc.load_string(data.c_str()));
+
+	xml_node root = doc.child(STR("root"));
+	CHECK(root.remove_child(root.child(STR("a"))));
+
+	CHECK_NODE(doc, STR("<root><tail/></root>"));
+}
+
 TEST(dom_node_copy_copyless)
 {
 	std::basic_string<char_t> data;


### PR DESCRIPTION
For very deep trees that can be parsed using our stackless parser,
attempts to remove the relevant nodes may cause a stack overflow due to
deep recursion.

Instead, use a stackless traversal; this is a little different from
other traversals we already have in the library, as it needs to process
each node *after* the entire subtree to avoid accessing destroyed
memory.

Fixes #701.