### PR TITLE
Work around GCC16 Wuninitialized occurence in xml_document::_move

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -7774,7 +7774,7 @@ namespace pugi
 		}
 
 		// reset other document
-		new (other) impl::xml_document_struct(PUGI_IMPL_GETPAGE(other));
+		new (other) impl::xml_document_struct(other_page);
 		rhs._buffer = NULL;
 	}
 #endif


### PR DESCRIPTION
What looks like is happening here is that GCC16 treats other as dead as we are constructing it anew, and the page read is marked as uninitialized, triggering -Wuninitialized warning when optimization is enabled.

Since we've already read the page pointer into other_page, we can just use that which fixes the warning.

Fixes #721 
Closes #723 