### PR TITLE
 Add xml_node::ensure_attribute and xml_node::ensure_child

### DIFF
--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -1377,7 +1377,7 @@ include::samples/modify_base.cpp[tags=attr]
 [[modify.add]]
 === Adding nodes/attributes
 
-[[xml_node::prepend_attribute]][[xml_node::append_attribute]][[xml_node::insert_attribute_after]][[xml_node::insert_attribute_before]][[xml_node::prepend_child]][[xml_node::append_child]][[xml_node::insert_child_after]][[xml_node::insert_child_before]]
+[[xml_node::prepend_attribute]][[xml_node::append_attribute]][[xml_node::insert_attribute_after]][[xml_node::insert_attribute_before]][[xml_node::ensure_attribute]][[xml_node::prepend_child]][[xml_node::append_child]][[xml_node::insert_child_after]][[xml_node::insert_child_before]][[xml_node::ensure_child]]
 Nodes and attributes do not exist without a document tree, so you can't create them without adding them to some document. A node or attribute can be created at the end of node/attribute list or before/after some other node:
 
 [source]
@@ -1404,9 +1404,14 @@ xml_node xml_node::insert_child_after(const char_t* name, const xml_node& node);
 xml_node xml_node::insert_child_after(string_view_t name, const xml_node& node);
 xml_node xml_node::insert_child_before(const char_t* name, const xml_node& node);
 xml_node xml_node::insert_child_before(string_view_t name, const xml_node& node);
+
+xml_attribute xml_node::ensure_attribute(const char_t* name);
+xml_attribute xml_node::ensure_attribute(string_view_t name);
+xml_node xml_node::ensure_child(const char_t* name);
+xml_node xml_node::ensure_child(string_view_t name);
 ----
 
-`append_attribute` and `append_child` create a new node/attribute at the end of the corresponding list of the node the method is called on; `prepend_attribute` and `prepend_child` create a new node/attribute at the beginning of the list; `insert_attribute_after`, `insert_attribute_before`, `insert_child_after` and `insert_child_before` add the node/attribute before or after the specified node/attribute.
+`append_attribute` and `append_child` create a new node/attribute at the end of the corresponding list of the node the method is called on; `prepend_attribute` and `prepend_child` create a new node/attribute at the beginning of the list; `insert_attribute_after`, `insert_attribute_before`, `insert_child_after` and `insert_child_before` add the node/attribute before or after the specified node/attribute. `ensure_attribute` and `ensure_child` return the existing attribute/child with the specified name, appending a new one only if no such attribute/child exists; this makes it convenient to write code like `node.ensure_attribute("id") = 123;`.
 
 Attribute functions create an attribute with the specified name; you can specify the empty name and change the name later if you want to. Node functions with the `type` argument create the node with the specified type; since node type can't be changed, you have to know the desired type beforehand. Also note that not all types can be added as children; see below for clarification. Node functions with the `name` argument create the element node (<<node_element,node_element>>) with the specified name.
 
@@ -1422,7 +1427,7 @@ All functions return the handle to the created object on success, and null handl
 
 Even if the operation fails, the document remains in consistent state, but the requested node/attribute is not added.
 
-CAUTION: `attribute()` and `child()` functions do not add attributes or nodes to the tree, so code like `node.attribute("id") = 123;` will not do anything if `node` does not have an attribute with name `"id"`. Make sure you're operating with existing attributes/nodes by adding them if necessary.
+CAUTION: `attribute()` and `child()` functions do not add attributes or nodes to the tree, so code like `node.attribute("id") = 123;` will not do anything if `node` does not have an attribute with name `"id"`. Make sure you're operating with existing attributes/nodes by adding them if necessary, or use `ensure_attribute`/`ensure_child`.
 
 This is an example of adding new attributes/nodes to the document (link:samples/modify_add.cpp[]):
 
@@ -2208,6 +2213,7 @@ Anniversary release (pugixml turns 20 this year!). Changes:
 
 * Improvements:
     . `PUGIXML_CHARCONV_FLOAT` option can be enabled to switch floating point conversions to `<charconv>`; this requires C{plus}{plus}17, makes the conversions locale-independent and can improve performance
+    . Add `xml_node::ensure_child` and `xml_node::ensure_attribute` that return the child/attribute with the specified name, adding one if it does not exist
     . Improve performance of searching for nodes and attributes by name
     . Loading a document from an empty buffer no longer performs memory allocations
 
@@ -3078,6 +3084,11 @@ const unsigned int +++<a href="#parse_wnorm_attribute">parse_wnorm_attribute</a>
     xml_node +++<a href="#xml_node::insert_child_after">insert_child_after</a>+++(string_view_t name, const xml_node& node);
     xml_node +++<a href="#xml_node::insert_child_before">insert_child_before</a>+++(const char_t* name, const xml_node& node);
     xml_node +++<a href="#xml_node::insert_child_before">insert_child_before</a>+++(string_view_t name, const xml_node& node);
+
+    xml_attribute +++<a href="#xml_node::ensure_attribute">ensure_attribute</a>+++(const char_t* name);
+    xml_attribute +++<a href="#xml_node::ensure_attribute">ensure_attribute</a>+++(string_view_t name);
+    xml_node +++<a href="#xml_node::ensure_child">ensure_child</a>+++(const char_t* name);
+    xml_node +++<a href="#xml_node::ensure_child">ensure_child</a>+++(string_view_t name);
 
     xml_attribute +++<a href="#xml_node::append_copy">append_copy</a>+++(const xml_attribute& proto);
     xml_attribute +++<a href="#xml_node::prepend_copy">prepend_copy</a>+++(const xml_attribute& proto);

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -2807,7 +2807,7 @@ Floating-point conversion functions depend on the current C locale as set with <
 <div class="sect2">
 <h3 id="modify.add"><a class="anchor" href="#modify.add"></a><a class="link" href="#modify.add">6.3. Adding nodes/attributes</a></h3>
 <div class="paragraph">
-<p><a id="xml_node::prepend_attribute"></a><a id="xml_node::append_attribute"></a><a id="xml_node::insert_attribute_after"></a><a id="xml_node::insert_attribute_before"></a><a id="xml_node::prepend_child"></a><a id="xml_node::append_child"></a><a id="xml_node::insert_child_after"></a><a id="xml_node::insert_child_before"></a>
+<p><a id="xml_node::prepend_attribute"></a><a id="xml_node::append_attribute"></a><a id="xml_node::insert_attribute_after"></a><a id="xml_node::insert_attribute_before"></a><a id="xml_node::ensure_attribute"></a><a id="xml_node::prepend_child"></a><a id="xml_node::append_child"></a><a id="xml_node::insert_child_after"></a><a id="xml_node::insert_child_before"></a><a id="xml_node::ensure_child"></a>
 Nodes and attributes do not exist without a document tree, so you can&#8217;t create them without adding them to some document. A node or attribute can be created at the end of node/attribute list or before/after some other node:</p>
 </div>
 <div class="listingblock">
@@ -2833,11 +2833,16 @@ Nodes and attributes do not exist without a document tree, so you can&#8217;t cr
 <span class="tok-n">xml_node</span><span class="tok-w"> </span><span class="tok-nf">xml_node::insert_child_after</span><span class="tok-p">(</span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">char_t</span><span class="tok-o">*</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">,</span><span class="tok-w"> </span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">xml_node</span><span class="tok-o">&amp;</span><span class="tok-w"> </span><span class="tok-n">node</span><span class="tok-p">);</span>
 <span class="tok-n">xml_node</span><span class="tok-w"> </span><span class="tok-nf">xml_node::insert_child_after</span><span class="tok-p">(</span><span class="tok-n">string_view_t</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">,</span><span class="tok-w"> </span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">xml_node</span><span class="tok-o">&amp;</span><span class="tok-w"> </span><span class="tok-n">node</span><span class="tok-p">);</span>
 <span class="tok-n">xml_node</span><span class="tok-w"> </span><span class="tok-nf">xml_node::insert_child_before</span><span class="tok-p">(</span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">char_t</span><span class="tok-o">*</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">,</span><span class="tok-w"> </span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">xml_node</span><span class="tok-o">&amp;</span><span class="tok-w"> </span><span class="tok-n">node</span><span class="tok-p">);</span>
-<span class="tok-n">xml_node</span><span class="tok-w"> </span><span class="tok-nf">xml_node::insert_child_before</span><span class="tok-p">(</span><span class="tok-n">string_view_t</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">,</span><span class="tok-w"> </span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">xml_node</span><span class="tok-o">&amp;</span><span class="tok-w"> </span><span class="tok-n">node</span><span class="tok-p">);</span></code></pre>
+<span class="tok-n">xml_node</span><span class="tok-w"> </span><span class="tok-nf">xml_node::insert_child_before</span><span class="tok-p">(</span><span class="tok-n">string_view_t</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">,</span><span class="tok-w"> </span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">xml_node</span><span class="tok-o">&amp;</span><span class="tok-w"> </span><span class="tok-n">node</span><span class="tok-p">);</span>
+
+<span class="tok-n">xml_attribute</span><span class="tok-w"> </span><span class="tok-nf">xml_node::ensure_attribute</span><span class="tok-p">(</span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">char_t</span><span class="tok-o">*</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">);</span>
+<span class="tok-n">xml_attribute</span><span class="tok-w"> </span><span class="tok-nf">xml_node::ensure_attribute</span><span class="tok-p">(</span><span class="tok-n">string_view_t</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">);</span>
+<span class="tok-n">xml_node</span><span class="tok-w"> </span><span class="tok-nf">xml_node::ensure_child</span><span class="tok-p">(</span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">char_t</span><span class="tok-o">*</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">);</span>
+<span class="tok-n">xml_node</span><span class="tok-w"> </span><span class="tok-nf">xml_node::ensure_child</span><span class="tok-p">(</span><span class="tok-n">string_view_t</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">);</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p><code>append_attribute</code> and <code>append_child</code> create a new node/attribute at the end of the corresponding list of the node the method is called on; <code>prepend_attribute</code> and <code>prepend_child</code> create a new node/attribute at the beginning of the list; <code>insert_attribute_after</code>, <code>insert_attribute_before</code>, <code>insert_child_after</code> and <code>insert_child_before</code> add the node/attribute before or after the specified node/attribute.</p>
+<p><code>append_attribute</code> and <code>append_child</code> create a new node/attribute at the end of the corresponding list of the node the method is called on; <code>prepend_attribute</code> and <code>prepend_child</code> create a new node/attribute at the beginning of the list; <code>insert_attribute_after</code>, <code>insert_attribute_before</code>, <code>insert_child_after</code> and <code>insert_child_before</code> add the node/attribute before or after the specified node/attribute. <code>ensure_attribute</code> and <code>ensure_child</code> return the existing attribute/child with the specified name, appending a new one only if no such attribute/child exists; this makes it convenient to write code like <code>node.ensure_attribute("id") = 123;</code>.</p>
 </div>
 <div class="paragraph">
 <p>Attribute functions create an attribute with the specified name; you can specify the empty name and change the name later if you want to. Node functions with the <code>type</code> argument create the node with the specified type; since node type can&#8217;t be changed, you have to know the desired type beforehand. Also note that not all types can be added as children; see below for clarification. Node functions with the <code>name</code> argument create the element node (<a href="#node_element">node_element</a>) with the specified name.</p>
@@ -2880,7 +2885,7 @@ Nodes and attributes do not exist without a document tree, so you can&#8217;t cr
 <div class="title">Caution</div>
 </td>
 <td class="content">
-<code>attribute()</code> and <code>child()</code> functions do not add attributes or nodes to the tree, so code like <code>node.attribute("id") = 123;</code> will not do anything if <code>node</code> does not have an attribute with name <code>"id"</code>. Make sure you&#8217;re operating with existing attributes/nodes by adding them if necessary.
+<code>attribute()</code> and <code>child()</code> functions do not add attributes or nodes to the tree, so code like <code>node.attribute("id") = 123;</code> will not do anything if <code>node</code> does not have an attribute with name <code>"id"</code>. Make sure you&#8217;re operating with existing attributes/nodes by adding them if necessary, or use <code>ensure_attribute</code>/<code>ensure_child</code>.
 </td>
 </tr>
 </table>
@@ -4151,6 +4156,9 @@ If exceptions are disabled, then in the event of parsing failure the query is in
 <ol class="arabic">
 <li>
 <p><code>PUGIXML_CHARCONV_FLOAT</code> option can be enabled to switch floating point conversions to <code>&lt;charconv&gt;</code>; this requires C&#43;&#43;17, makes the conversions locale-independent and can improve performance</p>
+</li>
+<li>
+<p>Add <code>xml_node::ensure_child</code> and <code>xml_node::ensure_attribute</code> that return the child/attribute with the specified name, adding one if it does not exist</p>
 </li>
 <li>
 <p>Improve performance of searching for nodes and attributes by name</p>
@@ -6128,6 +6136,11 @@ If exceptions are disabled, then in the event of parsing failure the query is in
 <span class="tok-w">    </span><span class="tok-n">xml_node</span><span class="tok-w"> </span><a href="#xml_node::insert_child_before">insert_child_before</a><span class="tok-p">(</span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">char_t</span><span class="tok-o">*</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">,</span><span class="tok-w"> </span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">xml_node</span><span class="tok-o">&amp;</span><span class="tok-w"> </span><span class="tok-n">node</span><span class="tok-p">);</span>
 <span class="tok-w">    </span><span class="tok-n">xml_node</span><span class="tok-w"> </span><a href="#xml_node::insert_child_before">insert_child_before</a><span class="tok-p">(</span><span class="tok-n">string_view_t</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">,</span><span class="tok-w"> </span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">xml_node</span><span class="tok-o">&amp;</span><span class="tok-w"> </span><span class="tok-n">node</span><span class="tok-p">);</span>
 
+<span class="tok-w">    </span><span class="tok-n">xml_attribute</span><span class="tok-w"> </span><a href="#xml_node::ensure_attribute">ensure_attribute</a><span class="tok-p">(</span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">char_t</span><span class="tok-o">*</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">);</span>
+<span class="tok-w">    </span><span class="tok-n">xml_attribute</span><span class="tok-w"> </span><a href="#xml_node::ensure_attribute">ensure_attribute</a><span class="tok-p">(</span><span class="tok-n">string_view_t</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">);</span>
+<span class="tok-w">    </span><span class="tok-n">xml_node</span><span class="tok-w"> </span><a href="#xml_node::ensure_child">ensure_child</a><span class="tok-p">(</span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">char_t</span><span class="tok-o">*</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">);</span>
+<span class="tok-w">    </span><span class="tok-n">xml_node</span><span class="tok-w"> </span><a href="#xml_node::ensure_child">ensure_child</a><span class="tok-p">(</span><span class="tok-n">string_view_t</span><span class="tok-w"> </span><span class="tok-n">name</span><span class="tok-p">);</span>
+
 <span class="tok-w">    </span><span class="tok-n">xml_attribute</span><span class="tok-w"> </span><a href="#xml_node::append_copy">append_copy</a><span class="tok-p">(</span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">xml_attribute</span><span class="tok-o">&amp;</span><span class="tok-w"> </span><span class="tok-n">proto</span><span class="tok-p">);</span>
 <span class="tok-w">    </span><span class="tok-n">xml_attribute</span><span class="tok-w"> </span><a href="#xml_node::prepend_copy">prepend_copy</a><span class="tok-p">(</span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">xml_attribute</span><span class="tok-o">&amp;</span><span class="tok-w"> </span><span class="tok-n">proto</span><span class="tok-p">);</span>
 <span class="tok-w">    </span><span class="tok-n">xml_attribute</span><span class="tok-w"> </span><a href="#xml_node::insert_copy_after">insert_copy_after</a><span class="tok-p">(</span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">xml_attribute</span><span class="tok-o">&amp;</span><span class="tok-w"> </span><span class="tok-n">proto</span><span class="tok-p">,</span><span class="tok-w"> </span><span class="tok-k">const</span><span class="tok-w"> </span><span class="tok-n">xml_attribute</span><span class="tok-o">&amp;</span><span class="tok-w"> </span><span class="tok-n">attr</span><span class="tok-p">);</span>
@@ -6375,7 +6388,7 @@ If exceptions are disabled, then in the event of parsing failure the query is in
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-06-13 16:47:23 -0700
+Last updated 2026-06-14 22:10:08 -0700
 </div>
 </div>
 </body>

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -6256,6 +6256,22 @@ namespace pugi
 	}
 #endif
 
+	PUGI_IMPL_FN xml_attribute xml_node::ensure_attribute(const char_t* name_)
+	{
+		xml_attribute result = attribute(name_);
+
+		return result ? result : append_attribute(name_);
+	}
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_attribute xml_node::ensure_attribute(string_view_t name_)
+	{
+		xml_attribute result = attribute(name_);
+
+		return result ? result : append_attribute(name_);
+	}
+#endif
+
 	PUGI_IMPL_FN xml_attribute xml_node::append_copy(const xml_attribute& proto)
 	{
 		if (!proto) return xml_attribute();
@@ -6467,6 +6483,22 @@ namespace pugi
 		result.set_name(name_);
 
 		return result;
+	}
+#endif
+
+	PUGI_IMPL_FN xml_node xml_node::ensure_child(const char_t* name_)
+	{
+		xml_node result = child(name_);
+
+		return result ? result : append_child(name_);
+	}
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_node xml_node::ensure_child(string_view_t name_)
+	{
+		xml_node result = child(name_);
+
+		return result ? result : append_child(name_);
 	}
 #endif
 

--- a/src/pugixml.hpp
+++ b/src/pugixml.hpp
@@ -625,6 +625,12 @@ namespace pugi
 		xml_attribute insert_attribute_before(string_view_t name, const xml_attribute& attr);
 	#endif
 
+		// Get attribute with specified name, adding one if it does not exist. Returns the existing or added attribute, or empty attribute on errors.
+		xml_attribute ensure_attribute(const char_t* name);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_attribute ensure_attribute(string_view_t name);
+	#endif
+
 		// Add a copy of the specified attribute. Returns added attribute, or empty attribute on errors.
 		xml_attribute append_copy(const xml_attribute& proto);
 		xml_attribute prepend_copy(const xml_attribute& proto);
@@ -647,6 +653,12 @@ namespace pugi
 		xml_node prepend_child(string_view_t name);
 		xml_node insert_child_after(string_view_t name, const xml_node& node);
 		xml_node insert_child_before(string_view_t name, const xml_node& node);
+	#endif
+
+		// Get child with specified name, adding one if it does not exist. Returns the existing or added node, or empty node on errors.
+		xml_node ensure_child(const char_t* name);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_node ensure_child(string_view_t name);
 	#endif
 
 		// Add a copy of the specified node as a child. Returns added node, or empty node on errors.

--- a/tests/test_dom_modify.cpp
+++ b/tests/test_dom_modify.cpp
@@ -379,6 +379,37 @@ TEST_XML(dom_node_append_attribute, "<node><child/></node>")
 	CHECK_NODE(doc, STR("<node a1=\"v1\" a2=\"v2\"><child a3=\"v3\"/></node>"));
 }
 
+TEST_XML(dom_node_ensure_attribute, "<node a1='v1'><child/></node>")
+{
+	CHECK(xml_node().ensure_attribute(STR("a")) == xml_attribute());
+	CHECK(doc.ensure_attribute(STR("a")) == xml_attribute());
+
+	xml_node node = doc.child(STR("node"));
+
+	// existing attribute is returned as is
+	xml_attribute a1 = node.ensure_attribute(STR("a1"));
+	CHECK(a1 && a1 == node.attribute(STR("a1")));
+	CHECK_STRING(a1.value(), STR("v1"));
+
+	// missing attribute is appended
+	xml_attribute a2 = node.ensure_attribute(STR("a2"));
+	CHECK(a2 && a2 != a1);
+	a2 = STR("v2");
+
+	// ensuring an existing attribute does not add a duplicate
+	CHECK(node.ensure_attribute(STR("a2")) == a2);
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+	xml_attribute a3 = node.child(STR("child")).ensure_attribute(string_view_t(STR("a3")));
+#else
+	xml_attribute a3 = node.child(STR("child")).ensure_attribute(STR("a3"));
+#endif
+	CHECK(a3 && a3 != a1 && a3 != a2);
+	a3 = STR("v3");
+
+	CHECK_NODE(doc, STR("<node a1=\"v1\" a2=\"v2\"><child a3=\"v3\"/></node>"));
+}
+
 TEST_XML(dom_node_insert_attribute_after, "<node a1='v1'><child a2='v2'/></node>")
 {
 	CHECK(xml_node().insert_attribute_after(STR("a"), xml_attribute()) == xml_attribute());
@@ -836,6 +867,34 @@ TEST_XML(dom_node_append_child_name, "<node>foo<child/></node>")
 	CHECK(n3 && n3 != n2 && n3 != n1);
 
 	CHECK_NODE(doc, STR("<node>foo<child/><n1/><n2/></node><n3/>"));
+}
+
+TEST_XML(dom_node_ensure_child, "<node>foo<child/></node>")
+{
+	CHECK(xml_node().ensure_child(STR("")) == xml_node());
+	CHECK(doc.child(STR("node")).first_child().ensure_child(STR("n")) == xml_node());
+
+	xml_node node = doc.child(STR("node"));
+
+	// existing child is returned as is
+	xml_node child = node.ensure_child(STR("child"));
+	CHECK(child && child == node.child(STR("child")));
+
+	// missing child is appended
+	xml_node n1 = node.ensure_child(STR("n1"));
+	CHECK(n1 && n1 != child);
+
+	// ensuring an existing child does not add a duplicate
+	CHECK(node.ensure_child(STR("child")) == child);
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+	xml_node n2 = doc.ensure_child(string_view_t(STR("n2")));
+#else
+	xml_node n2 = doc.ensure_child(STR("n2"));
+#endif
+	CHECK(n2 && n2 != child && n2 != n1);
+
+	CHECK_NODE(doc, STR("<node>foo<child/><n1/></node><n2/>"));
 }
 
 TEST_XML(dom_node_insert_child_after_name, "<node>foo<child/></node>")


### PR DESCRIPTION
These are equivalent to a named lookup (`attribute`/`child`) followed by
appending the attribute/child if an existing one is not found. The
implementation is trivial but this is fairly commonplace in code that
modifies an existing DOM.

For example, updating an existing configuration node can now be done as:

```c++
pugi::xml_node font = config.ensure_child("font");
font.ensure_attribute("size").set_value(14);
```

... whereas previously this would require creating new nodes/attributes explicitly:

```c++
pugi::xml_node font = config.child("font");
if (!font) font = config.append_child("font");

pugi::xml_attribute size = font.attribute("size");
if (!size) size = font.append_attribute("size");

size.set_value(14);
```

Fixes #409.