### PR TITLE
 XPath: Accelerate child::name and attribute::name traversals

### DIFF
--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -256,9 +256,9 @@ PUGI_IMPL_NS_BEGIN
 		assert(src && dst);
 
 	#ifdef PUGIXML_WCHAR_MODE
-		return wcscmp(src, dst) == 0;
+		return *src == *dst && wcscmp(src, dst) == 0;
 	#else
-		return strcmp(src, dst) == 0;
+		return *src == *dst && strcmp(src, dst) == 0;
 	#endif
 	}
 

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -10591,18 +10591,42 @@ PUGI_IMPL_NS_BEGIN
 			{
 			case axis_attribute:
 			{
-				for (xml_attribute_struct* a = n->first_attribute; a; a = a->next_attribute)
-					if (step_push(ns, a, n, alloc) & once)
-						return;
+				if (_test == nodetest_name)
+				{
+					for (xml_attribute_struct* a = n->first_attribute; a; a = a->next_attribute)
+						if (a->name && strequal(a->name, _data.nodetest) && is_xpath_attribute(a->name))
+						{
+							ns.push_back(xpath_node(xml_attribute(a), xml_node(n)), alloc);
+							return; // once=true by construction
+						}
+				}
+				else
+				{
+					for (xml_attribute_struct* a = n->first_attribute; a; a = a->next_attribute)
+						if (step_push(ns, a, n, alloc) & once)
+							return;
+				}
 
 				break;
 			}
 
 			case axis_child:
 			{
-				for (xml_node_struct* c = n->first_child; c; c = c->next_sibling)
-					if (step_push(ns, c, alloc) & once)
-						return;
+				if (_test == nodetest_name)
+				{
+					for (xml_node_struct* c = n->first_child; c; c = c->next_sibling)
+						if (c->name && strequal(c->name, _data.nodetest) && PUGI_IMPL_NODETYPE(c) == node_element)
+						{
+							ns.push_back(xml_node(c), alloc);
+							if (once) return;
+						}
+				}
+				else
+				{
+					for (xml_node_struct* c = n->first_child; c; c = c->next_sibling)
+						if (step_push(ns, c, alloc) & once)
+							return;
+				}
 
 				break;
 			}


### PR DESCRIPTION
Currently we use a general structure where step_fill calls step_push for
every node/attribute, and step_push does the relevant test. This is
necessary because both axis and test can be mixed arbitrarily, but this
results in extra overhead: step_push may not be inlined, and it has a
switch dispatch that we have to go through on every iteration.

Since child/attribute and name node test are by far the most prevalent
in real queries, we can add a fast-path that removes the switch dispatch
and directly traverses the children while checking their names; this,
then, is similar to existing loops that find children/attributes and
runs faster than our general dispatch.

Also, as part of this we optimize strequal by checking the first character
inline. While it's not always profitable it usually speeds up traversal appreciably,
whether done via XPath or via pugixml APIs. In typical loops that call strequal,
this adds a couple instructions for every successful match that terminates
the traversal, but often allows to skip strcmp calls for unsuccessful
matches so it's usually a net win.

This results in ~20-30% wins across most XPathMark benchmarks.