### PR TITLE
Reject null delimiter in first_element_by_path to prevent heap-buffer-overflow

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -6786,6 +6786,8 @@ namespace pugi
 
 	PUGI_IMPL_FN xml_node xml_node::first_element_by_path(const char_t* path_, char_t delimiter) const
 	{
+		if (delimiter == 0) return xml_node();
+		
 		xml_node context = path_[0] == delimiter ? root() : *this;
 
 		if (!context._root) return xml_node();


### PR DESCRIPTION
Fixes the issue described in #714

Heap-buffer-overflow occurs in `pugi::xml_node::first_element_by_path` function when delimiter parameter is null character.

The fix rejects a null-character delimiter at the top of `first_element_by_path` by returning an empty `xml_node`, preventing the segment-skipping loops from advancing past the string's null terminator and causing a heap-buffer-overflow.