### PR TITLE
Use charconv for numeric parsing printing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ cmake_dependent_option(PUGIXML_INSTALL_SOURCE
 # Expose options from the pugiconfig.hpp
 option(PUGIXML_WCHAR_MODE "Enable wchar_t mode" OFF)
 option(PUGIXML_COMPACT "Enable compact mode" OFF)
+option(PUGIXML_CHARCONV_FLOAT "Enable charconv number conversion" OFF)
 
 # Advanced options from pugiconfig.hpp
 option(PUGIXML_NO_XPATH "Disable XPath" OFF)
@@ -69,6 +70,7 @@ endif()
 set(PUGIXML_PUBLIC_DEFINITIONS
   $<$<BOOL:${PUGIXML_WCHAR_MODE}>:PUGIXML_WCHAR_MODE>
   $<$<BOOL:${PUGIXML_COMPACT}>:PUGIXML_COMPACT>
+  $<$<BOOL:${PUGIXML_CHARCONV_FLOAT}>:PUGIXML_CHARCONV_FLOAT>
   $<$<BOOL:${PUGIXML_NO_XPATH}>:PUGIXML_NO_XPATH>
   $<$<BOOL:${PUGIXML_NO_STL}>:PUGIXML_NO_STL>
   $<$<BOOL:${PUGIXML_NO_EXCEPTIONS}>:PUGIXML_NO_EXCEPTIONS>
@@ -144,6 +146,10 @@ if (BUILD_SHARED_LIBS)
       ${msvc-rt-mtd-static}
       ${msvc-rt-mt-shared}
       ${msvc-rt-mt-static})
+  target_compile_features(pugixml-shared
+    PRIVATE
+      $<$<BOOL:${PUGIXML_CHARCONV_FLOAT}>:cxx_std_17>
+  )
 endif()
 
 if (NOT BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
@@ -167,6 +173,10 @@ if (NOT BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
       ${msvc-rt-mtd-static}
       ${msvc-rt-mt-shared}
       ${msvc-rt-mt-static})
+  target_compile_features(pugixml-static
+    PRIVATE
+      $<$<BOOL:${PUGIXML_CHARCONV_FLOAT}>:cxx_std_17>
+  )
 endif()
 
 if (BUILD_SHARED_LIBS)

--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -228,6 +228,8 @@ pugixml uses several defines to control the compilation process. There are two w
 
 [[PUGIXML_WCHAR_MODE]]`PUGIXML_WCHAR_MODE` define toggles between UTF-8 style interface (the in-memory text encoding is assumed to be UTF-8, most functions use `char` as character type) and UTF-16/32 style interface (the in-memory text encoding is assumed to be UTF-16/32, depending on `wchar_t` size, most functions use `wchar_t` as character type). See <<dom.unicode>> for more details.
 
+[[PUGIXML_CHARCONV_FLOAT]]`PUGIXML_CHARCONV_FLOAT` will use https://en.cppreference.com/cpp/header/charconv[<charconv>] for floating-point number formatting instead of `<stdio.h>` functions, which requires C++17 and UTF-8 interface. Note that the conversion will then ignore the locale and always act as if the default `C` locale is used.
+
 [[PUGIXML_COMPACT]]`PUGIXML_COMPACT` define activates a different internal representation of document storage that is much more memory efficient for documents with a lot of markup (i.e. nodes and attributes), but is slightly slower to parse and access. For details see <<dom.memory.compact>>.
 
 [[PUGIXML_NO_XPATH]]`PUGIXML_NO_XPATH` define disables XPath. Both XPath interfaces and XPath implementation are excluded from compilation. This option is provided in case you do not need XPath functionality and need to save code space.

--- a/src/pugiconfig.hpp
+++ b/src/pugiconfig.hpp
@@ -15,6 +15,9 @@
 // Uncomment this to enable wchar_t mode
 // #define PUGIXML_WCHAR_MODE
 
+// Uncomment this to enable from_chars/to_chars for number conversion
+// #define PUGIXML_CHARCONV_FLOAT
+
 // Uncomment this to enable compact mode
 // #define PUGIXML_COMPACT
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4807,7 +4807,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		char buf[128];
 	#ifdef PUGIXML_CHARCONV_FLOAT
-		std::to_chars_result result = std::to_chars(std::begin(buf), std::end(buf), value, std::chars_format::general, precision);
+		std::to_chars_result result = std::to_chars(std::begin(buf), std::end(buf) - 1, value, std::chars_format::general, precision);
 		*result.ptr = '\0';
 	#else
 		PUGI_IMPL_SNPRINTF(buf, "%.*g", precision, double(value));
@@ -4820,7 +4820,7 @@ PUGI_IMPL_NS_BEGIN
 	{
 		char buf[128];
 	#ifdef PUGIXML_CHARCONV_FLOAT
-		std::to_chars_result result = std::to_chars(std::begin(buf), std::end(buf), value, std::chars_format::general, precision);
+		std::to_chars_result result = std::to_chars(std::begin(buf), std::end(buf) - 1, value, std::chars_format::general, precision);
 		*result.ptr = '\0';
 	#else
 		PUGI_IMPL_SNPRINTF(buf, "%.*g", precision, value);

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -35,6 +35,10 @@
 #	include <string>
 #endif
 
+#ifdef PUGIXML_CHARCONV_FLOAT
+#	include <charconv>
+#endif
+
 // For placement new
 #include <new>
 
@@ -4700,6 +4704,14 @@ PUGI_IMPL_NS_BEGIN
 	{
 	#ifdef PUGIXML_WCHAR_MODE
 		return wcstod(value, NULL);
+	#elif defined(PUGIXML_CHARCONV_FLOAT)
+		while (PUGI_IMPL_IS_CHARTYPE(*value, ct_space))
+			value++;
+		if (*value == '+')
+			value++;
+		double result = 0.0;
+		std::from_chars(value, value + strlen(value), result);
+		return result;
 	#else
 		return strtod(value, NULL);
 	#endif
@@ -4709,6 +4721,14 @@ PUGI_IMPL_NS_BEGIN
 	{
 	#ifdef PUGIXML_WCHAR_MODE
 		return static_cast<float>(wcstod(value, NULL));
+	#elif defined(PUGIXML_CHARCONV_FLOAT)
+		while (PUGI_IMPL_IS_CHARTYPE(*value, ct_space))
+			value++;
+		if (*value == '+')
+			value++;
+		float result = 0.0f;
+		std::from_chars(value, value + strlen(value), result);
+		return result;
 	#else
 		return static_cast<float>(strtod(value, NULL));
 	#endif
@@ -4786,8 +4806,12 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, float value, int precision)
 	{
 		char buf[128];
+	#ifdef PUGIXML_CHARCONV_FLOAT
+		std::to_chars_result result = std::to_chars(std::begin(buf), std::end(buf), value, std::chars_format::general, precision);
+		*result.ptr = '\0';
+	#else
 		PUGI_IMPL_SNPRINTF(buf, "%.*g", precision, double(value));
-
+	#endif
 		return set_value_ascii(dest, header, header_mask, buf);
 	}
 
@@ -4795,7 +4819,12 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, double value, int precision)
 	{
 		char buf[128];
+	#ifdef PUGIXML_CHARCONV_FLOAT
+		std::to_chars_result result = std::to_chars(std::begin(buf), std::end(buf), value, std::chars_format::general, precision);
+		*result.ptr = '\0';
+	#else
 		PUGI_IMPL_SNPRINTF(buf, "%.*g", precision, value);
+	#endif
 
 		return set_value_ascii(dest, header, header_mask, buf);
 	}
@@ -8862,14 +8891,22 @@ PUGI_IMPL_NS_BEGIN
 #else
 	PUGI_IMPL_FN void convert_number_to_mantissa_exponent(double value, char (&buffer)[32], char** out_mantissa, int* out_exponent)
 	{
+	#ifdef PUGIXML_CHARCONV_FLOAT
+		std::to_chars_result res = std::to_chars(std::begin(buffer), std::end(buffer) - 1, value, std::chars_format::scientific, DBL_DIG);
+		*res.ptr = '\0';
+	#else
 		// get a scientific notation value with IEEE DBL_DIG decimals
 		PUGI_IMPL_SNPRINTF(buffer, "%.*e", DBL_DIG, value);
-
+	#endif
 		// get the exponent (possibly negative)
 		char* exponent_string = strchr(buffer, 'e');
 		assert(exponent_string);
 
-		int exponent = atoi(exponent_string + 1);
+		char *s = exponent_string + 1;
+		bool isneg = *s++ == '-';
+		int exponent = 0;
+		while (*s) exponent = exponent * 10 + (*s++ - '0');
+		exponent = isneg ? -exponent : exponent;
 
 		// extract mantissa string: skip sign
 		char* mantissa = buffer[0] == '-' ? buffer + 1 : buffer;
@@ -8958,9 +8995,6 @@ PUGI_IMPL_NS_BEGIN
 
 	PUGI_IMPL_FN bool check_string_to_number_format(const char_t* string)
 	{
-		// parse leading whitespace
-		while (PUGI_IMPL_IS_CHARTYPE(*string, ct_space)) ++string;
-
 		// parse sign
 		if (*string == '-') ++string;
 
@@ -8988,12 +9022,19 @@ PUGI_IMPL_NS_BEGIN
 
 	PUGI_IMPL_FN double convert_string_to_number(const char_t* string)
 	{
+		// parse leading whitespace
+		while (PUGI_IMPL_IS_CHARTYPE(*string, ct_space)) ++string;
+
 		// check string format
 		if (!check_string_to_number_format(string)) return gen_nan();
 
 		// parse string
 	#ifdef PUGIXML_WCHAR_MODE
 		return wcstod(string, NULL);
+	#elif defined(PUGIXML_CHARCONV_FLOAT)
+		double result = 0.0;
+		std::from_chars(string, string + strlen(string), result);
+		return result;
 	#else
 		return strtod(string, NULL);
 	#endif


### PR DESCRIPTION
This hooks up https://en.cppreference.com/cpp/utility/from_chars and https://en.cppreference.com/cpp/utility/to_chars,
it will trigger automatically if code is compiled for C++17 and a C++ prodiving *float* support for these functions is available.

patch should be straight forward, the calls into stdio functions are replaced, charconv is independend from locale,
but stops at the first character that cant be parsed, including whitespace - so those must be manually skipped.

**The first commit is compatible with the test framwork**, the second tries to naively use charconv in convert_number_to_string.
I dont understand why another function is necessary to ectract mantissa / exp an construct an own kind
of double to string conversion.

trying to dig into the xpath stuff gave me headaches. I would want to merge only the first commit, but want to clear up if we can fix / replace the convert_number_to_string function too. I believe the string representation is different, but the parsed float value would be identical.

```
Test xpath_xalan_string_9 failed: "string(.0000123456789)" does not evaluate to "0.0000123456789" in context c at pugixml/tests/test_xpath_xalan_2.cpp:336
Test xpath_xalan_string_8 failed: "string(9876543.21012345)" does not evaluate to "9876543.21012345" in context c at pugixml/tests/test_xpath_xalan_2.cpp:303
Test xpath_xalan_string_6 failed: "string(1234567)" does not evaluate to "1234567" in context c at pugixml/tests/test_xpath_xalan_2.cpp:197
Test xpath_xalan_math_9 failed: "string(number('0.0000000000001'))" does not evaluate to "0.0000000000001" in context c at pugixml/tests/test_xpath_xalan_1.cpp:395
Test xpath_string_string failed: "string(1234567)" does not evaluate to "1234567" in context c at pugixml/tests/test_xpath_functions.cpp:280
Test xpath_out_of_memory_evaluate_number_to_string failed: q.evaluate_string(0, 0, xml_node()) == 1 is false at pugixml/tests/test_xpath.cpp:578
Test xpath_denorm_numbers failed: query.c_str() does not evaluate to "0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009999987484955998" in context xml_node() at pugixml/tests/test_xpath.cpp:275
Test xpath_long_numbers_stringize failed: test_xpath_string_prefix(c, str_flt_max, str_flt_max, 15) is false at pugixml/tests/test_xpath.cpp:252
FAILURE: 8 out of 983 tests failed.
```