### PR TITLE
Silence Wsign-conversion under clang as it's enabled in Wconversion

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -54,6 +54,7 @@
 #if defined(__clang__)
 #	pragma clang diagnostic push
 #	pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant" // NULL as null pointer constant
+#	pragma clang diagnostic ignored "-Wsign-conversion" // implicit conversion changes signedness
 #endif
 
 #if defined(_MSC_VER) && defined(__c2__)


### PR DESCRIPTION
This is not a problem for GCC which doesn't enable sign-conversion warnings as part of Wconversion, but it's a problem for clang. These warnings are noisy and do not mask any real bugs, so it's cleaner to silence the warning.

Fixes #688.