### PR TITLE
Improve and test std::charconv integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,26 +12,34 @@ jobs:
       matrix:
         os: [ubuntu, macos]
         compiler: [g++, clang++]
-        defines: [standard, PUGIXML_WCHAR_MODE, PUGIXML_COMPACT, PUGIXML_NO_EXCEPTIONS]
+        defines: [standard, PUGIXML_WCHAR_MODE, PUGIXML_COMPACT, PUGIXML_NO_EXCEPTIONS, PUGIXML_CHARCONV_FLOAT]
         exclude:
           - os: macos
             compiler: g++
+          - os: macos
+            defines: PUGIXML_CHARCONV_FLOAT # std::charconv is not supported until Xcode 26
     name: ${{matrix.os}} (${{matrix.compiler}}, ${{matrix.defines}})
     runs-on: ${{matrix.os}}-latest
     steps:
     - uses: actions/checkout@v4
     - name: make test
+      if: matrix.defines != 'PUGIXML_CHARCONV_FLOAT' # std::charconv requires C++17, tested below
       run: |
         export CXX=${{matrix.compiler}}
         make test cxxstd=c++11 defines=${{matrix.defines}} config=release -j2
         make test cxxstd=c++98 defines=${{matrix.defines}} config=debug -j2
         make test cxxstd=c++17 defines=${{matrix.defines}} config=debug -j2
         make test defines=${{matrix.defines}} config=sanitize -j2
+    - name: make test charconv
+      if: matrix.defines == 'PUGIXML_CHARCONV_FLOAT'
+      run: |
+        export CXX=${{matrix.compiler}}
+        make test cxxstd=c++17 defines=${{matrix.defines}} config=sanitize -j2
     - name: make coverage
       if: ${{!(matrix.os == 'ubuntu' && matrix.compiler == 'clang++')}} # linux/clang produces coverage info gcov can't parse
       run: |
         export CXX=${{matrix.compiler}}
-        make test defines=${{matrix.defines}} config=coverage -j2
+        make test cxxstd=c++17 defines=${{matrix.defines}} config=coverage -j2
         bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov -X search -t ${{secrets.CODECOV_TOKEN}} -B ${{github.ref}}
 
   unix-cmake:
@@ -55,7 +63,7 @@ jobs:
     strategy:
       matrix:
         arch: [Win32, x64]
-        defines: [standard, PUGIXML_WCHAR_MODE, PUGIXML_COMPACT, PUGIXML_NO_EXCEPTIONS]
+        defines: [standard, PUGIXML_WCHAR_MODE, PUGIXML_COMPACT, PUGIXML_NO_EXCEPTIONS, PUGIXML_CHARCONV_FLOAT]
     steps:
     - uses: actions/checkout@v4
     - name: cmake configure

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -996,6 +996,9 @@ can include pugixml.cpp in your project (see <a href="#install.building.embed">B
 <p><a id="PUGIXML_WCHAR_MODE"></a><code>PUGIXML_WCHAR_MODE</code> define toggles between UTF-8 style interface (the in-memory text encoding is assumed to be UTF-8, most functions use <code>char</code> as character type) and UTF-16/32 style interface (the in-memory text encoding is assumed to be UTF-16/32, depending on <code>wchar_t</code> size, most functions use <code>wchar_t</code> as character type). See <a href="#dom.unicode">Unicode interface</a> for more details.</p>
 </div>
 <div class="paragraph">
+<p><a id="PUGIXML_CHARCONV_FLOAT"></a><code>PUGIXML_CHARCONV_FLOAT</code> will use <a href="https://en.cppreference.com/cpp/header/charconv">&lt;charconv&gt;</a> for floating-point number formatting instead of <code>&lt;stdio.h&gt;</code> functions, which requires C++17 and UTF-8 interface. Note that the conversion will then ignore the locale and always act as if the default <code>C</code> locale is used.</p>
+</div>
+<div class="paragraph">
 <p><a id="PUGIXML_COMPACT"></a><code>PUGIXML_COMPACT</code> define activates a different internal representation of document storage that is much more memory efficient for documents with a lot of markup (i.e. nodes and attributes), but is slightly slower to parse and access. For details see <a href="#dom.memory.compact">Compact mode</a>.</p>
 </div>
 <div class="paragraph">
@@ -6273,7 +6276,7 @@ If exceptions are disabled, then in the event of parsing failure the query is in
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-15 00:37:51 -0700
+Last updated 2026-05-15 13:19:50 -0700
 </div>
 </div>
 </body>

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -4709,6 +4709,7 @@ PUGI_IMPL_NS_BEGIN
 			value++;
 		if (*value == '+')
 			value++;
+		// return code is intentionally ignored to let libc++/MSVC STL correctly handle underflow/overflow
 		double result = 0.0;
 		std::from_chars(value, value + strlen(value), result);
 		return result;
@@ -4726,6 +4727,7 @@ PUGI_IMPL_NS_BEGIN
 			value++;
 		if (*value == '+')
 			value++;
+		// return code is intentionally ignored to let libc++/MSVC STL correctly handle underflow/overflow
 		float result = 0.0f;
 		std::from_chars(value, value + strlen(value), result);
 		return result;
@@ -4807,7 +4809,8 @@ PUGI_IMPL_NS_BEGIN
 	{
 		char buf[128];
 	#ifdef PUGIXML_CHARCONV_FLOAT
-		std::to_chars_result result = std::to_chars(std::begin(buf), std::end(buf) - 1, value, std::chars_format::general, precision);
+		std::to_chars_result result = std::to_chars(buf, buf + sizeof(buf) - 1, value, std::chars_format::general, precision);
+		if (result.ec != std::errc()) return false;
 		*result.ptr = '\0';
 	#else
 		PUGI_IMPL_SNPRINTF(buf, "%.*g", precision, double(value));
@@ -4820,7 +4823,8 @@ PUGI_IMPL_NS_BEGIN
 	{
 		char buf[128];
 	#ifdef PUGIXML_CHARCONV_FLOAT
-		std::to_chars_result result = std::to_chars(std::begin(buf), std::end(buf) - 1, value, std::chars_format::general, precision);
+		std::to_chars_result result = std::to_chars(buf, buf + sizeof(buf) - 1, value, std::chars_format::general, precision);
+		if (result.ec != std::errc()) return false;
 		*result.ptr = '\0';
 	#else
 		PUGI_IMPL_SNPRINTF(buf, "%.*g", precision, value);
@@ -8894,7 +8898,8 @@ PUGI_IMPL_NS_BEGIN
 	PUGI_IMPL_FN void convert_number_to_mantissa_exponent(double value, char (&buffer)[32], char** out_mantissa, int* out_exponent)
 	{
 	#ifdef PUGIXML_CHARCONV_FLOAT
-		std::to_chars_result res = std::to_chars(std::begin(buffer), std::end(buffer) - 1, value, std::chars_format::scientific, DBL_DIG);
+		std::to_chars_result res = std::to_chars(buffer, buffer + sizeof(buffer) - 1, value, std::chars_format::scientific, DBL_DIG);
+		assert(res.ec == std::errc());
 		*res.ptr = '\0';
 	#else
 		// get a scientific notation value with IEEE DBL_DIG decimals
@@ -9034,6 +9039,7 @@ PUGI_IMPL_NS_BEGIN
 	#ifdef PUGIXML_WCHAR_MODE
 		return wcstod(string, NULL);
 	#elif defined(PUGIXML_CHARCONV_FLOAT)
+		// return code is intentionally ignored to let libc++/MSVC STL correctly handle underflow/overflow
 		double result = 0.0;
 		std::from_chars(string, string + strlen(string), result);
 		return result;


### PR DESCRIPTION
This is based on #710 and adds GHA integration as well as fixing the error handling for `to_chars`: on error, it would store the *end* of the buffer in `result.ptr`, which would produce an uninitialized but zero terminated string. We now return false on error (which should only be reachable if abnormally large precision is requested externally).

Note that for correct `from_chars` behavior on out of range floats, we prefer libc++/MSVC STL behavior of setting the output value to zero/infinity; C++ standard specifies broken behavior that libstdc++ implements, in which case we'd return 0 (which is okay on underflow but obviously not ideal for overflow - it's impossible to distinguish these when using libstdc++). See https://isocpp.org/files/papers/P4168R0.html for details.

Since for locale-independent behavior you can now compile pugixml with `PUGIXML_CHARCONV_FLOAT`, this also:

- Closes #470
- Fixes #469
- Fixes #568