### PR TITLE
Treat nodes with a single PCDATA child as empty during output

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4198,6 +4198,13 @@ PUGI_IMPL_NS_BEGIN
 		}
 	}
 
+	PUGI_IMPL_FN bool node_output_empty(xml_node_struct* node)
+	{
+		xml_node_struct* child = node->first_child;
+
+		return !child || (!child->next_sibling && PUGI_IMPL_NODETYPE(child) == node_pcdata && (!child->value || !child->value[0]));
+	}
+
 	PUGI_IMPL_FN bool node_output_start(xml_buffered_writer& writer, xml_node_struct* node, const char_t* indent, size_t indent_length, unsigned int flags, unsigned int depth)
 	{
 		const char_t* default_name = PUGIXML_TEXT(":anonymous");
@@ -4212,7 +4219,7 @@ PUGI_IMPL_NS_BEGIN
 		// element nodes can have value if parse_embed_pcdata was used
 		if (!node->value)
 		{
-			if (!node->first_child)
+			if (!node->first_child || node_output_empty(node))
 			{
 				if (flags & format_no_empty_element_tags)
 				{

--- a/tests/test_dom_modify.cpp
+++ b/tests/test_dom_modify.cpp
@@ -1928,7 +1928,7 @@ TEST_XML(dom_node_set_deallocate, "<node attr='value'>text</node>")
 	node.set_name(STR(""));
 	node.text().set(STR(""));
 
-	CHECK_NODE(doc, STR("<:anonymous :anonymous=\"\"></:anonymous>"));
+	CHECK_NODE(doc, STR("<:anonymous :anonymous=\"\"/>"));
 }
 
 TEST(dom_node_copy_declaration_empty_name)

--- a/tests/test_dom_text.cpp
+++ b/tests/test_dom_text.cpp
@@ -236,7 +236,7 @@ TEST_XML(dom_text_set, "<node/>")
 
     t.set(STR(""));
     CHECK(node.first_child().type() == node_pcdata);
-    CHECK_NODE(node, STR("<node></node>"));
+    CHECK_NODE(node, STR("<node/>"));
 
     t.set(STR("boo"));
     CHECK(node.first_child().type() == node_pcdata);
@@ -250,7 +250,7 @@ TEST_XML(dom_text_set, "<node/>")
 
     t.set(STR(""));
     CHECK(node.first_child().type() == node_pcdata);
-    CHECK_NODE(node, STR("<node></node>"));
+    CHECK_NODE(node, STR("<node/>"));
 }
 
 TEST_XML(dom_text_set_with_size, "<node/>")
@@ -260,7 +260,7 @@ TEST_XML(dom_text_set_with_size, "<node/>")
 
     t.set(STR(""), 0);
     CHECK(node.first_child().type() == node_pcdata);
-    CHECK_NODE(node, STR("<node></node>"));
+    CHECK_NODE(node, STR("<node/>"));
 
     t.set(STR("boo"), 3);
     CHECK(node.first_child().type() == node_pcdata);
@@ -274,7 +274,7 @@ TEST_XML(dom_text_set_with_size, "<node/>")
 
     t.set(STR(""), 0);
     CHECK(node.first_child().type() == node_pcdata);
-    CHECK_NODE(node, STR("<node></node>"));
+    CHECK_NODE(node, STR("<node/>"));
 }
 
 TEST_XML(dom_text_set_partially_with_size, "<node/>")
@@ -284,7 +284,7 @@ TEST_XML(dom_text_set_partially_with_size, "<node/>")
 
     t.set(STR("foo"), 0);
     CHECK(node.first_child().type() == node_pcdata);
-    CHECK_NODE(node, STR("<node></node>"));
+    CHECK_NODE(node, STR("<node/>"));
 
     t.set(STR("boofoo"), 3);
     CHECK(node.first_child().type() == node_pcdata);
@@ -298,7 +298,7 @@ TEST_XML(dom_text_set_partially_with_size, "<node/>")
 
     t.set(STR("foo"), 0);
     CHECK(node.first_child().type() == node_pcdata);
-    CHECK_NODE(node, STR("<node></node>"));
+    CHECK_NODE(node, STR("<node/>"));
 }
 
 #ifdef PUGIXML_HAS_STRING_VIEW
@@ -309,7 +309,7 @@ TEST_XML(dom_text_set_with_string_view, "<node/>")
 
 	t.set(string_view_t(STR("")));
 	CHECK(node.first_child().type() == node_pcdata);
-	CHECK_NODE(node, STR("<node></node>"));
+	CHECK_NODE(node, STR("<node/>"));
 
 	t.set(string_view_t(STR("boo")));
 	CHECK(node.first_child().type() == node_pcdata);
@@ -323,7 +323,7 @@ TEST_XML(dom_text_set_with_string_view, "<node/>")
 
 	t.set(string_view_t(STR("")));
 	CHECK(node.first_child().type() == node_pcdata);
-	CHECK_NODE(node, STR("<node></node>"));
+	CHECK_NODE(node, STR("<node/>"));
 
 	t.set(string_view_t(STR("something")));
 	CHECK(node.first_child().type() == node_pcdata);
@@ -332,7 +332,7 @@ TEST_XML(dom_text_set_with_string_view, "<node/>")
 	// empty string view (null data pointer)
 	t.set(string_view_t());
 	CHECK(node.first_child().type() == node_pcdata);
-	CHECK_NODE(node, STR("<node></node>"));
+	CHECK_NODE(node, STR("<node/>"));
 
 	t.set(string_view_t(STR("afternulldata")));
 	CHECK(node.first_child().type() == node_pcdata);
@@ -346,7 +346,7 @@ TEST_XML(dom_text_set_partially_with_string_view, "<node/>")
 
 	t.set(string_view_t(STR("foo"), 0));
 	CHECK(node.first_child().type() == node_pcdata);
-	CHECK_NODE(node, STR("<node></node>"));
+	CHECK_NODE(node, STR("<node/>"));
 
 	t.set(string_view_t(STR("boofoo"), 3));
 	CHECK(node.first_child().type() == node_pcdata);
@@ -360,7 +360,7 @@ TEST_XML(dom_text_set_partially_with_string_view, "<node/>")
 
 	t.set(string_view_t(STR("foo"), 0));
 	CHECK(node.first_child().type() == node_pcdata);
-	CHECK_NODE(node, STR("<node></node>"));
+	CHECK_NODE(node, STR("<node/>"));
 }
 #endif
 

--- a/tests/test_write.cpp
+++ b/tests/test_write.cpp
@@ -572,12 +572,36 @@ TEST(write_pcdata_null)
 	xml_document doc;
 	doc.append_child(STR("node")).append_child(node_pcdata);
 
-	CHECK_NODE(doc, STR("<node></node>"));
-	CHECK_NODE_EX(doc, STR("<node></node>\n"), STR("\t"), format_indent);
+	CHECK_NODE(doc, STR("<node/>"));
+	CHECK_NODE_EX(doc, STR("<node />\n"), STR("\t"), format_indent);
+	CHECK_NODE_EX(doc, STR("<node></node>"), STR("\t"), format_raw | format_no_empty_element_tags);
+	CHECK_NODE_EX(doc, STR("<node></node>\n"), STR("\t"), format_indent | format_no_empty_element_tags);
 
 	doc.first_child().append_child(node_pcdata);
 
+	CHECK_NODE(doc, STR("<node></node>"));
 	CHECK_NODE_EX(doc, STR("<node></node>\n"), STR("\t"), format_indent);
+	CHECK_NODE_EX(doc, STR("<node></node>\n"), STR("\t"), format_indent | format_no_empty_element_tags);
+}
+
+TEST(write_pcdata_basic)
+{
+	xml_document doc;
+	doc.append_child(STR("node")).append_child(node_pcdata).set_value(STR("text"));
+
+	CHECK_NODE(doc, STR("<node>text</node>"));
+	CHECK_NODE_EX(doc, STR("<node>text</node>\n"), STR("\t"), format_indent);
+	CHECK_NODE_EX(doc, STR("<node>text</node>"), STR("\t"), format_raw | format_no_empty_element_tags);
+}
+
+TEST(write_pcdata_empty_text)
+{
+	xml_document doc;
+	doc.append_child(STR("node")).text().set(STR(""));
+
+	CHECK_NODE(doc, STR("<node/>"));
+	CHECK_NODE_EX(doc, STR("<node />\n"), STR("\t"), format_indent);
+	CHECK_NODE_EX(doc, STR("<node></node>"), STR("\t"), format_raw | format_no_empty_element_tags);
 }
 
 TEST(write_pcdata_whitespace_fixedpoint)


### PR DESCRIPTION
When a node only has a single child with PCDATA set to empty, we no longer output a separate start and end element tag, unless flag format_no_empty_element_tags is used.

This makes the output shorter in some cases and is better for roundtripping: as we never create empty PCDATA nodes during parsing, saving this document and loading it again would result in no children. With this, save(doc) matches save(load(save(doc))).

Fixes #570.