### PR TITLE
Delete xml_attribute::set_value/xml_text::set overloads for char8_t*

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         make test cxxstd=c++11 defines=${{matrix.defines}} config=release -j2
         make test cxxstd=c++98 defines=${{matrix.defines}} config=debug -j2
         make test cxxstd=c++17 defines=${{matrix.defines}} config=debug -j2
+        make test cxxstd=c++20 defines=${{matrix.defines}} config=debug -j2
         make test defines=${{matrix.defines}} config=sanitize -j2
     - name: make test charconv
       if: matrix.defines == 'PUGIXML_CHARCONV_FLOAT'

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -493,6 +493,12 @@ namespace pugi
 		xml_attribute& operator=(unsigned long long rhs);
 	#endif
 
+	#ifdef __cpp_char8_t
+		// Delete char8_t overloads to prevent accidental conversion to bool
+		void set_value(const char8_t* rhs) = delete;
+		xml_attribute& operator=(const char8_t* rhs) = delete;
+	#endif
+
 		// Get next/previous attribute in the attribute list of the parent node
 		xml_attribute next_attribute() const;
 		xml_attribute previous_attribute() const;
@@ -814,6 +820,7 @@ namespace pugi
 	{
 		friend class xml_node;
 
+	private:
 		xml_node_struct* _root;
 
 		typedef void (*unspecified_bool_type)(xml_text***);
@@ -896,6 +903,12 @@ namespace pugi
 	#ifdef PUGIXML_HAS_LONG_LONG
 		xml_text& operator=(long long rhs);
 		xml_text& operator=(unsigned long long rhs);
+	#endif
+
+	#ifdef __cpp_char8_t
+		// Delete char8_t overloads to prevent accidental conversion to bool
+		void set(const char8_t* rhs) = delete;
+		xml_text& operator=(const char8_t* rhs) = delete;
 	#endif
 
 		// Get the data node (node_pcdata or node_cdata) for this object


### PR DESCRIPTION
When using C++20 in applications that use `const char8_t*`, it's possible to accidentally use attribute/text assignment (`set_value`/`set`/`operator=`) without casting to `const char*`.

Previously, these calls would compile - the pointer would be implicitly cast to `bool`. This is almost definitely a mistake in the code, and we now force the caller to cast by deleting these overloads.

It would be possible to delete `const void*` overloads instead to cover *any* pointers distinct from `char_t`, but this is more likely to break valid code that sets booleans intentionally using the pointer NULLness, such as:

	node.append_attribute("has_data") = data;
	if (data) ...

Fixes #378.