### PR TITLE
Update AppVeyor configuration for VS2026

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ branches:
     - master
 
 image:
+  - Visual Studio 2026
   - Visual Studio 2022
   - Visual Studio 2019
   - Visual Studio 2017
@@ -11,11 +12,10 @@ image:
 version: "{branch}-{build}"
 
 build_script:
-  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2013") { .\scripts\nuget_build.ps1 2013}
-  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\scripts\nuget_build.ps1 2015}
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2017") { .\scripts\nuget_build.ps1 2017}
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2019") { .\scripts\nuget_build.ps1 2019}
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2022") { .\scripts\nuget_build.ps1 2022}
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2026") { .\scripts\nuget_build.ps1 2026}
 
 test_script:
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\cmake-appveyor.ps1 9 2008 }
@@ -24,11 +24,13 @@ test_script:
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2017") { .\tests\cmake-appveyor.ps1 15 2017 }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2019") { .\tests\cmake-appveyor.ps1 16 2019 }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2022") { .\tests\cmake-appveyor.ps1 17 2022 }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2026") { .\tests\cmake-appveyor.ps1 18 2026 }
 
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\autotest-appveyor.ps1 9 10 11 12 14 }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2017") { .\tests\autotest-appveyor.ps1 15 }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2019") { .\tests\autotest-appveyor.ps1 19 }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2022") { .\tests\autotest-appveyor.ps1 22 }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2026") { .\tests\autotest-appveyor.ps1 26 }
 
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { & C:\cygwin\bin\bash.exe -c "PATH=/usr/bin:/usr/local/bin:$PATH; make -j2 config=coverage test && bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov 2>&1" }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { & C:\cygwin\bin\bash.exe -c "PATH=/usr/bin:/usr/local/bin:$PATH; make -j2 config=coverage defines=PUGIXML_WCHAR_MODE test && bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov 2>&1" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,13 @@ image:
 
 version: "{branch}-{build}"
 
+for:
+  - matrix:
+      only:
+        - image: Visual Studio 2026
+    install:
+      - pip install --upgrade cmake
+
 build_script:
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2017") { .\scripts\nuget_build.ps1 2017}
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2019") { .\scripts\nuget_build.ps1 2019}

--- a/scripts/nuget/pugixml.nuspec
+++ b/scripts/nuget/pugixml.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://pugixml.org/</projectUrl>
     <description>pugixml is a C++ XML processing library, which consists of a DOM-like interface with rich traversal/modification capabilities, an extremely fast XML parser which constructs the DOM tree from an XML file/buffer, and an XPath 1.0 implementation for complex data-driven tree queries. Full Unicode support is also available, with Unicode interface variants and conversions between different Unicode encodings (which happen automatically during parsing/saving).
 pugixml is used by a lot of projects, both open-source and proprietary, for performance and easy-to-use interface.
-This package contains builds for VS2013, VS2015, VS2017, VS2019, VS2022 and VS2026, for both statically linked and DLL CRT; you can switch the CRT linkage in Project -> Properties -> Referenced Packages -> pugixml.</description>
+This package contains builds for VS2017, VS2019, VS2022 and VS2026, for both statically linked and DLL CRT; you can switch the CRT linkage in Project -> Properties -> Referenced Packages -> pugixml.</description>
     <summary>Light-weight, simple and fast XML parser for C++ with XPath support</summary>
     <releaseNotes>https://pugixml.org/docs/manual.html#changes</releaseNotes>
     <copyright>Copyright (c) 2006-2026 Arseny Kapoulkine</copyright>

--- a/tests/autotest-appveyor.ps1
+++ b/tests/autotest-appveyor.ps1
@@ -30,6 +30,10 @@ foreach ($vs in $args)
 			$vsdevcmdarch = if ($arch -eq "x64") { "amd64" } else { "x86" }
 			Invoke-CmdScript "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" "-arch=$vsdevcmdarch"
 		}
+		elseif ($vs -eq 26) {
+			$vsdevcmdarch = if ($arch -eq "x64") { "amd64" } else { "x86" }
+			Invoke-CmdScript "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\Tools\VsDevCmd.bat" "-arch=$vsdevcmdarch"
+		}
 		else
 		{
 			Invoke-CmdScript "C:\Program Files (x86)\Microsoft Visual Studio $vs.0\VC\vcvarsall.bat" $arch


### PR DESCRIPTION
- Add VS2026 builds to AppVeyor configuration
- Remove VS2013/VS2015 from AppVeyor NuGet packages

VS2013/2015 are out of support according to https://learn.microsoft.com/en-us/visualstudio/releases/2026/servicing-vs.

Note that for now we still build and test pugixml itself for the older VS versions; the removals here only apply to the NuGet package.

This won't build until https://github.com/appveyor/ci/issues/3985 is fixed.