### PR TITLE
Switch AppVeyor to a sparse build matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,11 +33,15 @@ test_script:
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2022") { .\tests\cmake-appveyor.ps1 17 2022 }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2026") { .\tests\cmake-appveyor.ps1 18 2026 }
 
-  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\autotest-appveyor.ps1 9 10 11 12 14 }
-  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2017") { .\tests\autotest-appveyor.ps1 15 }
-  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2019") { .\tests\autotest-appveyor.ps1 19 }
-  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2022") { .\tests\autotest-appveyor.ps1 22 }
-  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2026") { .\tests\autotest-appveyor.ps1 26 }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\autotest-appveyor.ps1 9 x86 standard }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\autotest-appveyor.ps1 10 x64 standard }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\autotest-appveyor.ps1 11 x86 PUGIXML_WCHAR_MODE }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\autotest-appveyor.ps1 12 x64 PUGIXML_COMPACT }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { .\tests\autotest-appveyor.ps1 14 x64 standard }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2017") { .\tests\autotest-appveyor.ps1 15 x86 standard }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2019") { .\tests\autotest-appveyor.ps1 19 x86 PUGIXML_COMPACT }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2022") { .\tests\autotest-appveyor.ps1 22 x64 PUGIXML_WCHAR_MODE }
+  - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2026") { .\tests\autotest-appveyor.ps1 26 x64 standard }
 
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { & C:\cygwin\bin\bash.exe -c "PATH=/usr/bin:/usr/local/bin:$PATH; make -j2 config=coverage test && bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov 2>&1" }
   - ps: if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") { & C:\cygwin\bin\bash.exe -c "PATH=/usr/bin:/usr/local/bin:$PATH; make -j2 config=coverage defines=PUGIXML_WCHAR_MODE test && bash <(curl -s https://codecov.io/bash) -f pugixml.cpp.gcov 2>&1" }

--- a/tests/autotest-appveyor.ps1
+++ b/tests/autotest-appveyor.ps1
@@ -12,9 +12,9 @@ function Invoke-CmdScript($scriptName)
 $sources = @("src/pugixml.cpp") + (Get-ChildItem -Path "tests/*.cpp" -Exclude "fuzz_*.cpp")
 $failed = $FALSE
 
-foreach ($vs in $args)
+foreach ($vs in @($args[0]))
 {
-	foreach ($arch in "x86","x64")
+	foreach ($arch in @($args[1]))
 	{
 		Write-Output "# Setting up VS$vs $arch"
 
@@ -43,7 +43,7 @@ foreach ($vs in $args)
 
 		$cxx = if ($vs -ge 19) { "/std:c++17" } else { "" }
 
-		foreach ($defines in "standard", "PUGIXML_WCHAR_MODE", "PUGIXML_COMPACT")
+		foreach ($defines in @($args[2]))
 		{
 			$target = "tests_vs${vs}_${arch}_${defines}"
 			$deflist = if ($defines -eq "standard") { "" } else { "/D$defines" }


### PR DESCRIPTION
AppVeyor is dramatically slower than GHA, and after recent VS2026 addition it is approaching 30 minutes of build time. It tests multiple configurations per VS version, many VS versions, and the builds are all sequential due to free tier limitations.

This is becoming unsustainable and the cross-configuration/version build problems are quite rare; additionally we do already test all of this for the latest VS version on GHA.

So it is time to dramatically reorganize the build configuration by making the matrix sparse: for each VS version we now only test *one* manual cl run with an interleaving of architecture and configuration selection, so that we hit every combination of arch-defines, and the combinations are somewhat creatively chosen to still exercise commonly seen configurations.

We still build CMake in addition to that, and of course all recent VS versions (2017+) build the NuGet package too; so in practice we get more than one pugixml.cpp build per agent, but just one build with all tests.